### PR TITLE
Eva Accession Pipeline compatible with Windows

### DIFF
--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
@@ -71,7 +71,7 @@ public class AccessionReportWriterTest {
     @Before
     public void setUp() throws Exception {
         output = temporaryFolderRule.newFile();
-        Path fastaPath = Paths.get(AccessionReportWriterTest.class.getResource("/input-files/fasta/mock.fa").getFile());
+        Path fastaPath = Paths.get(AccessionReportWriterTest.class.getResource("/input-files/fasta/mock.fa").toURI());
         fastaSequenceReader = new FastaSequenceReader(fastaPath);
         accessionReportWriter = new AccessionReportWriter(output, fastaSequenceReader);
         executionContext = new ExecutionContext();

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
@@ -81,7 +81,7 @@ public class AccessionWriterTest {
     @Before
     public void setUp() throws Exception {
         output = temporaryFolderRule.newFile();
-        Path fastaPath = Paths.get(AccessionReportWriterTest.class.getResource("/input-files/fasta/mock.fa").getFile());
+        Path fastaPath = Paths.get(AccessionReportWriterTest.class.getResource("/input-files/fasta/mock.fa").toURI());
         AccessionReportWriter accessionReportWriter = new AccessionReportWriter(output,
                                                                                 new FastaSequenceReader(fastaPath));
         accessionWriter = new AccessionWriter(service, accessionReportWriter);

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/FastaSequenceReaderTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/FastaSequenceReaderTest.java
@@ -42,7 +42,7 @@ public class FastaSequenceReaderTest {
     @Before
     public void setUp() throws Exception {
         reader = new FastaSequenceReader(Paths.get(
-                FastaSequenceReaderTest.class.getResource("/input-files/fasta/Gallus_gallus-5.0.test.fa").getFile()));
+                FastaSequenceReaderTest.class.getResource("/input-files/fasta/Gallus_gallus-5.0.test.fa").toURI()));
     }
 
     @After
@@ -94,7 +94,7 @@ public class FastaSequenceReaderTest {
     @Test
     public void fastaWithNoDictionary() throws Exception {
         FastaSequenceReader fastaSequenceReader = new FastaSequenceReader(Paths.get(
-                FastaSequenceReaderTest.class.getResource("/input-files/fasta/fastaWithNoDictionary.fa").getFile()));
+                FastaSequenceReaderTest.class.getResource("/input-files/fasta/fastaWithNoDictionary.fa").toURI()));
         // this sequence is split between three lines in the FASTA file
         assertEquals("CAGCCGCAGTCCGGACAGCGCATGCGCCAGCCGCGAGACCGCACAGCGCATGCGCCAGCGCGAGTGACAGCG",
                      fastaSequenceReader.getSequence("22", 174, 245));
@@ -105,7 +105,7 @@ public class FastaSequenceReaderTest {
         String fastaFilename = "fastaWithNoDictionary.fa";
         File temporaryFolderRoot = temporaryFolder.getRoot();
         Path fasta = Files.copy(
-                Paths.get(FastaSequenceReaderTest.class.getResource("/input-files/fasta/" + fastaFilename).getFile()),
+                Paths.get(FastaSequenceReaderTest.class.getResource("/input-files/fasta/" + fastaFilename).toURI()),
                 temporaryFolderRoot.toPath().resolve(fastaFilename));
 
         FastaSequenceReader fastaSequenceReader = new FastaSequenceReader(fasta);

--- a/eva-accession-pipeline/src/test/resources/accession-pipeline-test.properties
+++ b/eva-accession-pipeline/src/test/resources/accession-pipeline-test.properties
@@ -13,6 +13,7 @@ parameters.vcfAggregation=NONE
 
 parameters.fasta=src/test/resources/input-files/fasta/Homo_sapiens.GRCh38.dna.chromosome.20.2000-lines.fa
 parameters.outputVcf=/tmp/accession-output.vcf
+#(Windows path) parameters.outputVcf=C:/Users/(user)/AppData/Local/Temp/accession-output.vcf
 
 spring.jpa.show-sql=true
 


### PR DESCRIPTION
Used toUri instead of getFile to get path File in order to support windows. 

Added windows temp path (commented) in accession-pipeline-test.properties, it must be used when running test in windows. 

Git property core.autocrlf must be set to input if using a windows machine so line ending will be LF instead of CRLF.