### PR TITLE
EVA-1208 Upgrade dependency to accession-commons 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,14 @@ language: java
 
 jdk:
   - oraclejdk8
+
+env:
+  - MONGODB_VERSION=3.2.17
+
+install:
+  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz
+  - tar xfz mongodb-linux-x86_64-$MONGODB_VERSION.tgz
+  - export PATH=`pwd`/mongodb-linux-x86_64-$MONGODB_VERSION/bin:$PATH
+  - mkdir -p data/db
+  - mongod --dbpath=data/db &
+  - mongod --version

--- a/eva-accession-core/pom.xml
+++ b/eva-accession-core/pom.xml
@@ -33,12 +33,19 @@
             <groupId>uk.ac.ebi.ampt2d</groupId>
             <artifactId>accession-commons-monotonic-generator-jpa</artifactId>
         </dependency>
-
         <dependency>
+            <groupId>com.lordofthejars</groupId>
+            <artifactId>nosqlunit-mongodb</artifactId>
+            <version>1.0.0-rc.5</version>
+            <scope>test</scope>
+        </dependency>
+
+<!--        <dependency>
             <groupId>com.github.fakemongo</groupId>
             <artifactId>fongo</artifactId>
             <scope>test</scope>
-        </dependency>
+        </dependency>-->
     </dependencies>
+
 
 </project>

--- a/eva-accession-core/pom.xml
+++ b/eva-accession-core/pom.xml
@@ -39,13 +39,6 @@
             <version>1.0.0-rc.5</version>
             <scope>test</scope>
         </dependency>
-
-<!--        <dependency>
-            <groupId>com.github.fakemongo</groupId>
-            <artifactId>fongo</artifactId>
-            <scope>test</scope>
-        </dependency>-->
     </dependencies>
-
 
 </project>

--- a/eva-accession-core/pom.xml
+++ b/eva-accession-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>eva-accession</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1</version>
     </parent>
 
     <artifactId>eva-accession-core</artifactId>
@@ -27,7 +27,11 @@
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.ampt2d</groupId>
-            <artifactId>accessioning-commons</artifactId>
+            <artifactId>accession-commons-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.ampt2d</groupId>
+            <artifactId>accession-commons-monotonic-generator-jpa</artifactId>
         </dependency>
 
         <dependency>

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariant.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariant.java
@@ -153,23 +153,24 @@ public class SubmittedVariant implements ISubmittedVariant {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SubmittedVariant that = (SubmittedVariant) o;
-        return start == that.start &&
-                supportedByEvidence == that.supportedByEvidence &&
-                Objects.equals(assemblyAccession, that.assemblyAccession) &&
-                Objects.equals(taxonomyAccession, that.taxonomyAccession) &&
-                Objects.equals(projectAccession, that.projectAccession) &&
-                Objects.equals(contig, that.contig) &&
-                Objects.equals(referenceAllele, that.referenceAllele) &&
-                Objects.equals(alternateAllele, that.alternateAllele) &&
-                Objects.equals(createdDate, that.createdDate);
+        if (o == null || !(o instanceof ISubmittedVariant)) return false;
+
+        ISubmittedVariant that = (ISubmittedVariant) o;
+
+        if (taxonomyAccession != that.getTaxonomyAccession()) return false;
+        if (start != that.getStart()) return false;
+        if (supportedByEvidence != that.isSupportedByEvidence()) return false;
+        if (!assemblyAccession.equals(that.getAssemblyAccession())) return false;
+        if (!projectAccession.equals(that.getProjectAccession())) return false;
+        if (!contig.equals(that.getContig())) return false;
+        if (!referenceAllele.equals(that.getReferenceAllele())) return false;
+        return alternateAllele.equals(that.getAlternateAllele());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession,
-                            contig, start, referenceAllele, alternateAllele, supportedByEvidence, createdDate);
+                            contig, start, referenceAllele, alternateAllele, supportedByEvidence);
     }
 
     @Override

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariant.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariant.java
@@ -159,7 +159,6 @@ public class SubmittedVariant implements ISubmittedVariant {
 
         if (taxonomyAccession != that.getTaxonomyAccession()) return false;
         if (start != that.getStart()) return false;
-        if (supportedByEvidence != that.isSupportedByEvidence()) return false;
         if (!assemblyAccession.equals(that.getAssemblyAccession())) return false;
         if (!projectAccession.equals(that.getProjectAccession())) return false;
         if (!contig.equals(that.getContig())) return false;
@@ -169,8 +168,8 @@ public class SubmittedVariant implements ISubmittedVariant {
 
     @Override
     public int hashCode() {
-        return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession,
-                            contig, start, referenceAllele, alternateAllele, supportedByEvidence);
+        return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession, contig, start,
+                            referenceAllele, alternateAllele);
     }
 
     @Override

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
@@ -17,10 +17,10 @@
  */
 package uk.ac.ebi.eva.accession.core;
 
-import uk.ac.ebi.ampt2d.commons.accession.core.BasicMonotonicAccessioningService;
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicAccessionGenerator;
 import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
+import uk.ac.ebi.ampt2d.commons.accession.service.BasicMonotonicAccessioningService;
 
 public class SubmittedVariantAccessioningService extends BasicMonotonicAccessioningService<ISubmittedVariant, String> {
 

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
@@ -26,15 +26,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import uk.ac.ebi.ampt2d.commons.accession.autoconfigure.EnableSpringDataContiguousIdService;
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicAccessionGenerator;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.BasicInactiveAccessionService;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.ContiguousIdBlockService;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.service.BasicMongoDbInactiveAccessionService;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantAccessioningDatabaseService;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantAccessioningRepository;
-import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantInactiveEntity;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationEntity;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationRepository;
@@ -54,8 +51,7 @@ public class SubmittedVariantAccessioningConfiguration {
     private SubmittedVariantOperationRepository operationRepository;
 
     @Autowired
-    private BasicInactiveAccessionService<Long, SubmittedVariantEntity, SubmittedVariantInactiveEntity,
-            SubmittedVariantOperationEntity> inactiveService;
+    private SubmittedVariantInactiveService inactiveService;
 
     @Autowired
     private ContiguousIdBlockService service;

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
@@ -37,6 +37,8 @@ import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantAccessioningRepo
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantInactiveEntity;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationEntity;
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationRepository;
+import uk.ac.ebi.eva.accession.core.service.SubmittedVariantInactiveService;
 
 @Configuration
 @EnableSpringDataContiguousIdService
@@ -48,6 +50,10 @@ public class SubmittedVariantAccessioningConfiguration {
     @Autowired
     private SubmittedVariantAccessioningRepository repository;
 
+    @Autowired
+    private SubmittedVariantOperationRepository operationRepository;
+
+    @Autowired
     private BasicInactiveAccessionService<Long, SubmittedVariantEntity, SubmittedVariantInactiveEntity,
             SubmittedVariantOperationEntity> inactiveService;
 
@@ -64,6 +70,18 @@ public class SubmittedVariantAccessioningConfiguration {
     public SubmittedVariantAccessioningService submittedVariantAccessioningService() {
         return new SubmittedVariantAccessioningService(submittedVariantAccessionGenerator(),
                                                        submittedVariantAccessioningDatabaseService());
+    }
+
+    @Bean
+    public SubmittedVariantOperationRepository submittedVariantOperationRepository() {
+        return operationRepository;
+    }
+
+    @Bean
+    public SubmittedVariantInactiveService submittedVariantInactiveService() {
+        return new SubmittedVariantInactiveService(operationRepository,
+                                                   SubmittedVariantInactiveEntity::new,
+                                                   SubmittedVariantOperationEntity::new);
     }
 
     @Bean

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
@@ -26,12 +26,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import uk.ac.ebi.ampt2d.commons.accession.autoconfigure.EnableSpringDataContiguousIdService;
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicAccessionGenerator;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.BasicInactiveAccessionService;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.ContiguousIdBlockService;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.service.BasicMongoDbInactiveAccessionService;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantAccessioningDatabaseService;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantAccessioningRepository;
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantInactiveEntity;
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationEntity;
 
 @Configuration
 @EnableSpringDataContiguousIdService
@@ -42,6 +47,9 @@ public class SubmittedVariantAccessioningConfiguration {
 
     @Autowired
     private SubmittedVariantAccessioningRepository repository;
+
+    private BasicInactiveAccessionService<Long, SubmittedVariantEntity, SubmittedVariantInactiveEntity,
+            SubmittedVariantOperationEntity> inactiveService;
 
     @Autowired
     private ContiguousIdBlockService service;
@@ -60,7 +68,7 @@ public class SubmittedVariantAccessioningConfiguration {
 
     @Bean
     public SubmittedVariantAccessioningDatabaseService submittedVariantAccessioningDatabaseService() {
-        return new SubmittedVariantAccessioningDatabaseService(repository);
+        return new SubmittedVariantAccessioningDatabaseService(repository, inactiveService);
     }
 
     @Bean

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningDatabaseService.java
@@ -18,6 +18,7 @@
 package uk.ac.ebi.eva.accession.core.persistence;
 
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicRange;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.BasicInactiveAccessionService;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.BasicSpringDataRepositoryDatabaseService;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
 
@@ -26,16 +27,17 @@ import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import java.util.Collection;
 
 public class SubmittedVariantAccessioningDatabaseService
-        extends BasicSpringDataRepositoryDatabaseService<ISubmittedVariant, SubmittedVariantEntity, Long>
+        extends BasicSpringDataRepositoryDatabaseService<ISubmittedVariant, Long, SubmittedVariantEntity>
         implements MonotonicDatabaseService<ISubmittedVariant, String> {
 
-    public SubmittedVariantAccessioningDatabaseService(SubmittedVariantAccessioningRepository repository) {
+    public SubmittedVariantAccessioningDatabaseService(SubmittedVariantAccessioningRepository repository,
+                                                       BasicInactiveAccessionService inactiveAccessionService) {
         super(repository,
-              repository,
               accessionWrapper -> new SubmittedVariantEntity(accessionWrapper.getAccession(),
                                                              accessionWrapper.getHash(),
                                                              accessionWrapper.getData()),
-              submittedVariant -> submittedVariant);
+              ISubmittedVariant.class::cast,
+              inactiveAccessionService);
     }
 
     @Override

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningDatabaseService.java
@@ -18,11 +18,11 @@
 package uk.ac.ebi.eva.accession.core.persistence;
 
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicRange;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.BasicInactiveAccessionService;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.BasicSpringDataRepositoryDatabaseService;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
+import uk.ac.ebi.eva.accession.core.service.SubmittedVariantInactiveService;
 
 import java.util.Collection;
 
@@ -31,7 +31,7 @@ public class SubmittedVariantAccessioningDatabaseService
         implements MonotonicDatabaseService<ISubmittedVariant, String> {
 
     public SubmittedVariantAccessioningDatabaseService(SubmittedVariantAccessioningRepository repository,
-                                                       BasicInactiveAccessionService inactiveAccessionService) {
+                                                       SubmittedVariantInactiveService inactiveAccessionService) {
         super(repository,
               accessionWrapper -> new SubmittedVariantEntity(accessionWrapper.getAccession(),
                                                              accessionWrapper.getHash(),

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningRepositoryImpl.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningRepositoryImpl.java
@@ -18,34 +18,13 @@
 package uk.ac.ebi.eva.accession.core.persistence;
 
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.IAccessionedObjectCustomRepository;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.repository.BasicMongoDbAccessionedCustomRepositoryImpl;
 
-import java.util.Collection;
-import java.util.Set;
-
-public class SubmittedVariantAccessioningRepositoryImpl implements IAccessionedObjectCustomRepository {
-
-    private static final String ID = "_id";
-
-    private static final String ACTIVE = "active";
-
-    private MongoTemplate mongoTemplate;
+public class SubmittedVariantAccessioningRepositoryImpl
+        extends BasicMongoDbAccessionedCustomRepositoryImpl<Long, SubmittedVariantEntity> {
 
     public SubmittedVariantAccessioningRepositoryImpl(MongoTemplate mongoTemplate) {
-        this.mongoTemplate = mongoTemplate;
+        super(SubmittedVariantEntity.class, mongoTemplate);
     }
 
-    @Override
-    public void enableByHashedMessageIn(Set<String> set) {
-        mongoTemplate.updateMulti(new Query(Criteria.where(ID).in(set)), Update.update(ACTIVE, true),
-                                  SubmittedVariantEntity.class);
-    }
-
-    @Override
-    public <ENTITY> void insert(Collection<ENTITY> collection) {
-        mongoTemplate.insert(collection, SubmittedVariantEntity.class);
-    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
@@ -17,25 +17,13 @@
  */
 package uk.ac.ebi.eva.accession.core.persistence;
 
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.domain.Persistable;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.IAccessionedObject;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.AccessionedDocument;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 
-import java.time.LocalDateTime;
-
 @Document
-public class SubmittedVariantEntity implements ISubmittedVariant, Persistable<String>, IAccessionedObject<Long> {
-
-    @Id
-    private String hashedMessage;
-
-    @Indexed
-    private Long accession;
+public class SubmittedVariantEntity extends AccessionedDocument<Long> implements ISubmittedVariant {
 
     private String assemblyAccession;
 
@@ -53,28 +41,20 @@ public class SubmittedVariantEntity implements ISubmittedVariant, Persistable<St
 
     private boolean supportedByEvidence;
 
-    private boolean active;
-
-    private int version;
-
-    @CreatedDate
-    private LocalDateTime createdDate;
-
     SubmittedVariantEntity() {
     }
 
     public SubmittedVariantEntity(Long accession, String hashedMessage, ISubmittedVariant model) {
         this(accession, hashedMessage, model.getAssemblyAccession(), model.getTaxonomyAccession(),
              model.getProjectAccession(), model.getContig(), model.getStart(), model.getReferenceAllele(),
-             model.getAlternateAllele(), model.isSupportedByEvidence(), true, 1);
+             model.getAlternateAllele(), model.isSupportedByEvidence(), 1);
     }
 
     public SubmittedVariantEntity(Long accession, String hashedMessage, String assemblyAccession,
                                   int taxonomyAccession, String projectAccession, String contig, long start,
                                   String referenceAllele, String alternateAllele, boolean isSupportedByEvidence,
-                                  boolean active, int version) {
-        this.accession = accession;
-        this.hashedMessage = hashedMessage;
+                                  int version) {
+        super(hashedMessage, accession, version);
         this.assemblyAccession = assemblyAccession;
         this.taxonomyAccession = taxonomyAccession;
         this.projectAccession = projectAccession;
@@ -83,16 +63,6 @@ public class SubmittedVariantEntity implements ISubmittedVariant, Persistable<St
         this.referenceAllele = referenceAllele;
         this.alternateAllele = alternateAllele;
         this.supportedByEvidence = isSupportedByEvidence;
-        this.active = active;
-        this.version = version;
-    }
-
-    public Long getAccession() {
-        return this.accession;
-    }
-
-    public String getHashedMessage() {
-        return hashedMessage;
     }
 
     @Override
@@ -135,39 +105,4 @@ public class SubmittedVariantEntity implements ISubmittedVariant, Persistable<St
         return supportedByEvidence;
     }
 
-    @Override
-    public LocalDateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    @Override
-    public boolean isActive() {
-        return active;
-    }
-
-    @Override
-    public int getVersion() {
-        return version;
-    }
-
-    @Override
-    public String getId() {
-        return hashedMessage;
-    }
-
-    /**
-     * If we want to insert entities with the @Id already filled, this is needed for using @CreatedDate.
-     * <p>
-     * Even if we implement the "insert" method in the repository to avoid updates and make inserts always, in
-     * MongoTemplate::doInsertBatch, a BeforeConvertEvent is issued, and the listener processing that event, in
-     * org.springframework.data.auditing.IsNewAwareAuditingHandler::markAudited it will check again if the entity is
-     * new or not.
-     * <p>
-     * An alternative explained here https://jira.spring.io/browse/DATAMONGO-946 is using @Version instead of
-     * Persistable.
-     */
-    @Override
-    public boolean isNew() {
-        return true;
-    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
@@ -116,7 +116,6 @@ public class SubmittedVariantEntity extends AccessionedDocument<Long> implements
 
         if (taxonomyAccession != that.getTaxonomyAccession()) return false;
         if (start != that.getStart()) return false;
-        if (supportedByEvidence != that.isSupportedByEvidence()) return false;
         if (!assemblyAccession.equals(that.getAssemblyAccession())) return false;
         if (!projectAccession.equals(that.getProjectAccession())) return false;
         if (!contig.equals(that.getContig())) return false;
@@ -126,7 +125,7 @@ public class SubmittedVariantEntity extends AccessionedDocument<Long> implements
 
     @Override
     public int hashCode() {
-        return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession,
-                            contig, start, referenceAllele, alternateAllele, supportedByEvidence);
+        return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession, contig, start,
+                            referenceAllele, alternateAllele);
     }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
@@ -124,7 +124,6 @@ public class SubmittedVariantEntity extends AccessionedDocument<Long> implements
         return alternateAllele.equals(that.getAlternateAllele());
     }
 
-
     @Override
     public int hashCode() {
         return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession,

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
@@ -22,6 +22,8 @@ import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.Accession
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 
+import java.util.Objects;
+
 @Document
 public class SubmittedVariantEntity extends AccessionedDocument<Long> implements ISubmittedVariant {
 
@@ -105,4 +107,27 @@ public class SubmittedVariantEntity extends AccessionedDocument<Long> implements
         return supportedByEvidence;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || !(o instanceof ISubmittedVariant)) return false;
+
+        ISubmittedVariant that = (ISubmittedVariant) o;
+
+        if (taxonomyAccession != that.getTaxonomyAccession()) return false;
+        if (start != that.getStart()) return false;
+        if (supportedByEvidence != that.isSupportedByEvidence()) return false;
+        if (!assemblyAccession.equals(that.getAssemblyAccession())) return false;
+        if (!projectAccession.equals(that.getProjectAccession())) return false;
+        if (!contig.equals(that.getContig())) return false;
+        if (!referenceAllele.equals(that.getReferenceAllele())) return false;
+        return alternateAllele.equals(that.getAlternateAllele());
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession,
+                            contig, start, referenceAllele, alternateAllele, supportedByEvidence);
+    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantInactiveEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantInactiveEntity.java
@@ -107,7 +107,6 @@ public class SubmittedVariantInactiveEntity extends InactiveSubDocument<Long> im
 
         if (taxonomyAccession != that.getTaxonomyAccession()) return false;
         if (start != that.getStart()) return false;
-        if (supportedByEvidence != that.isSupportedByEvidence()) return false;
         if (!assemblyAccession.equals(that.getAssemblyAccession())) return false;
         if (!projectAccession.equals(that.getProjectAccession())) return false;
         if (!contig.equals(that.getContig())) return false;
@@ -117,7 +116,7 @@ public class SubmittedVariantInactiveEntity extends InactiveSubDocument<Long> im
 
     @Override
     public int hashCode() {
-        return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession,
-                            contig, start, referenceAllele, alternateAllele, supportedByEvidence);
+        return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession, contig, start,
+                            referenceAllele, alternateAllele);
     }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantInactiveEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantInactiveEntity.java
@@ -17,11 +17,11 @@
  */
 package uk.ac.ebi.eva.accession.core.persistence;
 
-import org.springframework.stereotype.Repository;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.IAccessionedObjectRepository;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.InactiveSubDocument;
 
-@Repository
-public interface SubmittedVariantAccessioningRepository extends
-        IAccessionedObjectRepository<SubmittedVariantEntity, Long> {
+/**
+ * TODO
+ */
+public class SubmittedVariantInactiveEntity extends InactiveSubDocument<Long> {
 
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantInactiveEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantInactiveEntity.java
@@ -24,4 +24,7 @@ import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.InactiveS
  */
 public class SubmittedVariantInactiveEntity extends InactiveSubDocument<Long> {
 
+    public SubmittedVariantInactiveEntity(SubmittedVariantEntity submittedVariantEntity) {
+        super(submittedVariantEntity);
+    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantInactiveEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantInactiveEntity.java
@@ -17,14 +17,107 @@
  */
 package uk.ac.ebi.eva.accession.core.persistence;
 
+import org.springframework.data.mongodb.core.mapping.Document;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.InactiveSubDocument;
 
-/**
- * TODO
- */
-public class SubmittedVariantInactiveEntity extends InactiveSubDocument<Long> {
+import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
+
+import java.util.Objects;
+
+@Document
+public class SubmittedVariantInactiveEntity extends InactiveSubDocument<Long> implements ISubmittedVariant {
+
+    private String assemblyAccession;
+
+    private int taxonomyAccession;
+
+    private String projectAccession;
+
+    private String contig;
+
+    private long start;
+
+    private String referenceAllele;
+
+    private String alternateAllele;
+
+    private boolean supportedByEvidence;
+
+    SubmittedVariantInactiveEntity() {
+    }
 
     public SubmittedVariantInactiveEntity(SubmittedVariantEntity submittedVariantEntity) {
         super(submittedVariantEntity);
+        this.assemblyAccession = submittedVariantEntity.getAssemblyAccession();
+        this.taxonomyAccession = submittedVariantEntity.getTaxonomyAccession();
+        this.projectAccession = submittedVariantEntity.getProjectAccession();
+        this.contig = submittedVariantEntity.getContig();
+        this.start = submittedVariantEntity.getStart();
+        this.referenceAllele = submittedVariantEntity.getReferenceAllele();
+        this.alternateAllele = submittedVariantEntity.getAlternateAllele();
+        this.supportedByEvidence = submittedVariantEntity.isSupportedByEvidence();
+    }
+
+    @Override
+    public String getAssemblyAccession() {
+        return assemblyAccession;
+    }
+
+    @Override
+    public int getTaxonomyAccession() {
+        return taxonomyAccession;
+    }
+
+    @Override
+    public String getProjectAccession() {
+        return projectAccession;
+    }
+
+    @Override
+    public String getContig() {
+        return contig;
+    }
+
+    @Override
+    public long getStart() {
+        return start;
+    }
+
+    @Override
+    public String getReferenceAllele() {
+        return referenceAllele;
+    }
+
+    @Override
+    public String getAlternateAllele() {
+        return alternateAllele;
+    }
+
+    @Override
+    public boolean isSupportedByEvidence() {
+        return supportedByEvidence;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || !(o instanceof ISubmittedVariant)) return false;
+
+        ISubmittedVariant that = (ISubmittedVariant) o;
+
+        if (taxonomyAccession != that.getTaxonomyAccession()) return false;
+        if (start != that.getStart()) return false;
+        if (supportedByEvidence != that.isSupportedByEvidence()) return false;
+        if (!assemblyAccession.equals(that.getAssemblyAccession())) return false;
+        if (!projectAccession.equals(that.getProjectAccession())) return false;
+        if (!contig.equals(that.getContig())) return false;
+        if (!referenceAllele.equals(that.getReferenceAllele())) return false;
+        return alternateAllele.equals(that.getAlternateAllele());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession,
+                            contig, start, referenceAllele, alternateAllele, supportedByEvidence);
     }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantOperationEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantOperationEntity.java
@@ -17,10 +17,9 @@
  */
 package uk.ac.ebi.eva.accession.core.persistence;
 
+import org.springframework.data.mongodb.core.mapping.Document;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.OperationDocument;
 
-/**
- * TODO
- */
+@Document
 public class SubmittedVariantOperationEntity extends OperationDocument<Long, SubmittedVariantInactiveEntity> {
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantOperationEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantOperationEntity.java
@@ -17,11 +17,10 @@
  */
 package uk.ac.ebi.eva.accession.core.persistence;
 
-import org.springframework.stereotype.Repository;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.IAccessionedObjectRepository;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.OperationDocument;
 
-@Repository
-public interface SubmittedVariantAccessioningRepository extends
-        IAccessionedObjectRepository<SubmittedVariantEntity, Long> {
-
+/**
+ * TODO
+ */
+public class SubmittedVariantOperationEntity extends OperationDocument<Long, SubmittedVariantInactiveEntity> {
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantOperationRepository.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantOperationRepository.java
@@ -1,4 +1,5 @@
 /*
+ *
  * Copyright 2018 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,20 +13,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
-package uk.ac.ebi.eva.accession.core.test;
+package uk.ac.ebi.eva.accession.core.persistence;
 
-import com.github.fakemongo.Fongo;
-import com.mongodb.MongoClient;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Repository;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.IHistoryRepository;
 
-@Configuration
-public class MongoTestConfiguration {
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationEntity;
 
-    @Bean
-    public MongoClient mongoClient() {
-        return new Fongo("defaultInstance").getMongo();
-    }
-
+@Repository
+public interface SubmittedVariantOperationRepository extends IHistoryRepository<Long, SubmittedVariantOperationEntity, String> {
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantOperationRepository.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantOperationRepository.java
@@ -20,8 +20,6 @@ package uk.ac.ebi.eva.accession.core.persistence;
 import org.springframework.stereotype.Repository;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.IHistoryRepository;
 
-import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationEntity;
-
 @Repository
 public interface SubmittedVariantOperationRepository extends IHistoryRepository<Long, SubmittedVariantOperationEntity, String> {
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/SubmittedVariantInactiveService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/SubmittedVariantInactiveService.java
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.service;
+
+import uk.ac.ebi.ampt2d.commons.accession.persistence.IHistoryRepository;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.service.BasicMongoDbInactiveAccessionService;
+
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantInactiveEntity;
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationEntity;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class SubmittedVariantInactiveService extends BasicMongoDbInactiveAccessionService<Long, SubmittedVariantEntity,
+        SubmittedVariantInactiveEntity, SubmittedVariantOperationEntity> {
+
+    public SubmittedVariantInactiveService(
+            IHistoryRepository<Long, SubmittedVariantOperationEntity, String> historyRepository,
+            Function<SubmittedVariantEntity, SubmittedVariantInactiveEntity> toInactiveEntity,
+            Supplier<SubmittedVariantOperationEntity> supplier) {
+        super(historyRepository, toInactiveEntity, supplier);
+    }
+}

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
@@ -33,13 +33,12 @@ import uk.ac.ebi.ampt2d.commons.accession.core.AccessionWrapper;
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
 
 import uk.ac.ebi.eva.accession.core.configuration.SubmittedVariantAccessioningConfiguration;
-import uk.ac.ebi.eva.accession.core.test.configuration.MongoDbTestConfiguration;
+import uk.ac.ebi.eva.accession.core.test.configuration.MongoTestConfiguration;
 import uk.ac.ebi.eva.accession.core.test.rule.FixSpringMongoDbRule;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -47,7 +46,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SpringRunner.class)
 @DataJpaTest
 @TestPropertySource("classpath:ss-accession-test.properties")
-@ContextConfiguration(classes = {SubmittedVariantAccessioningConfiguration.class, MongoDbTestConfiguration.class})
+@ContextConfiguration(classes = {SubmittedVariantAccessioningConfiguration.class, MongoTestConfiguration.class})
 public class SubmittedVariantAccessioningServiceTest {
 
     @Rule

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
@@ -53,10 +53,8 @@ public class SubmittedVariantAccessioningServiceTest {
                 new SubmittedVariant("assembly", 1111,
                                      "project", "contig_2", 100, "ref",
                                      "alt", true));
-        List<AccessionWrapper<ISubmittedVariant, String, Long>> generatedAccessions = service.getOrCreateAccessions(
-                variants);
-        List<AccessionWrapper<ISubmittedVariant, String, Long>> retrievedAccessions = service.getOrCreateAccessions(
-                variants);
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> generatedAccessions = service.getOrCreate(variants);
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> retrievedAccessions = service.getOrCreate(variants);
 
         assertEquals(new HashSet(generatedAccessions), new HashSet(retrievedAccessions));
     }

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
@@ -16,10 +16,16 @@
 
 package uk.ac.ebi.eva.accession.core;
 
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbConfigurationBuilder;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -27,23 +33,36 @@ import uk.ac.ebi.ampt2d.commons.accession.core.AccessionWrapper;
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
 
 import uk.ac.ebi.eva.accession.core.configuration.SubmittedVariantAccessioningConfiguration;
-import uk.ac.ebi.eva.accession.core.test.MongoTestConfiguration;
+import uk.ac.ebi.eva.accession.core.test.configuration.MongoDbTestConfiguration;
+import uk.ac.ebi.eva.accession.core.test.rule.FixSpringMongoDbRule;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
-@TestPropertySource("classpath:accession-test.properties")
-@ContextConfiguration(classes = {SubmittedVariantAccessioningConfiguration.class, MongoTestConfiguration.class})
+@TestPropertySource("classpath:ss-accession-test.properties")
+@ContextConfiguration(classes = {SubmittedVariantAccessioningConfiguration.class, MongoDbTestConfiguration.class})
 public class SubmittedVariantAccessioningServiceTest {
 
-    @Autowired
-    SubmittedVariantAccessioningService service;
+    @Rule
+    public MongoDbRule mongoDbRule = new FixSpringMongoDbRule(
+            MongoDbConfigurationBuilder.mongoDb().databaseName("submitted-variants-test").build());
 
+    @Autowired
+    private SubmittedVariantAccessioningService service;
+
+    //Required by nosql-unit
+    @Autowired
+    private ApplicationContext applicationContext;
+
+
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
     @Test
     public void sameAccessionsAreReturnedForIdenticalVariants() throws AccessionCouldNotBeGeneratedException {
         List<SubmittedVariant> variants = Arrays.asList(

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/test/configuration/MongoDbTestConfiguration.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/test/configuration/MongoDbTestConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.test.configuration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantInactiveEntity;
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationEntity;
+import uk.ac.ebi.eva.accession.core.service.SubmittedVariantInactiveService;
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationRepository;
+
+@Configuration
+@EntityScan(basePackages = {"uk.ac.ebi.eva.accession.core.persistence"})
+@EnableMongoRepositories(basePackages = {
+        "uk.ac.ebi.eva.accession.core.persistence",
+        "uk.ac.ebi.eva.accession.core.test.persistence.repository",
+        "uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.repository"})
+@EnableMongoAuditing
+@AutoConfigureDataMongo
+public class MongoDbTestConfiguration {
+
+//    @Autowired
+//    private SubmittedVariantOperationRepository testOperationRepository;
+
+//    @Autowired
+//    private SubmittedVariantInactiveService inactiveService;
+//    private BasicInactiveAccessionService<Long, SubmittedVariantEntity, SubmittedVariantInactiveEntity,
+//            SubmittedVariantOperationEntity> inactiveService;
+//
+//    @Bean
+//    public TestMongoDbInactiveAccessionService testMongoDbInactiveAccessionService() {
+//        return new TestMongoDbInactiveAccessionService(
+//                testOperationRepository,
+//                TestInactiveSubDocument::new,
+//                TestOperationDocument::new
+//        );
+//    }
+//
+//    @Bean
+//    public SubmittedVariantInactiveService submittedVariantInactiveService() {
+//        return new SubmittedVariantInactiveService(
+//                testOperationRepository,
+//                SubmittedVariantInactiveEntity::new,
+//                SubmittedVariantOperationEntity::new
+//        );
+//    }
+//
+//    @Bean
+//    public SubmittedVariantOperationRepository testOperationRepository() {
+//        return testOperationRepository;
+//    }
+}

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/test/configuration/MongoTestConfiguration.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/test/configuration/MongoTestConfiguration.java
@@ -34,7 +34,6 @@ import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationReposit
 @EntityScan(basePackages = {"uk.ac.ebi.eva.accession.core.persistence"})
 @EnableMongoRepositories(basePackages = {
         "uk.ac.ebi.eva.accession.core.persistence",
-        "uk.ac.ebi.eva.accession.core.test.persistence.repository",
         "uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.repository"})
 @EnableMongoAuditing
 @AutoConfigureDataMongo

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/test/configuration/MongoTestConfiguration.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/test/configuration/MongoTestConfiguration.java
@@ -38,36 +38,6 @@ import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationReposit
         "uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.repository"})
 @EnableMongoAuditing
 @AutoConfigureDataMongo
-public class MongoDbTestConfiguration {
+public class MongoTestConfiguration {
 
-//    @Autowired
-//    private SubmittedVariantOperationRepository testOperationRepository;
-
-//    @Autowired
-//    private SubmittedVariantInactiveService inactiveService;
-//    private BasicInactiveAccessionService<Long, SubmittedVariantEntity, SubmittedVariantInactiveEntity,
-//            SubmittedVariantOperationEntity> inactiveService;
-//
-//    @Bean
-//    public TestMongoDbInactiveAccessionService testMongoDbInactiveAccessionService() {
-//        return new TestMongoDbInactiveAccessionService(
-//                testOperationRepository,
-//                TestInactiveSubDocument::new,
-//                TestOperationDocument::new
-//        );
-//    }
-//
-//    @Bean
-//    public SubmittedVariantInactiveService submittedVariantInactiveService() {
-//        return new SubmittedVariantInactiveService(
-//                testOperationRepository,
-//                SubmittedVariantInactiveEntity::new,
-//                SubmittedVariantOperationEntity::new
-//        );
-//    }
-//
-//    @Bean
-//    public SubmittedVariantOperationRepository testOperationRepository() {
-//        return testOperationRepository;
-//    }
 }

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/test/rule/FixSpringMongoDbRule.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/test/rule/FixSpringMongoDbRule.java
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.test.rule;
+
+import com.lordofthejars.nosqlunit.mongodb.MongoDbConfiguration;
+import com.lordofthejars.nosqlunit.mongodb.SpringMongoDbRule;
+
+/**
+ * Temporary fix until nosql unit rc-6 or final is released
+ */
+public class FixSpringMongoDbRule extends SpringMongoDbRule {
+
+    public FixSpringMongoDbRule(MongoDbConfiguration mongoDbConfiguration) {
+        super(mongoDbConfiguration);
+    }
+
+    public FixSpringMongoDbRule(MongoDbConfiguration mongoDbConfiguration, Object object) {
+        super(mongoDbConfiguration, object);
+    }
+
+    @Override
+    public void close() {
+        // DO NOT CLOSE the connection (Spring will do it when destroying the context)
+    }
+
+}

--- a/eva-accession-core/src/test/resources/accession-test.properties
+++ b/eva-accession-core/src/test/resources/accession-test.properties
@@ -1,5 +1,0 @@
-accessioning.instanceId=test-instance-01
-accessioning.variant.blockSize=1000
-accessioning.variant.categoryId=test-ss
-
-spring.data.mongodb.database=test-db

--- a/eva-accession-core/src/test/resources/ss-accession-test.properties
+++ b/eva-accession-core/src/test/resources/ss-accession-test.properties
@@ -6,3 +6,5 @@ spring.data.mongodb.database=submitted-variants-test
 spring.data.mongodb.host=localhost
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
+
+mongodb.read-preference=primary

--- a/eva-accession-core/src/test/resources/ss-accession-test.properties
+++ b/eva-accession-core/src/test/resources/ss-accession-test.properties
@@ -1,0 +1,8 @@
+accessioning.instanceId=test-instance-01
+accessioning.variant.blockSize=1000
+accessioning.variant.categoryId=test-ss
+
+spring.data.mongodb.database=submitted-variants-test
+spring.data.mongodb.host=localhost
+spring.data.mongodb.password=
+spring.data.mongodb.port=27017

--- a/eva-accession-import/pom.xml
+++ b/eva-accession-import/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>eva-accession</artifactId>
         <groupId>uk.ac.ebi.eva</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>eva-accession-core</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1</version>
         </dependency>
         <!--TODO : add PostgreSQL driver with scope runtime for production deployment-->
     </dependencies>

--- a/eva-accession-pipeline/pom.xml
+++ b/eva-accession-pipeline/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>eva-accession</artifactId>
         <groupId>uk.ac.ebi.eva</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1</version>
     </parent>
 
     <artifactId>eva-accession-pipeline</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>eva-accession-core</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1</version>
         </dependency>
 
         <dependency>

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriter.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriter.java
@@ -46,7 +46,7 @@ public class AccessionWriter implements ItemStreamWriter<ISubmittedVariant> {
 
     @Override
     public void write(List<? extends ISubmittedVariant> variants) throws Exception {
-        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.getOrCreateAccessions(variants);
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.getOrCreate(variants);
         accessions.sort(new AccessionWrapperComparator(variants));
         accessionReportWriter.write(accessions);
         checkCountsMatch(variants, accessions);

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
@@ -112,8 +112,7 @@ public class AccessionWriterTest {
 
         accessionWriter.write(Collections.singletonList(variant));
 
-        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.getAccessions(
-                Collections.singletonList(variant));
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.get(Collections.singletonList(variant));
         assertEquals(1, accessions.size());
         assertEquals(EXPECTED_ACCESSION, (long) accessions.iterator().next().getAccession());
 
@@ -141,8 +140,8 @@ public class AccessionWriterTest {
 
         accessionWriter.write(Arrays.asList(firstVariant, secondVariant));
 
-        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.getAccessions(
-                Arrays.asList(firstVariant, secondVariant));
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = 
+                service.get(Arrays.asList(firstVariant, secondVariant));
         assertEquals(2, accessions.size());
 
         Iterator<AccessionWrapper<ISubmittedVariant, String, Long>> iterator = accessions.iterator();
@@ -165,8 +164,7 @@ public class AccessionWriterTest {
 
         accessionWriter.write(Arrays.asList(variant, variant));
 
-        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.getAccessions(
-                Collections.singletonList(variant));
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.get(Collections.singletonList(variant));
         assertEquals(1, accessions.size());
 
         assertVariantEquals(variant, accessions.iterator().next().getData());
@@ -180,8 +178,7 @@ public class AccessionWriterTest {
         LocalDateTime beforeSave = LocalDateTime.now();
         accessionWriter.write(Collections.singletonList(variant));
 
-        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.getAccessions(
-                Collections.singletonList(variant));
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.get(Collections.singletonList(variant));
         assertEquals(1, accessions.size());
         ISubmittedVariant savedVariant = accessions.iterator().next().getData();
         assertTrue(beforeSave.isBefore(savedVariant.getCreatedDate()));
@@ -195,8 +192,7 @@ public class AccessionWriterTest {
 
         accessionWriter.write(Arrays.asList(variant, variant));
 
-        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.getAccessions(
-                Collections.singletonList(variant));
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.get(Collections.singletonList(variant));
         assertEquals(1, accessions.size());
 
         String vcfLine = AccessionReportWriterTest.getFirstVariantLine(output);

--- a/eva-accession-ws/pom.xml
+++ b/eva-accession-ws/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>eva-accession</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1</version>
     </parent>
 
     <artifactId>eva-accession-ws</artifactId>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>eva-accession-core</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1</version>
         </dependency>
 
         <dependency>

--- a/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/SubmittedVariantDTO.java
+++ b/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/SubmittedVariantDTO.java
@@ -20,6 +20,7 @@ package uk.ac.ebi.eva.accession.ws.rest;
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public class SubmittedVariantDTO implements ISubmittedVariant {
 
@@ -107,5 +108,27 @@ public class SubmittedVariantDTO implements ISubmittedVariant {
     @Override
     public LocalDateTime getCreatedDate() {
         return createdDate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || !(o instanceof ISubmittedVariant)) return false;
+
+        ISubmittedVariant that = (ISubmittedVariant) o;
+
+        if (taxonomyAccession != that.getTaxonomyAccession()) return false;
+        if (start != that.getStart()) return false;
+        if (!assemblyAccession.equals(that.getAssemblyAccession())) return false;
+        if (!projectAccession.equals(that.getProjectAccession())) return false;
+        if (!contig.equals(that.getContig())) return false;
+        if (!referenceAllele.equals(that.getReferenceAllele())) return false;
+        return alternateAllele.equals(that.getAlternateAllele());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(assemblyAccession, taxonomyAccession, projectAccession, contig, start,
+                            referenceAllele, alternateAllele);
     }
 }

--- a/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/SubmittedVariantsRestController.java
+++ b/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/SubmittedVariantsRestController.java
@@ -46,7 +46,7 @@ public class SubmittedVariantsRestController {
     @GetMapping(value = "/{identifiers}", produces = "application/json")
     public List<AccessionResponseDTO<SubmittedVariantDTO, ISubmittedVariant, String, Long>> get(
             @PathVariable List<Long> identifiers) {
-        return basicRestController.get(identifiers, false);
+        return basicRestController.get(identifiers);
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.ac.ebi.eva</groupId>
     <artifactId>eva-accession</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1</version>
     <packaging>pom</packaging>
 
     <name>eva-accession</name>
@@ -31,8 +31,13 @@
         <dependencies>
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
-                <artifactId>accessioning-commons</artifactId>
-                <version>0.3-SNAPSHOT</version>
+                <artifactId>accession-commons-mongodb</artifactId>
+                <version>0.4-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>uk.ac.ebi.ampt2d</groupId>
+                <artifactId>accession-commons-monotonic-generator-jpa</artifactId>
+                <version>0.4-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-mongodb</artifactId>
-                <version>0.4-SNAPSHOT</version>
+                <version>0.4</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-monotonic-generator-jpa</artifactId>
-                <version>0.4-SNAPSHOT</version>
+                <version>0.4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The new version of the dependency improves support for MongoDB, including the request of overlapping variants across files in the same study.

It also drops the 'active' and 'version' flags, which are now defined in an interface.

All the variants in the main collection are considered active, and those that have been merged or deprecated will go into a history collection. The list of operations performed over an accession will be tracked in said collection.