### PR TITLE
EVA-1116 Fix to work on PostgreSQL and refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.2.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
@@ -87,6 +93,17 @@
                 <configuration>
                     <reuseForks>false</reuseForks>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/uk/ac/ebi/eva/accession/variant/VariantAccessioningConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/accession/variant/VariantAccessioningConfiguration.java
@@ -28,7 +28,7 @@ import uk.ac.ebi.eva.accession.variant.persistence.VariantAccessioningDatabaseSe
 import uk.ac.ebi.eva.accession.variant.persistence.VariantAccessioningRepository;
 import uk.ac.ebi.ampt2d.commons.accession.autoconfigure.EnableSpringDataContiguousIdService;
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicAccessionGenerator;
-import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.persistence.service.ContiguousIdBlockService;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.monotonic.service.ContiguousIdBlockService;
 
 @Configuration
 @EnableSpringDataContiguousIdService

--- a/src/main/java/uk/ac/ebi/eva/accession/variant/persistence/VariantAccessioningDatabaseService.java
+++ b/src/main/java/uk/ac/ebi/eva/accession/variant/persistence/VariantAccessioningDatabaseService.java
@@ -21,7 +21,7 @@ package uk.ac.ebi.eva.accession.variant.persistence;
 import uk.ac.ebi.eva.accession.variant.VariantModel;
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicRange;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.BasicSpringDataRepositoryDatabaseService;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.MonotonicDatabaseService;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.monotonic.service.MonotonicDatabaseService;
 
 import java.util.Collection;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,20 +1,3 @@
-#
-#
-# Copyright 2018 EMBL - European Bioinformatics Institute
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-#
 accessioning.instanceId=instance-01;
 accessioning.variant.blockSize=1000
 accessioning.variant.categoryId=ss

--- a/src/test/java/uk/ac/ebi/eva/test/configurationaccession/VariantAccessioningDatabaseServiceTestConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/test/configurationaccession/VariantAccessioningDatabaseServiceTestConfiguration.java
@@ -25,7 +25,7 @@ import uk.ac.ebi.eva.accession.variant.VariantModel;
 import uk.ac.ebi.eva.accession.variant.persistence.VariantAccessioningDatabaseService;
 import uk.ac.ebi.eva.accession.variant.persistence.VariantAccessioningRepository;
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicAccessionGenerator;
-import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.persistence.service.ContiguousIdBlockService;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.monotonic.service.ContiguousIdBlockService;
 
 @TestConfiguration
 public class VariantAccessioningDatabaseServiceTestConfiguration {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,20 +1,3 @@
-#
-#
-# Copyright 2018 EMBL - European Bioinformatics Institute
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-#
 accessioning.instanceId=instance-01;
 accessioning.variant.blockSize=1000
 accessioning.variant.categoryId=ss


### PR DESCRIPTION
PostgreSQL driver dependency added to POM file.
Spring Boot Maven plug-in configured to run Spring Boot application with `java -jar`.
Package imports accommodating changes in https://github.com/EBIvariation/accession-commons/pull/20
Copyright headers removed from properties files.