### PR TITLE
EVA-1182 Access to legacy dbSNP SS objects with coordinates

### DIFF
--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
@@ -17,6 +17,14 @@
  */
 package uk.ac.ebi.eva.accession.core;
 
+import uk.ac.ebi.ampt2d.commons.accession.core.AccessionVersionsWrapper;
+import uk.ac.ebi.ampt2d.commons.accession.core.AccessionWrapper;
+import uk.ac.ebi.ampt2d.commons.accession.core.AccessioningService;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionDeprecatedException;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionDoesNotExistException;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionMergedException;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.HashAlreadyExistsException;
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicAccessionGenerator;
 import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
@@ -24,11 +32,99 @@ import uk.ac.ebi.ampt2d.commons.accession.service.BasicMonotonicAccessioningServ
 
 import uk.ac.ebi.eva.accession.core.summary.SubmittedVariantSummaryFunction;
 
-public class SubmittedVariantAccessioningService extends BasicMonotonicAccessioningService<ISubmittedVariant, String> {
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SubmittedVariantAccessioningService implements AccessioningService<ISubmittedVariant, String, Long> {
+
+    private static final Long ACCESSIONING_MONOTONIC_INIT_SS = 5000000000L;
+
+    private BasicMonotonicAccessioningService<ISubmittedVariant, String> accessioningService;
+
+    private BasicMonotonicAccessioningService<ISubmittedVariant, String> accessioningServiceDbsnp;
 
     public SubmittedVariantAccessioningService(MonotonicAccessionGenerator<ISubmittedVariant> accessionGenerator,
-                                               MonotonicDatabaseService dbService) {
-        super(accessionGenerator, dbService, new SubmittedVariantSummaryFunction(), new SHA1HashingFunction());
+                                               MonotonicDatabaseService dbService,
+                                               MonotonicDatabaseService dbServiceDbsnp) {
+        this.accessioningService = new BasicMonotonicAccessioningService<ISubmittedVariant, String>
+                (accessionGenerator, dbService, new SubmittedVariantSummaryFunction(), new SHA1HashingFunction());
+        this.accessioningServiceDbsnp = new BasicMonotonicAccessioningService<ISubmittedVariant, String>
+                (accessionGenerator, dbServiceDbsnp, new SubmittedVariantSummaryFunction(), new SHA1HashingFunction());
     }
 
+    @Override
+    public List<AccessionWrapper<ISubmittedVariant, String, Long>> getOrCreate(
+            List<? extends ISubmittedVariant> variants)
+            throws AccessionCouldNotBeGeneratedException {
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> dbsnpVariants = accessioningServiceDbsnp.get(variants);
+        List<ISubmittedVariant> variantsNotInDbsnp = removeFromList(variants, dbsnpVariants);
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> submittedVariants = accessioningService.getOrCreate(variantsNotInDbsnp);
+        return joinLists(submittedVariants, dbsnpVariants);
+    }
+
+    private List<ISubmittedVariant> removeFromList(List<? extends ISubmittedVariant> allVariants,
+                                                   List<AccessionWrapper<ISubmittedVariant, String, Long>>
+                                                           vatiantsToDelete) {
+        return allVariants.stream().filter(variant -> !contains(vatiantsToDelete, variant))
+                          .collect(Collectors.toList());
+    }
+
+    private Boolean contains(List<AccessionWrapper<ISubmittedVariant, String, Long>> accessionWrapperList,
+                             ISubmittedVariant iSubmittedVariant) {
+        return accessionWrapperList.stream().anyMatch(x -> x.getData().equals(iSubmittedVariant));
+    }
+
+    private List<AccessionWrapper<ISubmittedVariant, String, Long>> joinLists(List l1, List l2) {
+        List allVariants = l1;
+        allVariants.addAll(l2);
+        return allVariants;
+    }
+
+    @Override
+    public List<AccessionWrapper<ISubmittedVariant, String, Long>> get(List<? extends ISubmittedVariant> variants) {
+        return joinLists(accessioningService.get(variants), accessioningServiceDbsnp.get(variants));
+    }
+
+    @Override
+    public List<AccessionWrapper<ISubmittedVariant, String, Long>> getByAccessions(List<Long> accessions) {
+        return joinLists(accessioningService.getByAccessions(accessions),
+                         accessioningServiceDbsnp.getByAccessions(accessions));
+    }
+
+    @Override
+    public AccessionWrapper<ISubmittedVariant, String, Long> getByAccessionAndVersion(Long accession, int version)
+            throws AccessionDoesNotExistException, AccessionMergedException, AccessionDeprecatedException {
+        if (accession >= ACCESSIONING_MONOTONIC_INIT_SS) {
+            return accessioningService.getByAccessionAndVersion(accession, version);
+        } else {
+            return accessioningServiceDbsnp.getByAccessionAndVersion(accession, version);
+        }
+    }
+
+    @Override
+    public AccessionVersionsWrapper<ISubmittedVariant, String, Long> update(Long accession, int version,
+                                                                            ISubmittedVariant iSubmittedVariant)
+            throws AccessionDoesNotExistException, HashAlreadyExistsException, AccessionDeprecatedException,
+            AccessionMergedException {
+        return accessioningService.update(accession, version, iSubmittedVariant);
+    }
+
+    @Override
+    public AccessionVersionsWrapper<ISubmittedVariant, String, Long> patch(Long accession, ISubmittedVariant variant)
+            throws AccessionDoesNotExistException, HashAlreadyExistsException, AccessionDeprecatedException,
+            AccessionMergedException {
+        return accessioningService.patch(accession, variant);
+    }
+
+    @Override
+    public void deprecate(Long accession, String reason)
+            throws AccessionMergedException, AccessionDoesNotExistException, AccessionDeprecatedException {
+        accessioningService.deprecate(accession, reason);
+    }
+
+    @Override
+    public void merge(Long accession, Long accession1, String reason)
+            throws AccessionMergedException, AccessionDoesNotExistException, AccessionDeprecatedException {
+        accessioningService.merge(accession, accession1, reason);
+    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
@@ -148,7 +148,6 @@ public class SubmittedVariantAccessioningService implements AccessioningService<
         } else if (accession < accessioningMonotonicInitSs && accession1 < accessioningMonotonicInitSs) {
             accessioningServiceDbsnp.merge(accession, accession1, reason);
         } else {
-//          TODO: Support merging submittedVariants and DbsnpSubmittedVariants
             throw new UnsupportedOperationException("Can't merge a submitted variant with a dbsnp submitted variant");
         }
     }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
@@ -76,7 +76,8 @@ public class SubmittedVariantAccessioningService implements AccessioningService<
 
     private Boolean contains(List<AccessionWrapper<ISubmittedVariant, String, Long>> accessionWrapperList,
                              ISubmittedVariant iSubmittedVariant) {
-        return accessionWrapperList.stream().anyMatch(x -> x.getData().equals(iSubmittedVariant));
+        return accessionWrapperList.stream().anyMatch(
+                accessionWrapper -> accessionWrapper.getData().equals(iSubmittedVariant));
     }
 
     private List<AccessionWrapper<ISubmittedVariant, String, Long>> joinLists(

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningService.java
@@ -30,6 +30,7 @@ import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
 import uk.ac.ebi.ampt2d.commons.accession.service.BasicMonotonicAccessioningService;
 
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpMonotonicAccessionGenerator;
 import uk.ac.ebi.eva.accession.core.summary.DbsnpSubmittedVariantSummaryFunction;
 import uk.ac.ebi.eva.accession.core.summary.SubmittedVariantSummaryFunction;
 
@@ -45,13 +46,14 @@ public class SubmittedVariantAccessioningService implements AccessioningService<
     private Long accessioningMonotonicInitSs;
 
     public SubmittedVariantAccessioningService(MonotonicAccessionGenerator<ISubmittedVariant> accessionGenerator,
+                                               DbsnpMonotonicAccessionGenerator<ISubmittedVariant> dbsnpAccessionGenerator,
                                                MonotonicDatabaseService dbService,
                                                MonotonicDatabaseService dbServiceDbsnp,
                                                Long accessioningMonotonicInitSs) {
         this.accessioningService = new BasicMonotonicAccessioningService<ISubmittedVariant, String>
                 (accessionGenerator, dbService, new SubmittedVariantSummaryFunction(), new SHA1HashingFunction());
         this.accessioningServiceDbsnp = new BasicMonotonicAccessioningService<ISubmittedVariant, String>
-                (accessionGenerator, dbServiceDbsnp, new DbsnpSubmittedVariantSummaryFunction(),
+                (dbsnpAccessionGenerator, dbServiceDbsnp, new DbsnpSubmittedVariantSummaryFunction(),
                  new SHA1HashingFunction());
         this.accessioningMonotonicInitSs = accessioningMonotonicInitSs;
     }
@@ -74,9 +76,9 @@ public class SubmittedVariantAccessioningService implements AccessioningService<
                           .collect(Collectors.toList());
     }
 
-    private Boolean contains(List<AccessionWrapper<ISubmittedVariant, String, Long>> accessionWrapperList,
+    private Boolean contains(List<AccessionWrapper<ISubmittedVariant, String, Long>> accessionWrappers,
                              ISubmittedVariant iSubmittedVariant) {
-        return accessionWrapperList.stream().anyMatch(
+        return accessionWrappers.stream().anyMatch(
                 accessionWrapper -> accessionWrapper.getData().equals(iSubmittedVariant));
     }
 

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
@@ -30,11 +30,17 @@ import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.Cont
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantAccessioningRepository;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantAccessioningDatabaseService;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantInactiveEntity;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantOperationEntity;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantOperationRepository;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantAccessioningDatabaseService;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantAccessioningRepository;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantInactiveEntity;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationEntity;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationRepository;
+import uk.ac.ebi.eva.accession.core.service.DbsnpSubmittedVariantInactiveService;
 import uk.ac.ebi.eva.accession.core.service.SubmittedVariantInactiveService;
 
 @Configuration
@@ -48,10 +54,19 @@ public class SubmittedVariantAccessioningConfiguration {
     private SubmittedVariantAccessioningRepository repository;
 
     @Autowired
+    private DbsnpSubmittedVariantAccessioningRepository dbsnpRepository;
+
+    @Autowired
     private SubmittedVariantOperationRepository operationRepository;
 
     @Autowired
+    private DbsnpSubmittedVariantOperationRepository dbsnpOperationRepository;
+
+    @Autowired
     private SubmittedVariantInactiveService inactiveService;
+
+    @Autowired
+    private DbsnpSubmittedVariantInactiveService dbsnpInactiveService;
 
     @Autowired
     private ContiguousIdBlockService service;
@@ -65,24 +80,8 @@ public class SubmittedVariantAccessioningConfiguration {
     @Bean
     public SubmittedVariantAccessioningService submittedVariantAccessioningService() {
         return new SubmittedVariantAccessioningService(submittedVariantAccessionGenerator(),
-                                                       submittedVariantAccessioningDatabaseService());
-    }
-
-    @Bean
-    public SubmittedVariantOperationRepository submittedVariantOperationRepository() {
-        return operationRepository;
-    }
-
-    @Bean
-    public SubmittedVariantInactiveService submittedVariantInactiveService() {
-        return new SubmittedVariantInactiveService(operationRepository,
-                                                   SubmittedVariantInactiveEntity::new,
-                                                   SubmittedVariantOperationEntity::new);
-    }
-
-    @Bean
-    public SubmittedVariantAccessioningDatabaseService submittedVariantAccessioningDatabaseService() {
-        return new SubmittedVariantAccessioningDatabaseService(repository, inactiveService);
+                                                       submittedVariantAccessioningDatabaseService(),
+                                                       dbsnpSubmittedVariantAccessioningDatabaseService());
     }
 
     @Bean
@@ -94,6 +93,40 @@ public class SubmittedVariantAccessioningConfiguration {
                 properties.getVariant().getCategoryId(),
                 properties.getInstanceId(),
                 service);
+    }
+
+    @Bean
+    public SubmittedVariantAccessioningDatabaseService submittedVariantAccessioningDatabaseService() {
+        return new SubmittedVariantAccessioningDatabaseService(repository, inactiveService);
+    }
+
+    @Bean
+    public DbsnpSubmittedVariantAccessioningDatabaseService dbsnpSubmittedVariantAccessioningDatabaseService() {
+        return new DbsnpSubmittedVariantAccessioningDatabaseService(dbsnpRepository, dbsnpInactiveService);
+    }
+
+    @Bean
+    public SubmittedVariantOperationRepository submittedVariantOperationRepository() {
+        return operationRepository;
+    }
+
+    @Bean
+    public DbsnpSubmittedVariantOperationRepository dbsnpSubmittedVariantOperationRepository() {
+        return dbsnpOperationRepository;
+    }
+
+    @Bean
+    public SubmittedVariantInactiveService submittedVariantInactiveService() {
+        return new SubmittedVariantInactiveService(operationRepository,
+                                                   SubmittedVariantInactiveEntity::new,
+                                                   SubmittedVariantOperationEntity::new);
+    }
+
+    @Bean
+    public DbsnpSubmittedVariantInactiveService dbsnpSubmittedVariantInactiveService() {
+        return new DbsnpSubmittedVariantInactiveService(dbsnpOperationRepository,
+                                                        DbsnpSubmittedVariantInactiveEntity::new,
+                                                        DbsnpSubmittedVariantOperationEntity::new);
     }
 
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
@@ -20,6 +20,7 @@ package uk.ac.ebi.eva.accession.core.configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,8 +31,8 @@ import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.Cont
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
-import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantAccessioningRepository;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantAccessioningDatabaseService;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantAccessioningRepository;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantInactiveEntity;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantOperationEntity;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantOperationRepository;
@@ -42,6 +43,8 @@ import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationEntity;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantOperationRepository;
 import uk.ac.ebi.eva.accession.core.service.DbsnpSubmittedVariantInactiveService;
 import uk.ac.ebi.eva.accession.core.service.SubmittedVariantInactiveService;
+
+import java.util.HashMap;
 
 @Configuration
 @EnableSpringDataContiguousIdService
@@ -71,6 +74,15 @@ public class SubmittedVariantAccessioningConfiguration {
     @Autowired
     private ContiguousIdBlockService service;
 
+    @Autowired
+    @Qualifier("contiguousBlockInitializations")
+    private HashMap<String, String> accessioningMonotonicInitProperties;
+
+    @Bean
+    public Long accessioningMonotonicInitSs() {
+        return new Long(accessioningMonotonicInitProperties.get("ss"));
+    }
+
     @Bean
     @ConfigurationProperties(prefix = "accessioning")
     public ApplicationProperties applicationProperties() {
@@ -81,7 +93,8 @@ public class SubmittedVariantAccessioningConfiguration {
     public SubmittedVariantAccessioningService submittedVariantAccessioningService() {
         return new SubmittedVariantAccessioningService(submittedVariantAccessionGenerator(),
                                                        submittedVariantAccessioningDatabaseService(),
-                                                       dbsnpSubmittedVariantAccessioningDatabaseService());
+                                                       dbsnpSubmittedVariantAccessioningDatabaseService(),
+                                                       accessioningMonotonicInitSs());
     }
 
     @Bean

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/SubmittedVariantAccessioningConfiguration.java
@@ -31,6 +31,7 @@ import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.Cont
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpMonotonicAccessionGenerator;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantAccessioningDatabaseService;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantAccessioningRepository;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantInactiveEntity;
@@ -92,6 +93,7 @@ public class SubmittedVariantAccessioningConfiguration {
     @Bean
     public SubmittedVariantAccessioningService submittedVariantAccessioningService() {
         return new SubmittedVariantAccessioningService(submittedVariantAccessionGenerator(),
+                                                       dbsnpSubmittedVariantAccessionGenerator(),
                                                        submittedVariantAccessioningDatabaseService(),
                                                        dbsnpSubmittedVariantAccessioningDatabaseService(),
                                                        accessioningMonotonicInitSs());
@@ -102,6 +104,16 @@ public class SubmittedVariantAccessioningConfiguration {
         ApplicationProperties properties = applicationProperties();
         logger.debug("Using application properties: " + properties.toString());
         return new MonotonicAccessionGenerator<>(
+                properties.getVariant().getBlockSize(),
+                properties.getVariant().getCategoryId(),
+                properties.getInstanceId(),
+                service);
+    }
+
+    @Bean
+    public DbsnpMonotonicAccessionGenerator<ISubmittedVariant> dbsnpSubmittedVariantAccessionGenerator() {
+        ApplicationProperties properties = applicationProperties();
+        return new DbsnpMonotonicAccessionGenerator<>(
                 properties.getVariant().getBlockSize(),
                 properties.getVariant().getCategoryId(),
                 properties.getInstanceId(),

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbSnpSubmittedVariantAccessioningRepositoryImpl.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbSnpSubmittedVariantAccessioningRepositoryImpl.java
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.persistence;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.repository.BasicMongoDbAccessionedCustomRepositoryImpl;
+
+public class DbSnpSubmittedVariantAccessioningRepositoryImpl extends
+        BasicMongoDbAccessionedCustomRepositoryImpl<Long, DbsnpSubmittedVariantEntity> {
+
+    public DbSnpSubmittedVariantAccessioningRepositoryImpl(MongoTemplate mongoTemplate) {
+        super(DbsnpSubmittedVariantEntity.class, mongoTemplate);
+    }
+}

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpMonotonicAccessionGenerator.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpMonotonicAccessionGenerator.java
@@ -20,37 +20,37 @@ public class DbsnpMonotonicAccessionGenerator<T> extends MonotonicAccessionGener
 
     @Override
     public synchronized void recoverState(long[] committedElements) throws AccessionIsNotPendingException {
-        throw new UnsupportedOperationException("New accessions should not be generated");
+        throw new UnsupportedOperationException("New accessions cannot be issued for dbSNP variants");
     }
 
     @Override
     public synchronized long[] generateAccessions(
             int numAccessionsToGenerate) throws AccessionCouldNotBeGeneratedException {
-        throw new UnsupportedOperationException("New accessions should not be generated");
+        throw new UnsupportedOperationException("New accessions cannot be issued for dbSNP variants");
     }
 
     @Override
     public synchronized void commit(long... accessions) throws AccessionIsNotPendingException {
-        throw new UnsupportedOperationException("New accessions should not be generated");
+        throw new UnsupportedOperationException("New accessions cannot be issued for dbSNP variants");
     }
 
     @Override
     public synchronized void release(long... accessions) throws AccessionIsNotPendingException {
-        throw new UnsupportedOperationException("New accessions should not be generated");
+        throw new UnsupportedOperationException("New accessions cannot be issued for dbSNP variants");
     }
 
     @Override
     public synchronized MonotonicRangePriorityQueue getAvailableRanges() {
-        throw new UnsupportedOperationException("New accessions should not be generated");
+        throw new UnsupportedOperationException("New accessions cannot be issued for dbSNP variants");
     }
 
     @Override
     public synchronized void postSave(SaveResponse response) {
-        throw new UnsupportedOperationException("New accessions should not be generated");
+        throw new UnsupportedOperationException("New accessions cannot be issued for dbSNP variants");
     }
 
     @Override
     public List<AccessionWrapper> generateAccessions(Map messages) throws AccessionCouldNotBeGeneratedException {
-        throw new UnsupportedOperationException("New accessions should not be generated");
+        throw new UnsupportedOperationException("New accessions cannot be issued for dbSNP variants");
     }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpMonotonicAccessionGenerator.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpMonotonicAccessionGenerator.java
@@ -1,0 +1,56 @@
+package uk.ac.ebi.eva.accession.core.persistence;
+
+import uk.ac.ebi.ampt2d.commons.accession.core.AccessionWrapper;
+import uk.ac.ebi.ampt2d.commons.accession.core.SaveResponse;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionIsNotPendingException;
+import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicAccessionGenerator;
+import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicRangePriorityQueue;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.ContiguousIdBlockService;
+
+import java.util.List;
+import java.util.Map;
+
+public class DbsnpMonotonicAccessionGenerator<T> extends MonotonicAccessionGenerator {
+
+    public DbsnpMonotonicAccessionGenerator(long blockSize, String categoryId, String applicationInstanceId,
+                                            ContiguousIdBlockService contiguousIdBlockService) {
+        super(blockSize, categoryId, applicationInstanceId, contiguousIdBlockService);
+    }
+
+    @Override
+    public synchronized void recoverState(long[] committedElements) throws AccessionIsNotPendingException {
+        throw new UnsupportedOperationException("New accessions should not be generated");
+    }
+
+    @Override
+    public synchronized long[] generateAccessions(
+            int numAccessionsToGenerate) throws AccessionCouldNotBeGeneratedException {
+        throw new UnsupportedOperationException("New accessions should not be generated");
+    }
+
+    @Override
+    public synchronized void commit(long... accessions) throws AccessionIsNotPendingException {
+        throw new UnsupportedOperationException("New accessions should not be generated");
+    }
+
+    @Override
+    public synchronized void release(long... accessions) throws AccessionIsNotPendingException {
+        throw new UnsupportedOperationException("New accessions should not be generated");
+    }
+
+    @Override
+    public synchronized MonotonicRangePriorityQueue getAvailableRanges() {
+        throw new UnsupportedOperationException("New accessions should not be generated");
+    }
+
+    @Override
+    public synchronized void postSave(SaveResponse response) {
+        throw new UnsupportedOperationException("New accessions should not be generated");
+    }
+
+    @Override
+    public List<AccessionWrapper> generateAccessions(Map messages) throws AccessionCouldNotBeGeneratedException {
+        throw new UnsupportedOperationException("New accessions should not be generated");
+    }
+}

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningDatabaseService.java
@@ -42,7 +42,7 @@ public class DbsnpSubmittedVariantAccessioningDatabaseService
 
     @Override
     public long[] getAccessionsInRanges(Collection<MonotonicRange> ranges) {
-        throw new UnsupportedOperationException("New accessions should not be generated using this service");
+        throw new UnsupportedOperationException("New accessions cannot be issued for dbSNP variants");
     }
 
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningDatabaseService.java
@@ -1,0 +1,48 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.persistence;
+
+import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicRange;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.BasicSpringDataRepositoryDatabaseService;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
+
+import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
+import uk.ac.ebi.eva.accession.core.service.DbsnpSubmittedVariantInactiveService;
+
+import java.util.Collection;
+
+public class DbsnpSubmittedVariantAccessioningDatabaseService
+        extends BasicSpringDataRepositoryDatabaseService<ISubmittedVariant, Long, DbsnpSubmittedVariantEntity>
+        implements MonotonicDatabaseService<ISubmittedVariant, String> {
+
+    public DbsnpSubmittedVariantAccessioningDatabaseService(DbsnpSubmittedVariantAccessioningRepository repository,
+                                                            DbsnpSubmittedVariantInactiveService inactiveService) {
+        super(repository,
+              accessionWrapper -> new DbsnpSubmittedVariantEntity(accessionWrapper.getAccession(),
+                                                                  accessionWrapper.getHash(),
+                                                                  accessionWrapper.getData()),
+              DbsnpSubmittedVariantEntity::getModel,
+              inactiveService);
+    }
+
+    @Override
+    public long[] getAccessionsInRanges(Collection<MonotonicRange> ranges) {
+        return new long[0];
+    }
+
+}

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningDatabaseService.java
@@ -42,7 +42,7 @@ public class DbsnpSubmittedVariantAccessioningDatabaseService
 
     @Override
     public long[] getAccessionsInRanges(Collection<MonotonicRange> ranges) {
-        return new long[0];
+        throw new UnsupportedOperationException("New accessions should not be generated using this service");
     }
 
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningRepository.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningRepository.java
@@ -1,0 +1,27 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.persistence;
+
+import org.springframework.stereotype.Repository;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.IAccessionedObjectRepository;
+
+@Repository
+public interface DbsnpSubmittedVariantAccessioningRepository extends
+        IAccessionedObjectRepository<DbsnpSubmittedVariantEntity, Long> {
+
+}

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningRepositoryImpl.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningRepositoryImpl.java
@@ -20,10 +20,10 @@ package uk.ac.ebi.eva.accession.core.persistence;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.repository.BasicMongoDbAccessionedCustomRepositoryImpl;
 
-public class DbSnpSubmittedVariantAccessioningRepositoryImpl extends
+public class DbsnpSubmittedVariantAccessioningRepositoryImpl extends
         BasicMongoDbAccessionedCustomRepositoryImpl<Long, DbsnpSubmittedVariantEntity> {
 
-    public DbSnpSubmittedVariantAccessioningRepositoryImpl(MongoTemplate mongoTemplate) {
+    public DbsnpSubmittedVariantAccessioningRepositoryImpl(MongoTemplate mongoTemplate) {
         super(DbsnpSubmittedVariantEntity.class, mongoTemplate);
     }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantEntity.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.ac.ebi.eva.accession.dbsnp.persistence;
+package uk.ac.ebi.eva.accession.core.persistence;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
-import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantEntity;
 
 public class DbsnpSubmittedVariantEntity extends SubmittedVariantEntity {
 

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantInactiveEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantInactiveEntity.java
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.persistence;
+
+public class DbsnpSubmittedVariantInactiveEntity extends SubmittedVariantInactiveEntity {
+
+    public DbsnpSubmittedVariantInactiveEntity() {
+        super();
+    }
+
+    public DbsnpSubmittedVariantInactiveEntity(DbsnpSubmittedVariantEntity dbsnpSubmittedVariantEntity) {
+        super(dbsnpSubmittedVariantEntity);
+    }
+}

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantOperationEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantOperationEntity.java
@@ -1,0 +1,26 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.persistence;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.OperationDocument;
+
+@Document
+public class DbsnpSubmittedVariantOperationEntity extends OperationDocument<Long, DbsnpSubmittedVariantInactiveEntity> {
+
+}

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantOperationRepository.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantOperationRepository.java
@@ -1,0 +1,25 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.persistence;
+
+import uk.ac.ebi.ampt2d.commons.accession.persistence.IHistoryRepository;
+
+public interface DbsnpSubmittedVariantOperationRepository extends IHistoryRepository<Long,
+        DbsnpSubmittedVariantOperationEntity, String> {
+
+}

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/DbsnpSubmittedVariantInactiveService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/DbsnpSubmittedVariantInactiveService.java
@@ -1,0 +1,40 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.core.service;
+
+import uk.ac.ebi.ampt2d.commons.accession.persistence.IHistoryRepository;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.service.BasicMongoDbInactiveAccessionService;
+
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantInactiveEntity;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantOperationEntity;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class DbsnpSubmittedVariantInactiveService extends BasicMongoDbInactiveAccessionService<Long,
+        DbsnpSubmittedVariantEntity, DbsnpSubmittedVariantInactiveEntity, DbsnpSubmittedVariantOperationEntity> {
+
+    public DbsnpSubmittedVariantInactiveService(
+            IHistoryRepository<Long, DbsnpSubmittedVariantOperationEntity, String> historyRepository,
+            Function<DbsnpSubmittedVariantEntity, DbsnpSubmittedVariantInactiveEntity> toInactiveEntity,
+            Supplier<DbsnpSubmittedVariantOperationEntity> supplier) {
+        super(historyRepository, toInactiveEntity, supplier);
+    }
+
+}

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package uk.ac.ebi.eva.accession.core;
 
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.MongoDbConfigurationBuilder;
 import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,27 +30,35 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.ampt2d.commons.accession.core.AccessionWrapper;
+import uk.ac.ebi.ampt2d.commons.accession.core.OperationType;
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionDeprecatedException;
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionDoesNotExistException;
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionMergedException;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.HashAlreadyExistsException;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.IOperation;
 
 import uk.ac.ebi.eva.accession.core.configuration.SubmittedVariantAccessioningConfiguration;
+import uk.ac.ebi.eva.accession.core.service.DbsnpSubmittedVariantInactiveService;
+import uk.ac.ebi.eva.accession.core.service.SubmittedVariantInactiveService;
 import uk.ac.ebi.eva.accession.core.test.configuration.MongoTestConfiguration;
 import uk.ac.ebi.eva.accession.core.test.rule.FixSpringMongoDbRule;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
 @TestPropertySource("classpath:ss-accession-test.properties")
 @ContextConfiguration(classes = {SubmittedVariantAccessioningConfiguration.class, MongoTestConfiguration.class})
-@UsingDataSet(locations = {"/test-data/submittedVariantEntity.json", "/test-data/dbsnpSubmittedVariantEntity.json"})
 public class SubmittedVariantAccessioningServiceTest {
 
     private static final Long CLUSTERED_VARIANT = null;
@@ -63,6 +71,30 @@ public class SubmittedVariantAccessioningServiceTest {
 
     private static final Boolean VALIDATED = false;
 
+    private static final String PROJECT = "PRJEB21794";
+
+    private static final String PROJECT_DBSNP = "DBSNP999";
+
+    private static final long ACCESSION = 5000000000L;
+
+    private static final long ACCESSION_TO_DEPRECATE = 5000000002L;
+
+    private static final long ACCESSION_TO_MERGE_1 = 5000000004L;
+
+    private static final long ACCESSION_TO_MERGE_2 = 5000000005L;
+
+    private static final long ACCESSION_DBSNP_1 = 2200000000L;
+
+    private static final long ACCESSION_DBSNP_2 = 2200000001L;
+
+    private SubmittedVariant submittedVariant;
+
+    private SubmittedVariant newSubmittedVariant;
+
+    private SubmittedVariant dbsnpSubmittedVariant;
+
+    private SubmittedVariant submittedVariantModified;
+
     @Rule
     public MongoDbRule mongoDbRule = new FixSpringMongoDbRule(
             MongoDbConfigurationBuilder.mongoDb().databaseName("submitted-variants-test").build());
@@ -70,10 +102,37 @@ public class SubmittedVariantAccessioningServiceTest {
     @Autowired
     private SubmittedVariantAccessioningService service;
 
+    @Autowired
+    private SubmittedVariantInactiveService inactiveService;
+
+    @Autowired
+    private DbsnpSubmittedVariantInactiveService dbsnpInactiveService;
+
+    @Autowired
+    private Long accessioningMonotonicInitSs;
+
     //Required by nosql-unit
     @Autowired
     private ApplicationContext applicationContext;
 
+    @Before
+    public void setUp() {
+        submittedVariant = new SubmittedVariant("GCA_000003055.3", 9913, PROJECT, "21", 20800319, "C", "T",
+                                                CLUSTERED_VARIANT, SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, true,
+                                                VALIDATED);
+
+        newSubmittedVariant = new SubmittedVariant("assembly", 1111, "project", "contig_2", 100, "ref", "alt",
+                                                   CLUSTERED_VARIANT, SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, true,
+                                                   VALIDATED);
+
+        dbsnpSubmittedVariant = new SubmittedVariant("GCA_000009999.3", 9999, PROJECT_DBSNP, "21", 20849999, "", "GG",
+                                                     CLUSTERED_VARIANT, SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, true,
+                                                     VALIDATED);
+
+        submittedVariantModified = new SubmittedVariant("GCA_000003055.3", 9913, PROJECT, "21", 20800319,
+                                                        "C", "TCTC", CLUSTERED_VARIANT, SUPPORTED_BY_EVIDENCE,
+                                                        MATCHES_ASSEMBLY, true, VALIDATED);
+    }
 
     @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
     @Test
@@ -81,8 +140,8 @@ public class SubmittedVariantAccessioningServiceTest {
         List<SubmittedVariant> variants = Arrays.asList(
                 new SubmittedVariant("assembly", 1111, "project", "contig_1", 100, "ref", "alt", CLUSTERED_VARIANT,
                                      SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH, VALIDATED),
-                new SubmittedVariant("assembly", 1111, "project", "contig_2", 100, "ref", "alt", CLUSTERED_VARIANT,
-                                     SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH, VALIDATED));
+                newSubmittedVariant);
+
         List<AccessionWrapper<ISubmittedVariant, String, Long>> generatedAccessions = service.getOrCreate(variants);
         List<AccessionWrapper<ISubmittedVariant, String, Long>> retrievedAccessions = service.getOrCreate(variants);
 
@@ -95,8 +154,7 @@ public class SubmittedVariantAccessioningServiceTest {
         List<SubmittedVariant> originalVariants = Arrays.asList(
                 new SubmittedVariant("assembly", 1111, "project", "contig_1", 100, "ref", "alt", CLUSTERED_VARIANT,
                                      SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH, VALIDATED),
-                new SubmittedVariant("assembly", 1111, "project", "contig_2", 100, "ref", "alt", CLUSTERED_VARIANT,
-                                     SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH, VALIDATED));
+                newSubmittedVariant);
         List<SubmittedVariant> requestedVariants = Arrays.asList(
                 new SubmittedVariant("assembly", 1111, "project", "contig_1", 100, "ref", "alt", null,
                                      SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH, VALIDATED),
@@ -110,68 +168,173 @@ public class SubmittedVariantAccessioningServiceTest {
         assertEquals(new HashSet<>(generatedAccessions), new HashSet<>(retrievedAccessions));
     }
 
+    @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json", "/test-data/dbsnpSubmittedVariantEntity.json"})
     @Test
-    public void getOrCreateAccessions() throws AccessionCouldNotBeGeneratedException {
-        List<SubmittedVariant> variants = Arrays.asList(
-                new SubmittedVariant("GCA_000003055.3", 9913, "PRJEB21794", "21", 20800319, "C", "T", CLUSTERED_VARIANT,
-                                     SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH, VALIDATED),
-                new SubmittedVariant("assembly", 1111, "project", "contig_2", 100, "ref", "alt", CLUSTERED_VARIANT,
-                                     SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH, VALIDATED),
-                new SubmittedVariant("GCA_000009999.3", 9999, "PRJEB21999", "21", 20849999, "", "GG", CLUSTERED_VARIANT,
-                                     SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, true, VALIDATED));
-
+    public void getOrCreateAccessionsInBothRepositories() throws AccessionCouldNotBeGeneratedException {
+        List<SubmittedVariant> variants = Arrays.asList(submittedVariant, newSubmittedVariant, dbsnpSubmittedVariant);
         List<AccessionWrapper<ISubmittedVariant, String, Long>> submittedVariants = service.getOrCreate(variants);
 
-        long accession = submittedVariants.stream().filter(x -> x.getData().getProjectAccession().equals("PRJEB21794"))
+        long accession = submittedVariants.stream()
+                                          .filter(x -> x.getData().getProjectAccession().equals(PROJECT))
                                           .collect(Collectors.toList())
                                           .get(0).getAccession();
-        assertEquals(5000000000L, accession);
+        assertEquals(ACCESSION, accession);
 
         long accessionDbsnp = submittedVariants.stream()
-                                               .filter(x -> x.getData().getProjectAccession().equals("PRJEB21999"))
+                                               .filter(x -> x.getData().getProjectAccession().equals(PROJECT_DBSNP))
                                                .collect(Collectors.toList())
                                                .get(0).getAccession();
-        assertEquals(1000000001L, accessionDbsnp);
+        assertEquals(ACCESSION_DBSNP_1, accessionDbsnp);
 
         assertEquals(3, submittedVariants.size());
     }
 
+    @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json", "/test-data/dbsnpSubmittedVariantEntity.json"})
     @Test
-    public void get() {
-        List<SubmittedVariant> variants = Arrays.asList(
-                new SubmittedVariant("GCA_000003055.3", 9913, "PRJEB21794", "21", 20800319, "C", "T", CLUSTERED_VARIANT,
-                                     SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH, VALIDATED),
-                new SubmittedVariant("assembly", 1111, "project", "contig_2", 100, "ref", "alt", CLUSTERED_VARIANT,
-                                     SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH, VALIDATED),
-                new SubmittedVariant("GCA_000009999.3", 9999, "PRJEB21999", "21", 20849999, "", "GG", CLUSTERED_VARIANT,
-                                     SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, true, VALIDATED));
-
+    public void getFromBothRepositories() {
+        List<SubmittedVariant> variants = Arrays.asList(submittedVariant, newSubmittedVariant, dbsnpSubmittedVariant);
         List<AccessionWrapper<ISubmittedVariant, String, Long>> accessions = service.get(variants);
         assertEquals(2, accessions.size());
     }
 
+    @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json", "/test-data/dbsnpSubmittedVariantEntity.json"})
     @Test
-    public void getByAccessions() {
-        List<Long> accessions = Arrays.asList(5000000000L, 1000000001L);
+    public void getByAccessionsFromBothRepositories() {
+        List<Long> accessions = Arrays.asList(ACCESSION, ACCESSION_DBSNP_1);
         List<AccessionWrapper<ISubmittedVariant, String, Long>> submittedVariants = service.getByAccessions(accessions);
         assertEquals(2, submittedVariants.size());
     }
 
+    @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json", "/test-data/dbsnpSubmittedVariantEntity.json"})
     @Test
-    public void getByAccessionAndVersion() throws AccessionMergedException, AccessionDoesNotExistException,
-            AccessionDeprecatedException {
-        SubmittedVariant variant = new SubmittedVariant("GCA_000003055.3", 9913, "PRJEB21794", "21", 20800319, "C", "T",
-                                                        CLUSTERED_VARIANT, SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY,
-                                                        true, VALIDATED);
+    public void getByAccessionAndVersionFromBothRepositories() throws AccessionMergedException,
+            AccessionDoesNotExistException, AccessionDeprecatedException {
         AccessionWrapper<ISubmittedVariant, String, Long> submittedVariant = service.getByAccessionAndVersion(
-                5000000000L, 1);
-        assertEquals(variant, submittedVariant.getData());
+                ACCESSION, 1);
+        assertEquals(this.submittedVariant, submittedVariant.getData());
 
-        SubmittedVariant dbsnpVariant = new SubmittedVariant("GCA_000009999.3", 9999, "PRJEB21999", "21", 20849999, "",
-                                                             "GG", CLUSTERED_VARIANT, SUPPORTED_BY_EVIDENCE,
-                                                             MATCHES_ASSEMBLY, true, VALIDATED);
         AccessionWrapper<ISubmittedVariant, String, Long> dbsnpSubmittedVariant = service.getByAccessionAndVersion(
-                1000000001L, 1);
-        assertEquals(dbsnpVariant, dbsnpSubmittedVariant.getData());
+                ACCESSION_DBSNP_1, 1);
+        assertEquals(this.dbsnpSubmittedVariant, dbsnpSubmittedVariant.getData());
     }
+
+    @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json"})
+    @Test
+    public void updateSubmittedVariant() throws AccessionDeprecatedException, AccessionDoesNotExistException,
+            AccessionMergedException, HashAlreadyExistsException {
+        assertUpdate(ACCESSION, submittedVariantModified);
+    }
+
+    private void assertUpdate(long accession, ISubmittedVariant modifiedVariant)
+            throws AccessionDeprecatedException, AccessionDoesNotExistException, AccessionMergedException,
+            HashAlreadyExistsException {
+        service.update(accession, 1, modifiedVariant);
+        assertEquals(modifiedVariant, service.getByAccessionAndVersion(accession, 1).getData());
+
+        IOperation<Long> lastOperation;
+        if (accession >= accessioningMonotonicInitSs) {
+            lastOperation = inactiveService.getLastOperation(accession);
+        } else {
+            lastOperation = dbsnpInactiveService.getLastOperation(accession);
+        }
+        assertEquals(OperationType.UPDATED, lastOperation.getOperationType());
+        assertEquals(accession, lastOperation.getAccessionIdOrigin().longValue());
+        assertNull(lastOperation.getAccessionIdDestination());
+    }
+
+    @UsingDataSet(locations = {"/test-data/dbsnpSubmittedVariantEntity.json"})
+    @Test
+    public void updateDbsnpSubmittedVariant() throws AccessionDeprecatedException, AccessionDoesNotExistException,
+            AccessionMergedException, HashAlreadyExistsException {
+        assertUpdate(ACCESSION_DBSNP_1, submittedVariantModified);
+    }
+
+    @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json"})
+    @Test
+    public void patchSubmittedVariant() throws AccessionDeprecatedException, AccessionDoesNotExistException,
+            AccessionMergedException, HashAlreadyExistsException {
+        assertPatch(ACCESSION, submittedVariantModified);
+    }
+
+    private void assertPatch(long accession, ISubmittedVariant modifiedVariant) throws AccessionDeprecatedException,
+            AccessionDoesNotExistException, AccessionMergedException, HashAlreadyExistsException {
+        service.patch(accession, modifiedVariant);
+        ISubmittedVariant variantFromDb = service.getByAccessions(Collections.singletonList(accession)).get(0)
+                                                 .getData();
+        assertEquals(modifiedVariant, variantFromDb);
+    }
+
+    @UsingDataSet(locations = {"/test-data/dbsnpSubmittedVariantEntity.json"})
+    @Test
+    public void patchDbsnpSubmittedVariant() throws AccessionDeprecatedException, AccessionDoesNotExistException,
+            AccessionMergedException, HashAlreadyExistsException {
+        assertPatch(ACCESSION_DBSNP_1, submittedVariantModified);
+    }
+
+    @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json"})
+    @Test
+    public void deprecateSubmittedVariant() throws AccessionMergedException, AccessionDoesNotExistException,
+            AccessionDeprecatedException {
+        assertDeprecate(ACCESSION_TO_DEPRECATE, "Test deprecate");
+    }
+
+    private void assertDeprecate(long accession, String reason) throws AccessionMergedException,
+            AccessionDoesNotExistException, AccessionDeprecatedException {
+        assertFalse(service.getByAccessions(Collections.singletonList(accession)).isEmpty());
+        service.deprecate(accession, reason);
+        assertTrue(service.getByAccessions(Collections.singletonList(accession)).isEmpty());
+
+        IOperation<Long> lastOperation;
+        if (accession >= accessioningMonotonicInitSs) {
+            lastOperation = inactiveService.getLastOperation(accession);
+        } else {
+            lastOperation = dbsnpInactiveService.getLastOperation(accession);
+        }
+        assertEquals(OperationType.DEPRECATED, lastOperation.getOperationType());
+        assertEquals(accession, lastOperation.getAccessionIdOrigin().longValue());
+        assertNull(lastOperation.getAccessionIdDestination());
+        assertEquals(reason, lastOperation.getReason());
+    }
+
+    @UsingDataSet(locations = {"/test-data/dbsnpSubmittedVariantEntity.json"})
+    @Test
+    public void deprecateDnsnpSubmittedVariant() throws AccessionMergedException, AccessionDoesNotExistException,
+            AccessionDeprecatedException {
+        assertDeprecate(ACCESSION_DBSNP_1, "Test deprecate");
+    }
+
+    @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json"})
+    @Test
+    public void mergeSubmittedVariant() throws AccessionMergedException, AccessionDoesNotExistException,
+            AccessionDeprecatedException {
+        assertMerge(ACCESSION_TO_MERGE_1, ACCESSION_TO_MERGE_2, "Test merge");
+    }
+
+    private void assertMerge(long accessionOrigin, long accessionDestination, String reason) throws
+            AccessionMergedException, AccessionDoesNotExistException, AccessionDeprecatedException {
+        assertFalse(service.getByAccessions(Collections.singletonList(accessionOrigin)).isEmpty());
+        assertFalse(service.getByAccessions(Collections.singletonList(accessionDestination)).isEmpty());
+        service.merge(accessionOrigin, accessionDestination, reason);
+        assertTrue(service.getByAccessions(Collections.singletonList(accessionOrigin)).isEmpty());
+        assertFalse(service.getByAccessions(Collections.singletonList(accessionDestination)).isEmpty());
+
+        IOperation<Long> lastOperation;
+        if (accessionOrigin >= accessioningMonotonicInitSs) {
+            lastOperation = inactiveService.getLastOperation(accessionOrigin);
+        } else {
+            lastOperation = dbsnpInactiveService.getLastOperation(accessionOrigin);
+        }
+        assertEquals(OperationType.MERGED_INTO, lastOperation.getOperationType());
+        assertEquals(accessionOrigin, lastOperation.getAccessionIdOrigin().longValue());
+        assertEquals(accessionDestination, lastOperation.getAccessionIdDestination().longValue());
+        assertEquals("Test merge", lastOperation.getReason());
+    }
+
+    @UsingDataSet(locations = {"/test-data/dbsnpSubmittedVariantEntity.json"})
+    @Test
+    public void mergeDbsnpSubmittedVariant() throws AccessionMergedException, AccessionDoesNotExistException,
+            AccessionDeprecatedException {
+        assertMerge(ACCESSION_DBSNP_1, ACCESSION_DBSNP_2, "Test merge");
+    }
+
 }

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/SubmittedVariantAccessioningServiceTest.java
@@ -87,6 +87,10 @@ public class SubmittedVariantAccessioningServiceTest {
 
     private static final long ACCESSION_DBSNP_2 = 2200000001L;
 
+    private static final String DEPRECATE_REASON = "Test deprecate";
+
+    private static final String MERGE_REASON = "Test merge";
+
     private SubmittedVariant submittedVariant;
 
     private SubmittedVariant newSubmittedVariant;
@@ -222,13 +226,12 @@ public class SubmittedVariantAccessioningServiceTest {
     @Test
     public void updateSubmittedVariant() throws AccessionDeprecatedException, AccessionDoesNotExistException,
             AccessionMergedException, HashAlreadyExistsException {
-        assertUpdate(ACCESSION, submittedVariantModified);
+        service.update(ACCESSION, 1, submittedVariantModified);
+        assertVariantUpdated(ACCESSION, submittedVariantModified);
     }
 
-    private void assertUpdate(long accession, ISubmittedVariant modifiedVariant)
-            throws AccessionDeprecatedException, AccessionDoesNotExistException, AccessionMergedException,
-            HashAlreadyExistsException {
-        service.update(accession, 1, modifiedVariant);
+    private void assertVariantUpdated(long accession, ISubmittedVariant modifiedVariant)
+            throws AccessionDeprecatedException, AccessionDoesNotExistException, AccessionMergedException {
         assertEquals(modifiedVariant, service.getByAccessionAndVersion(accession, 1).getData());
 
         IOperation<Long> lastOperation;
@@ -246,19 +249,19 @@ public class SubmittedVariantAccessioningServiceTest {
     @Test
     public void updateDbsnpSubmittedVariant() throws AccessionDeprecatedException, AccessionDoesNotExistException,
             AccessionMergedException, HashAlreadyExistsException {
-        assertUpdate(ACCESSION_DBSNP_1, submittedVariantModified);
+        service.update(ACCESSION_DBSNP_1, 1, submittedVariantModified);
+        assertVariantUpdated(ACCESSION_DBSNP_1, submittedVariantModified);
     }
 
     @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json"})
     @Test
     public void patchSubmittedVariant() throws AccessionDeprecatedException, AccessionDoesNotExistException,
             AccessionMergedException, HashAlreadyExistsException {
-        assertPatch(ACCESSION, submittedVariantModified);
+        service.patch(ACCESSION, submittedVariantModified);
+        assertVariantPatched(ACCESSION, submittedVariantModified);
     }
 
-    private void assertPatch(long accession, ISubmittedVariant modifiedVariant) throws AccessionDeprecatedException,
-            AccessionDoesNotExistException, AccessionMergedException, HashAlreadyExistsException {
-        service.patch(accession, modifiedVariant);
+    private void assertVariantPatched(long accession, ISubmittedVariant modifiedVariant) {
         ISubmittedVariant variantFromDb = service.getByAccessions(Collections.singletonList(accession)).get(0)
                                                  .getData();
         assertEquals(modifiedVariant, variantFromDb);
@@ -268,20 +271,20 @@ public class SubmittedVariantAccessioningServiceTest {
     @Test
     public void patchDbsnpSubmittedVariant() throws AccessionDeprecatedException, AccessionDoesNotExistException,
             AccessionMergedException, HashAlreadyExistsException {
-        assertPatch(ACCESSION_DBSNP_1, submittedVariantModified);
+        service.patch(ACCESSION_DBSNP_1, submittedVariantModified);
+        assertVariantPatched(ACCESSION_DBSNP_1, submittedVariantModified);
     }
 
     @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json"})
     @Test
     public void deprecateSubmittedVariant() throws AccessionMergedException, AccessionDoesNotExistException,
             AccessionDeprecatedException {
-        assertDeprecate(ACCESSION_TO_DEPRECATE, "Test deprecate");
+        assertFalse(service.getByAccessions(Collections.singletonList(ACCESSION_TO_DEPRECATE)).isEmpty());
+        service.deprecate(ACCESSION_TO_DEPRECATE, DEPRECATE_REASON);
+        assertVariantDeprecated(ACCESSION_TO_DEPRECATE, DEPRECATE_REASON);
     }
 
-    private void assertDeprecate(long accession, String reason) throws AccessionMergedException,
-            AccessionDoesNotExistException, AccessionDeprecatedException {
-        assertFalse(service.getByAccessions(Collections.singletonList(accession)).isEmpty());
-        service.deprecate(accession, reason);
+    private void assertVariantDeprecated(long accession, String reason) {
         assertTrue(service.getByAccessions(Collections.singletonList(accession)).isEmpty());
 
         IOperation<Long> lastOperation;
@@ -300,21 +303,22 @@ public class SubmittedVariantAccessioningServiceTest {
     @Test
     public void deprecateDnsnpSubmittedVariant() throws AccessionMergedException, AccessionDoesNotExistException,
             AccessionDeprecatedException {
-        assertDeprecate(ACCESSION_DBSNP_1, "Test deprecate");
+        assertFalse(service.getByAccessions(Collections.singletonList(ACCESSION_DBSNP_1)).isEmpty());
+        service.deprecate(ACCESSION_DBSNP_1, DEPRECATE_REASON);
+        assertVariantDeprecated(ACCESSION_DBSNP_1, DEPRECATE_REASON);
     }
 
     @UsingDataSet(locations = {"/test-data/submittedVariantEntity.json"})
     @Test
     public void mergeSubmittedVariant() throws AccessionMergedException, AccessionDoesNotExistException,
             AccessionDeprecatedException {
-        assertMerge(ACCESSION_TO_MERGE_1, ACCESSION_TO_MERGE_2, "Test merge");
+        assertFalse(service.getByAccessions(Collections.singletonList(ACCESSION_TO_MERGE_1)).isEmpty());
+        assertFalse(service.getByAccessions(Collections.singletonList(ACCESSION_TO_MERGE_2)).isEmpty());
+        service.merge(ACCESSION_TO_MERGE_1, ACCESSION_TO_MERGE_2, MERGE_REASON);
+        assertVariantMerged(ACCESSION_TO_MERGE_1, ACCESSION_TO_MERGE_2, MERGE_REASON);
     }
 
-    private void assertMerge(long accessionOrigin, long accessionDestination, String reason) throws
-            AccessionMergedException, AccessionDoesNotExistException, AccessionDeprecatedException {
-        assertFalse(service.getByAccessions(Collections.singletonList(accessionOrigin)).isEmpty());
-        assertFalse(service.getByAccessions(Collections.singletonList(accessionDestination)).isEmpty());
-        service.merge(accessionOrigin, accessionDestination, reason);
+    private void assertVariantMerged(long accessionOrigin, long accessionDestination, String reason) {
         assertTrue(service.getByAccessions(Collections.singletonList(accessionOrigin)).isEmpty());
         assertFalse(service.getByAccessions(Collections.singletonList(accessionDestination)).isEmpty());
 
@@ -327,14 +331,17 @@ public class SubmittedVariantAccessioningServiceTest {
         assertEquals(OperationType.MERGED_INTO, lastOperation.getOperationType());
         assertEquals(accessionOrigin, lastOperation.getAccessionIdOrigin().longValue());
         assertEquals(accessionDestination, lastOperation.getAccessionIdDestination().longValue());
-        assertEquals("Test merge", lastOperation.getReason());
+        assertEquals(MERGE_REASON, lastOperation.getReason());
     }
 
     @UsingDataSet(locations = {"/test-data/dbsnpSubmittedVariantEntity.json"})
     @Test
     public void mergeDbsnpSubmittedVariant() throws AccessionMergedException, AccessionDoesNotExistException,
             AccessionDeprecatedException {
-        assertMerge(ACCESSION_DBSNP_1, ACCESSION_DBSNP_2, "Test merge");
+        assertFalse(service.getByAccessions(Collections.singletonList(ACCESSION_DBSNP_1)).isEmpty());
+        assertFalse(service.getByAccessions(Collections.singletonList(ACCESSION_DBSNP_2)).isEmpty());
+        service.merge(ACCESSION_DBSNP_1, ACCESSION_DBSNP_2, MERGE_REASON);
+        assertVariantMerged(ACCESSION_DBSNP_1, ACCESSION_DBSNP_2, MERGE_REASON);
     }
 
 }

--- a/eva-accession-core/src/test/resources/ss-accession-test.properties
+++ b/eva-accession-core/src/test/resources/ss-accession-test.properties
@@ -2,6 +2,8 @@ accessioning.instanceId=test-instance-01
 accessioning.variant.blockSize=1000
 accessioning.variant.categoryId=test-ss
 
+accessioning.monotonic.init.ss=5000000000
+
 spring.data.mongodb.database=submitted-variants-test
 spring.data.mongodb.host=localhost
 spring.data.mongodb.password=

--- a/eva-accession-core/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-core/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -1,16 +1,29 @@
 {
   "dbsnpSubmittedVariantEntity": [
     {
-      "_id" : "980E2EA1AF733B432D4E7EB520B632BDB9EC20BE",
+      "_id" : "610EEAC8314DDB24F1BD1225F65AE4DFEB9F84BE",
       "asm" : "GCA_000009999.3",
       "tax" : 9999,
-      "study" : "PRJEB21999",
+      "study" : "DBSNP999",
       "contig" : "21",
       "start" : 20849999,
       "ref" : "",
       "alt" : "GG",
       "evidence" : true,
-      "accession" : 1000000001,
+      "accession" : 2200000000,
+      "version" : 1
+    },
+    {
+      "_id" : "9587ADB2417604F9EC19414587331151AA30BCBF",
+      "asm" : "GCA_000009999.3",
+      "tax" : 9999,
+      "study" : "DBSNP111",
+      "contig" : "21",
+      "start" : 20849999,
+      "ref" : "",
+      "alt" : "GG",
+      "evidence" : true,
+      "accession" : 2200000001,
       "version" : 1
     }
   ]

--- a/eva-accession-core/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-core/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -1,0 +1,17 @@
+{
+  "dbsnpSubmittedVariantEntity": [
+    {
+      "_id" : "980E2EA1AF733B432D4E7EB520B632BDB9EC20BE",
+      "asm" : "GCA_000009999.3",
+      "tax" : 9999,
+      "study" : "PRJEB21999",
+      "contig" : "21",
+      "start" : 20849999,
+      "ref" : "",
+      "alt" : "GG",
+      "evidence" : true,
+      "accession" : 1000000001,
+      "version" : 1
+    }
+  ]
+}

--- a/eva-accession-core/src/test/resources/test-data/submittedVariantEntity.json
+++ b/eva-accession-core/src/test/resources/test-data/submittedVariantEntity.json
@@ -1,17 +1,69 @@
 {
   "submittedVariantEntity": [
     {
-      "_id" : "925E489266E58B67F1CDCCDF1914A7B4B6FC697A",
-      "asm" : "GCA_000003055.3",
-      "tax" : 9913,
-      "study" : "PRJEB21794",
-      "contig" : "21",
-      "start" : 20800319,
-      "ref" : "C",
-      "alt" : "T",
-      "evidence" : true,
-      "accession" : 5000000000,
-      "version" : 1
+      "_id": "925E489266E58B67F1CDCCDF1914A7B4B6FC697A",
+      "asm": "GCA_000003055.3",
+      "tax": 9913,
+      "study": "PRJEB21794",
+      "contig": "21",
+      "start": 20800319,
+      "ref": "C",
+      "alt": "T",
+      "evidence": true,
+      "accession": 5000000000,
+      "version": 1
+    },
+    {
+      "_id": "F2D754CF53BC28B48969A9D5FCE0971473239488",
+      "asm": "GCA_000002285.2",
+      "tax": 9615,
+      "study": "PRJEB24328",
+      "contig": "17",
+      "start": 22907389,
+      "ref": "",
+      "alt": "G",
+      "evidence": true,
+      "accession": 5000000002,
+      "version": 1
+    },
+    {
+      "_id": "06F9F4A45938C671E1E1A21D928B2FD01802BEBC",
+      "asm": "GCA_000002305.1",
+      "tax": 9796,
+      "study": "PRJEB25439",
+      "contig": "1",
+      "start": 94372649,
+      "ref": "C",
+      "alt": "T",
+      "evidence": true,
+      "accession": 5000000003,
+      "version": 1
+    },
+    {
+      "_id": "88B90C6B052F23681876943B54747DEB1640FF6D",
+      "asm": "GCA_000002305.1",
+      "tax": 9796,
+      "study": "PRJEB9799",
+      "contig": "1",
+      "start": 13887,
+      "ref": "C",
+      "alt": "T",
+      "evidence": true,
+      "accession": 5000000004,
+      "version": 1
+    },
+    {
+      "_id": "B4E7D497664B8EA2E731E0D23D04A9E9CD7FA41B",
+      "asm": "GCA_000002305.1",
+      "tax": 9796,
+      "study": "PRJEB9799",
+      "contig": "1",
+      "start": 38431,
+      "ref": "T",
+      "alt": "A",
+      "evidence": true,
+      "accession": 5000000005,
+      "version": 1
     }
   ]
 }

--- a/eva-accession-core/src/test/resources/test-data/submittedVariantEntity.json
+++ b/eva-accession-core/src/test/resources/test-data/submittedVariantEntity.json
@@ -1,0 +1,17 @@
+{
+  "submittedVariantEntity": [
+    {
+      "_id" : "925E489266E58B67F1CDCCDF1914A7B4B6FC697A",
+      "asm" : "GCA_000003055.3",
+      "tax" : 9913,
+      "study" : "PRJEB21794",
+      "contig" : "21",
+      "start" : 20800319,
+      "ref" : "C",
+      "alt" : "T",
+      "evidence" : true,
+      "accession" : 5000000000,
+      "version" : 1
+    }
+  ]
+}

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpSubmittedVariantWriter.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpSubmittedVariantWriter.java
@@ -21,7 +21,7 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
-import uk.ac.ebi.eva.accession.dbsnp.persistence.DbsnpSubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantEntity;
 
 import java.util.List;
 

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToVariantProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToVariantProcessor.java
@@ -20,9 +20,9 @@ import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariant;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.summary.DbsnpSubmittedVariantSummaryFunction;
 import uk.ac.ebi.eva.accession.dbsnp.model.SubSnpNoHgvs;
-import uk.ac.ebi.eva.accession.dbsnp.persistence.DbsnpSubmittedVariantEntity;
 import uk.ac.ebi.eva.commons.core.models.Region;
 
 import java.util.ArrayList;

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpSubmittedVariantWriterTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpSubmittedVariantWriterTest.java
@@ -31,7 +31,7 @@ import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariant;
 import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.accession.core.summary.DbsnpSubmittedVariantSummaryFunction;
-import uk.ac.ebi.eva.accession.dbsnp.persistence.DbsnpSubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.dbsnp.test.MongoTestConfiguration;
 
 import java.util.Arrays;

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToVariantProcessorTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToVariantProcessorTest.java
@@ -15,15 +15,14 @@
  */
 package uk.ac.ebi.eva.accession.dbsnp.processors;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.dbsnp.model.DbsnpVariantType;
 import uk.ac.ebi.eva.accession.dbsnp.model.Orientation;
 import uk.ac.ebi.eva.accession.dbsnp.model.SubSnpNoHgvs;
-import uk.ac.ebi.eva.accession.dbsnp.persistence.DbsnpSubmittedVariantEntity;
 
 import java.sql.Timestamp;
 import java.util.List;

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
@@ -64,7 +64,7 @@ public class AccessionWriterTest {
 
     private static final int TAXONOMY = 3880;
 
-    private static final long EXPECTED_ACCESSION = 10000000000L;
+    private static final long EXPECTED_ACCESSION = 5000000000L;
 
     private static final String CONTIG_1 = "contig_1";
 

--- a/eva-accession-pipeline/src/test/resources/accession-pipeline-test.properties
+++ b/eva-accession-pipeline/src/test/resources/accession-pipeline-test.properties
@@ -1,8 +1,8 @@
 accessioning.instanceId=test-instance-01
 accessioning.variant.blockSize=1000
-accessioning.variant.categoryId=test-ss
+accessioning.variant.categoryId=ss
 
-accessioning.monotonic.init.test-ss=10000000000
+accessioning.monotonic.init.ss=5000000000
 
 parameters.assemblyAccession=assembly
 parameters.taxonomyAccession=1111

--- a/eva-accession-ws/src/test/resources/accession-ws-test.properties
+++ b/eva-accession-ws/src/test/resources/accession-ws-test.properties
@@ -1,6 +1,8 @@
 accessioning.instanceId=test-ws-instance-01
 accessioning.variant.blockSize=1000
-accessioning.variant.categoryId=test-ss
+accessioning.variant.categoryId=ss
+
+accessioning.monotonic.init.ss=5000000000
 
 spring.datasource.driver-class-name=org.hsqldb.jdbcDriver
 spring.datasource.url=jdbc:hsqldb:mem:db;sql.syntax_pgs=true;DB_CLOSE_DELAY=-1


### PR DESCRIPTION
Created Dbsnp entity, repository, database service. Modified service `SubmittedVariantAccessioningService` to use both repositories. Added tests.