### PR TITLE
EVA-1251 Reduce size of MongoDB documents

### DIFF
--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/MongoConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/MongoConfiguration.java
@@ -27,7 +27,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 import java.net.UnknownHostException;
@@ -56,4 +60,10 @@ public class MongoConfiguration {
         return properties.createMongoClient(mongoClientOptions, environment);
     }
 
+    @Bean
+    public MongoTemplate mongoTemplate(MongoDbFactory mongoDbFactory,
+                                       MappingMongoConverter converter) throws UnknownHostException {
+        converter.setTypeMapper(new DefaultMongoTypeMapper(null));
+        return new MongoTemplate(mongoDbFactory, converter);
+    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
@@ -18,6 +18,7 @@
 package uk.ac.ebi.eva.accession.core.persistence;
 
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.AccessionedDocument;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
@@ -27,20 +28,26 @@ import java.util.Objects;
 @Document
 public class SubmittedVariantEntity extends AccessionedDocument<Long> implements ISubmittedVariant {
 
+    @Field("asm")
     private String assemblyAccession;
 
+    @Field("tax")
     private int taxonomyAccession;
 
+    @Field("study")
     private String projectAccession;
 
     private String contig;
 
     private long start;
 
+    @Field("ref")
     private String referenceAllele;
 
+    @Field("alt")
     private String alternateAllele;
 
+    @Field("evidence")
     private boolean supportedByEvidence;
 
     SubmittedVariantEntity() {

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
@@ -177,11 +177,13 @@ public class AccessionWriterTest {
                                                         "reference", "alternate", false);
         LocalDateTime beforeSave = LocalDateTime.now();
         accessionWriter.write(Collections.singletonList(variant));
+        LocalDateTime afterSave = LocalDateTime.now();
 
         List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.get(Collections.singletonList(variant));
         assertEquals(1, accessions.size());
         ISubmittedVariant savedVariant = accessions.iterator().next().getData();
         assertTrue(beforeSave.isBefore(savedVariant.getCreatedDate()));
+        assertTrue(afterSave.isAfter(savedVariant.getCreatedDate()));
     }
 
     @Test


### PR DESCRIPTION
reduce documents from 372 to 227 bytes. this means that when we have 10 billion accessions, the size will be 2.27 TB instead of 3.72 TB. 

We could also change (in accession-commons):
- "createdDate" to "created"
- "version" to "ver"

but my measures show no difference (others' measures show 2 bytes which would be 20 GB, 0.88 %).

Note that I improved the test that checks the auto generated date