### PR TITLE
EVA-1278 Unroll compressed microsatellite alleles

### DIFF
--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
@@ -45,7 +45,7 @@ public class DbsnpVariantAlleles {
         "\\(" + MOTIF_GROUP_REGEX + "\\))";
 
     /** This regex captures how many times a motif is repeated, i.e. '5' in '(GA)5' */
-    private static final String COUNT_GROUP_REGEX = "(?<" + STR_COUNT_REGEX_GROUP_NAME + ">\\d*)";
+    private static final String COUNT_GROUP_REGEX = "(?<" + STR_COUNT_REGEX_GROUP_NAME + ">(\\d*|-))";
 
     /** This regex captures a plain sequence of bases */
     private static final String BASES_GROUP_REGEX = "(?<" + BASES_REGEX_GROUP_NAME + ">[a-zA-Z]+)";
@@ -286,11 +286,12 @@ public class DbsnpVariantAlleles {
             while (matcher.find()) {
                 String motif = matcher.group(STR_MOTIF_REGEX_GROUP_NAME);
                 String bases = matcher.group(BASES_REGEX_GROUP_NAME);
+                String count = matcher.group(STR_COUNT_REGEX_GROUP_NAME);
 
                 if (motif != null) {
                     // If a motif is detected, append it 'count' times
-                    int count = Integer.valueOf(matcher.group(STR_COUNT_REGEX_GROUP_NAME));
-                    for (int j = 0; j < count; j++) {
+                    int actualCount = NumberUtils.isDigits(count) ? Integer.valueOf(count) : 0;
+                    for (int j = 0; j < actualCount; j++) {
                         unrolledAllele.append(motif);
                     }
                 } else if (bases != null) {

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
@@ -60,6 +60,8 @@ public class DbsnpVariantAlleles {
 
     private static final Pattern ANY_UNIT_PATTERN = Pattern.compile(ANY_UNIT_REGEX);
 
+    private static final Pattern ONLY_VALID_UNITS_PATTERN = Pattern.compile("^(" + ANY_UNIT_REGEX + ")+$");
+
     private String referenceAllele;
 
     private String[] alleles;
@@ -164,6 +166,7 @@ public class DbsnpVariantAlleles {
      */
     private List<String> getMicrosatelliteAllelesInForwardStrand() {
         String[] allelesArray = decodeMicrosatelliteAlleles(removeSurroundingSquareBrackets(alleles));
+        checkMicrosatelliteAlleles(allelesArray);
 
         if (allelesOrientation.equals(Orientation.REVERSE)) {
             allelesArray = Arrays.stream(allelesArray).map(this::reverseComplementMicrosatelliteSequence)
@@ -218,6 +221,21 @@ public class DbsnpVariantAlleles {
         }
 
         return allelesArray;
+    }
+
+    /**
+     * Checks that all the alleles correspond to an STR variant.
+     *
+     * @param allelesArray alleles to be validated
+     */
+    public void checkMicrosatelliteAlleles(String[] allelesArray) {
+        for (String allele : allelesArray) {
+            if (allele.isEmpty() || ONLY_VALID_UNITS_PATTERN.matcher(allele).matches()) {
+                continue;
+            }
+
+            throw new IllegalArgumentException("Allele '" + allele + "' is not a valid STR");
+        }
     }
 
     /**

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
@@ -44,8 +44,11 @@ public class DbsnpVariantAlleles {
     private static final String BRACKETED_MOTIF_GROUP_REGEX = "(?<" + BRACKETED_STR_MOTIF_REGEX_GROUP_NAME + ">" +
         "\\(" + MOTIF_GROUP_REGEX + "\\))";
 
-    /** This regex captures how many times a motif is repeated, i.e. '5' in '(GA)5' */
-    private static final String COUNT_GROUP_REGEX = "(?<" + STR_COUNT_REGEX_GROUP_NAME + ">(\\d*|-))";
+    /**
+     * This regex captures how many times a motif is repeated, i.e. '5' in '(GA)5', '-' in '(GA)-', or '' in '(GA)'
+     * Dash must have greater priority than the empty string in order to be captured correctly.
+     */
+    private static final String COUNT_GROUP_REGEX = "(?<" + STR_COUNT_REGEX_GROUP_NAME + ">(\\-|\\d*))";
 
     /** This regex captures a plain sequence of bases */
     private static final String BASES_GROUP_REGEX = "(?<" + BASES_REGEX_GROUP_NAME + ">[a-zA-Z]+)";
@@ -289,8 +292,11 @@ public class DbsnpVariantAlleles {
 
     /**
      * This method unroll all the microsatellite 'units' in an allele. Each unit is a sequence motif and the number of
-     * times it is repeated, i.e. the microsatellite "(AG)5(C)4" has the units "(AG)5" and "(C)4". If expressed with the
-     * compressed syntax, alleles are also unrolled, e.g. (T)4 becomes TTTT.
+     * times it is repeated, i.e. the microsatellite "(AG)5(C)4" has the units "(AG)5" and "(C)4".
+     *
+     * If expressed with the compressed syntax, units are also unrolled, e.g. (T)4 becomes TTTT.
+     * If you count is provided, the unit is kept as is, e.g. (T) becomes T.
+     * If the count is a dash, the unit is deleted, e.g. A(T)- becomes A.
      *
      * @param allelesArray Array containing all alleles
      * @return Array containing all the unrolled alleles
@@ -308,7 +314,7 @@ public class DbsnpVariantAlleles {
 
                 if (motif != null) {
                     // If a motif is detected, append it 'count' times
-                    int actualCount = NumberUtils.isDigits(count) ? Integer.valueOf(count) : 0;
+                    int actualCount = NumberUtils.isDigits(count) ? Integer.valueOf(count) : (count.isEmpty() ? 1 : 0);
                     for (int j = 0; j < actualCount; j++) {
                         unrolledAllele.append(motif);
                     }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 EMBL - European Bioinformatics Institute
+ * Copyright 2018 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
@@ -275,21 +275,23 @@ public class DbsnpVariantAlleles {
      * @return Array containing all the unrolled alleles
      */
     private String[] unrollMicrosatelliteAlleles(String[] allelesArray) {
-        for (int i = 0; i<allelesArray.length; i++) {
+        for (int i = 0; i < allelesArray.length; i++) {
+            String allele = allelesArray[i];
             StringBuilder unrolledAllele = new StringBuilder();
-            Matcher matcher = ANY_UNIT_PATTERN.matcher(allelesArray[i]);
 
+            Matcher matcher = ANY_UNIT_PATTERN.matcher(allele);
             while (matcher.find()) {
-                if (matcher.group(STR_MOTIF_REGEX_GROUP_NAME) != null) {
+                String motif = matcher.group(STR_MOTIF_REGEX_GROUP_NAME);
+                String bases = matcher.group(BASES_REGEX_GROUP_NAME);
+
+                if (motif != null) {
                     // If a motif is detected, append it 'count' times
-                    String motif = matcher.group(STR_MOTIF_REGEX_GROUP_NAME);
                     int count = Integer.valueOf(matcher.group(STR_COUNT_REGEX_GROUP_NAME));
                     for (int j = 0; j < count; j++) {
                         unrolledAllele.append(motif);
                     }
-                } else if (matcher.group(BASES_REGEX_GROUP_NAME) != null) {
+                } else if (bases != null) {
                     // If a list of bases is detected, append as is
-                    String bases = matcher.group(BASES_REGEX_GROUP_NAME);
                     unrolledAllele.append(bases);
                 }
             }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
@@ -182,21 +182,17 @@ public class DbsnpVariantAlleles {
     }
 
     /**
-     * There are some dbSNP STR variant alleles that are surrounded by square brackets. This method removes them so the
-     * variant can be parsed correctly
+     * Some STR variant alleles are surrounded by square brackets. This method removes them so the variant can be parsed
+     * correctly.
      *
      * @param allelesArray Array containing all alleles
      * @return Array containing all alleles, where the surrounding square brackets have been removed
      */
     private String[] removeSurroundingSquareBrackets(String[] allelesArray) {
-        if (allelesArray[0].charAt(0) == '[') {
-            // All the STR patterns have been checked, and when the first character is a opening square bracket,
-            // the closing one is the last one
-            allelesArray[0] = allelesArray[0].substring(1);
-            int lastAlleleIndex = allelesArray.length -1;
-            allelesArray[lastAlleleIndex] = allelesArray[lastAlleleIndex].substring(0, allelesArray[lastAlleleIndex]
-                    .length() - 1);
+        for (int i = 0; i < allelesArray.length; i++) {
+            allelesArray[i] = allelesArray[i].replace("[", "").replace("]", "");
         }
+
         return allelesArray;
     }
 

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
@@ -63,7 +63,7 @@ public class DbsnpVariantAlleles {
 
     private static final Pattern ANY_UNIT_PATTERN = Pattern.compile(ANY_UNIT_REGEX);
 
-    private static final Pattern ONLY_VALID_UNITS_PATTERN = Pattern.compile("^(" + ANY_UNIT_REGEX + ")+$");
+    private static final Pattern ONLY_VALID_UNITS_PATTERN = Pattern.compile("^\\s*(" + ANY_UNIT_REGEX + "\\s*)+$");
 
     private String referenceAllele;
 

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAlleles.java
@@ -203,14 +203,17 @@ public class DbsnpVariantAlleles {
      */
     private String[] decodeMicrosatelliteAlleles(String[] allelesArray) {
         String firstAllele = allelesArray[0];
+        Matcher matcher = STR_UNIT_PATTERN.matcher(firstAllele);
+
+        if (!matcher.matches()) {
+            return allelesArray;
+        }
+
         for (int i = 1; i < allelesArray.length; i++) {
-            // if a allele in the array is a number, prepend to it the sequence found in the first allele. If the first
+            // if an allele in the array is a number, prepend to it the sequence found in the first allele. If the first
             // allele does not match the regular expression, don't modify the alleles
             if (NumberUtils.isDigits(allelesArray[i])) {
-                Matcher matcher = STR_UNIT_PATTERN.matcher(firstAllele);
-                if (matcher.matches()) {
-                    allelesArray[i] = matcher.group(BRACKETED_STR_MOTIF_REGEX_GROUP_NAME) + allelesArray[i];
-                }
+                allelesArray[i] = matcher.group(BRACKETED_STR_MOTIF_REGEX_GROUP_NAME) + allelesArray[i];
             }
         }
 

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
@@ -166,6 +166,40 @@ public class DbsnpVariantAllelesTest {
     }
 
     @Test
+    public void dashCountSTRAlleles() {
+        DbsnpVariantAlleles dashCountOnly = new DbsnpVariantAlleles("AT", "(AT)-", Orientation.FORWARD,
+                                                                    Orientation.FORWARD,
+                                                                    DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("AT", dashCountOnly.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList(""), dashCountOnly.getAllelesInForwardStrand());
+
+        DbsnpVariantAlleles dashAndOtherCounts = new DbsnpVariantAlleles("AC", "(AC)3/(A)1(AC)2/(A)1(AC)1/(A)1(AC)-",
+                                                                         Orientation.FORWARD, Orientation.FORWARD,
+                                                                         DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("AC", dashAndOtherCounts.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("ACACAC", "AACAC", "AAC", "A"), dashAndOtherCounts.getAllelesInForwardStrand());
+    }
+
+    @Test
+    public void noCountSTRAlleles() {
+        DbsnpVariantAlleles emptyCountOnly = new DbsnpVariantAlleles("AT", "(AT)", Orientation.FORWARD,
+                                                                     Orientation.FORWARD,
+                                                                     DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("AT", emptyCountOnly.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList(""), emptyCountOnly.getAllelesInForwardStrand());
+
+        DbsnpVariantAlleles dashAndOtherCounts = new DbsnpVariantAlleles("AC", "(A)(AC)2/(A)1(AC)", Orientation.FORWARD,
+                                                                         Orientation.FORWARD,
+                                                                         DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("AC", dashAndOtherCounts.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("ACAC", "A"), dashAndOtherCounts.getAllelesInForwardStrand());
+    }
+
+    @Test
     public void complexSTRAlleles() {
         DbsnpVariantAlleles complexSTR1 = new DbsnpVariantAlleles("T", "(T)4(ACT)3AG(C)5", Orientation.FORWARD,
                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
@@ -152,7 +152,7 @@ public class DbsnpVariantAllelesTest {
                                                                         DbsnpVariantType.MICROSATELLITE);
 
         assertEquals("T", forwardAllelesSTR.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList("(T)4", "(T)5", "(T)7"), forwardAllelesSTR.getAllelesInForwardStrand());
+        assertEquals(Arrays.asList("TTTT", "TTTTT", "TTTTTTT"), forwardAllelesSTR.getAllelesInForwardStrand());
     }
 
     @Test
@@ -162,7 +162,7 @@ public class DbsnpVariantAllelesTest {
                                                                         DbsnpVariantType.MICROSATELLITE);
 
         assertEquals("AT", reverseAllelesSTR.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList("(GA)8(T)2", "(TA)3"), reverseAllelesSTR.getAllelesInForwardStrand());
+        assertEquals(Arrays.asList("GAGAGAGAGAGAGAGATT", "TATATA"), reverseAllelesSTR.getAllelesInForwardStrand());
     }
 
     @Test
@@ -171,37 +171,22 @@ public class DbsnpVariantAllelesTest {
                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
 
         assertEquals("T", complexSTR1.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList("(T)4(ACT)3AG(C)5"), complexSTR1.getAllelesInForwardStrand());
-
+        assertEquals(Arrays.asList("TTTTACTACTACTAGCCCCC"), complexSTR1.getAllelesInForwardStrand());
 
         DbsnpVariantAlleles complexSTR2 = new DbsnpVariantAlleles("T", "(T)4(ACT)3AG(C)5/(T)4AG", Orientation.FORWARD,
                                                                   Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
 
         assertEquals("T", complexSTR2.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList("(T)4(ACT)3AG(C)5", "(T)4AG"), complexSTR2.getAllelesInForwardStrand());
-    }
-
-    @Test
-    public void unrollSTRAlleles() {
-        DbsnpVariantAlleles complexSTR1 = new DbsnpVariantAlleles("T", "(T)4/5/7", Orientation.FORWARD,
-                                                                        Orientation.FORWARD,
-                                                                        DbsnpVariantType.MICROSATELLITE);
-
-        assertArrayEquals(new String[]{"TTTT", "TTTTT", "TTTTTTT"}, complexSTR1.unrollMicrosatelliteAlleles(new String[]{"(T)4", "(T)5", "(T)7"}));
-
-        DbsnpVariantAlleles complexSTR2 = new DbsnpVariantAlleles("T", "(T)4(ACT)3AG(C)5", Orientation.FORWARD,
-                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
-
-        assertArrayEquals(new String[] {"TTTTACTACTACTAGCCCCC"}, complexSTR2.unrollMicrosatelliteAlleles(new String[]{"(T)4(ACT)3AG(C)5"}));
+        assertEquals(Arrays.asList("TTTTACTACTACTAGCCCCC", "TTTTAG"), complexSTR2.getAllelesInForwardStrand());
 
         DbsnpVariantAlleles complexSTR3 = new DbsnpVariantAlleles("T", "AG(T)4(ACT)3(C)5", Orientation.FORWARD,
                                                                   Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
 
-        assertArrayEquals(new String[] {"AGTTTTACTACTACTCCCCC"}, complexSTR3.unrollMicrosatelliteAlleles(new String[]{"AG(T)4(ACT)3(C)5"}));
+        assertEquals(Arrays.asList("AGTTTTACTACTACTCCCCC"), complexSTR3.getAllelesInForwardStrand());
 
         DbsnpVariantAlleles complexSTR4 = new DbsnpVariantAlleles("T", "(T)4(ACT)3(C)5AG", Orientation.FORWARD,
                                                                   Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
 
-        assertArrayEquals(new String[] {"TTTTACTACTACTCCCCCAG"}, complexSTR4.unrollMicrosatelliteAlleles(new String[]{"(T)4(ACT)3(C)5AG"}));
+        assertEquals(Arrays.asList("TTTTACTACTACTCCCCCAG"), complexSTR4.getAllelesInForwardStrand());
     }
 }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
@@ -194,14 +194,29 @@ public class DbsnpVariantAllelesTest {
                                                                      DbsnpVariantType.MICROSATELLITE);
 
         assertEquals("AT", emptyCountOnly.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList(""), emptyCountOnly.getAllelesInForwardStrand());
+        assertEquals(Arrays.asList("AT"), emptyCountOnly.getAllelesInForwardStrand());
 
-        DbsnpVariantAlleles dashAndOtherCounts = new DbsnpVariantAlleles("AC", "(A)(AC)2/(A)1(AC)", Orientation.FORWARD,
-                                                                         Orientation.FORWARD,
-                                                                         DbsnpVariantType.MICROSATELLITE);
+        DbsnpVariantAlleles emptyAndOtherCounts = new DbsnpVariantAlleles("AC", "(A)(AC)2/(A)1(AC)",
+                                                                          Orientation.FORWARD, Orientation.FORWARD,
+                                                                          DbsnpVariantType.MICROSATELLITE);
 
-        assertEquals("AC", dashAndOtherCounts.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList("ACAC", "A"), dashAndOtherCounts.getAllelesInForwardStrand());
+        assertEquals("AC", emptyAndOtherCounts.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("AACAC", "AAC"), emptyAndOtherCounts.getAllelesInForwardStrand());
+    }
+
+    @Test
+    public void emptySTRAllele() {
+        DbsnpVariantAlleles empty1 = new DbsnpVariantAlleles("T", "(T)-", Orientation.FORWARD,
+                                                             Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("T", empty1.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList(""), empty1.getAllelesInForwardStrand());
+
+        DbsnpVariantAlleles empty2 = new DbsnpVariantAlleles("TAC", "(T)-(AC)-", Orientation.FORWARD,
+                                                             Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("TAC", empty2.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList(""), empty2.getAllelesInForwardStrand());
     }
 
     @Test
@@ -227,21 +242,6 @@ public class DbsnpVariantAllelesTest {
                                                                   Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
 
         assertEquals(Arrays.asList("TTTTACTACTACTCCCCCAG"), complexSTR4.getAllelesInForwardStrand());
-    }
-
-    @Test
-    public void emptySTRAllele() {
-        DbsnpVariantAlleles empty1 = new DbsnpVariantAlleles("T", "(T)", Orientation.FORWARD,
-                                                             Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
-
-        assertEquals("T", empty1.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList(""), empty1.getAllelesInForwardStrand());
-
-        DbsnpVariantAlleles empty2 = new DbsnpVariantAlleles("T", "(T)-", Orientation.FORWARD,
-                                                             Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
-
-        assertEquals("T", empty2.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList(""), empty2.getAllelesInForwardStrand());
     }
 
     @Test

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
@@ -245,6 +245,27 @@ public class DbsnpVariantAllelesTest {
     }
 
     @Test
+    public void whitespaceInSTRAlleles() {
+        DbsnpVariantAlleles whitespace1 = new DbsnpVariantAlleles("GT", "(GT)9 GGGTAC", Orientation.FORWARD,
+                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("GT", whitespace1.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("GTGTGTGTGTGTGTGTGTGGGTAC"), whitespace1.getAllelesInForwardStrand());
+
+        DbsnpVariantAlleles whitespace2 = new DbsnpVariantAlleles("GT", " (GT)9 GTGTAC", Orientation.FORWARD,
+                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("GT", whitespace2.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("GTGTGTGTGTGTGTGTGTGTGTAC"), whitespace2.getAllelesInForwardStrand());
+
+        DbsnpVariantAlleles whitespace3 = new DbsnpVariantAlleles("GT", "(GT)9 GTAC ", Orientation.FORWARD,
+                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("GT", whitespace3.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("GTGTGTGTGTGTGTGTGTGTAC"), whitespace3.getAllelesInForwardStrand());
+    }
+
+    @Test
     public void invalidSTRAlleles() {
         DbsnpVariantAlleles invalid1 = new DbsnpVariantAlleles("T", "(T)_4", Orientation.FORWARD,
                                                                   Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
@@ -151,13 +151,37 @@ public class DbsnpVariantAllelesTest {
     }
 
     @Test
+    public void squareBracketsAreIgnored() {
+        DbsnpVariantAlleles squareBrackets = new DbsnpVariantAlleles("ACACACACAC", "[(GT)11/4]", Orientation.FORWARD,
+                                                                     Orientation.FORWARD,
+                                                                     DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("ACACACACAC", squareBrackets.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("GTGTGTGTGTGTGTGTGTGTGT", "GTGTGTGT"), squareBrackets.getAllelesInForwardStrand());
+    }
+
+    @Test
     public void forwardSTRAlleles() {
-        DbsnpVariantAlleles forwardAllelesSTR = new DbsnpVariantAlleles("T", "(T)4/5/7", Orientation.FORWARD,
+        DbsnpVariantAlleles forward1 = new DbsnpVariantAlleles("T", "(T)4/5/7", Orientation.FORWARD,
                                                                         Orientation.FORWARD,
                                                                         DbsnpVariantType.MICROSATELLITE);
 
-        assertEquals("T", forwardAllelesSTR.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList("TTTT", "TTTTT", "TTTTTTT"), forwardAllelesSTR.getAllelesInForwardStrand());
+        assertEquals("T", forward1.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("TTTT", "TTTTT", "TTTTTTT"), forward1.getAllelesInForwardStrand());
+
+        DbsnpVariantAlleles forward2 = new DbsnpVariantAlleles("T", "-/(AT)2/(AT)4/(AT)1", Orientation.FORWARD,
+                                                               Orientation.FORWARD,
+                                                               DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("T", forward2.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("", "ATAT", "ATATATAT", "AT"), forward2.getAllelesInForwardStrand());
+
+        DbsnpVariantAlleles forward3 = new DbsnpVariantAlleles("CT", "-/CT/CTATCT(CT)1/CTATCTATCT", Orientation.FORWARD,
+                                                               Orientation.FORWARD,
+                                                               DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("CT", forward3.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("", "CT", "CTATCTCT", "CTATCTATCT"), forward3.getAllelesInForwardStrand());
     }
 
     @Test

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
@@ -147,21 +147,51 @@ public class DbsnpVariantAllelesTest {
 
     @Test
     public void forwardSTRAlleles() {
-        DbsnpVariantAlleles forwardAllelesMNV = new DbsnpVariantAlleles("T", "(T)4/5/7", Orientation.FORWARD,
+        DbsnpVariantAlleles forwardAllelesSTR = new DbsnpVariantAlleles("T", "(T)4/5/7", Orientation.FORWARD,
                                                                         Orientation.FORWARD,
                                                                         DbsnpVariantType.MICROSATELLITE);
 
-        assertEquals("T", forwardAllelesMNV.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList("(T)4", "(T)5", "(T)7"), forwardAllelesMNV.getAllelesInForwardStrand());
+        assertEquals("T", forwardAllelesSTR.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("(T)4", "(T)5", "(T)7"), forwardAllelesSTR.getAllelesInForwardStrand());
     }
 
     @Test
     public void reverseSTRAlleles() {
-        DbsnpVariantAlleles forwardAllelesMNV = new DbsnpVariantAlleles("AT", "(A)2(TC)8/(TA)3", Orientation.FORWARD,
+        DbsnpVariantAlleles reverseAllelesSTR = new DbsnpVariantAlleles("AT", "(A)2(TC)8/(TA)3", Orientation.FORWARD,
                                                                         Orientation.REVERSE,
                                                                         DbsnpVariantType.MICROSATELLITE);
 
-        assertEquals("AT", forwardAllelesMNV.getReferenceInForwardStrand());
-        assertEquals(Arrays.asList("(GA)8(T)2", "(TA)3"), forwardAllelesMNV.getAllelesInForwardStrand());
+        assertEquals("AT", reverseAllelesSTR.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("(GA)8(T)2", "(TA)3"), reverseAllelesSTR.getAllelesInForwardStrand());
+    }
+
+    @Test
+    public void complexSTRAlleles() {
+        DbsnpVariantAlleles complexSTR1 = new DbsnpVariantAlleles("T", "(T)4(ACT)3AG(C)5", Orientation.FORWARD,
+                                                                 Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("T", complexSTR1.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("(T)4(ACT)3AG(C)5"), complexSTR1.getAllelesInForwardStrand());
+
+
+        DbsnpVariantAlleles complexSTR2 = new DbsnpVariantAlleles("T", "(T)4(ACT)3AG(C)5/(T)4AG", Orientation.FORWARD,
+                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("T", complexSTR2.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList("(T)4(ACT)3AG(C)5", "(T)4AG"), complexSTR2.getAllelesInForwardStrand());
+    }
+
+    @Test
+    public void unrollSTRAlleles() {
+        DbsnpVariantAlleles forwardAllelesSTR = new DbsnpVariantAlleles("T", "(T)4/5/7", Orientation.FORWARD,
+                                                                        Orientation.FORWARD,
+                                                                        DbsnpVariantType.MICROSATELLITE);
+
+        assertArrayEquals(new String[]{"TTTT", "TTTTT", "TTTTTTT"}, forwardAllelesSTR.unrollMicrosatelliteAlleles(new String[]{"(T)4", "(T)5", "(T)7"}));
+
+        DbsnpVariantAlleles complexSTR2 = new DbsnpVariantAlleles("T", "(T)4(ACT)3AG(C)5", Orientation.FORWARD,
+                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertArrayEquals(new String[] {"TTTTACTACTACTAGCCCCC"}, complexSTR2.unrollMicrosatelliteAlleles(new String[]{"(T)4(ACT)3AG(C)5"}));
     }
 }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
@@ -15,13 +15,18 @@
  */
 package uk.ac.ebi.eva.accession.dbsnp.model;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
 public class DbsnpVariantAllelesTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void forwardAllelesAndReference() {
@@ -223,4 +228,44 @@ public class DbsnpVariantAllelesTest {
 
         assertEquals(Arrays.asList("TTTTACTACTACTCCCCCAG"), complexSTR4.getAllelesInForwardStrand());
     }
+
+    @Test
+    public void emptySTRAllele() {
+        DbsnpVariantAlleles empty1 = new DbsnpVariantAlleles("T", "(T)", Orientation.FORWARD,
+                                                             Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("T", empty1.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList(""), empty1.getAllelesInForwardStrand());
+
+        DbsnpVariantAlleles empty2 = new DbsnpVariantAlleles("T", "(T)-", Orientation.FORWARD,
+                                                             Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("T", empty2.getReferenceInForwardStrand());
+        assertEquals(Arrays.asList(""), empty2.getAllelesInForwardStrand());
+    }
+
+    @Test
+    public void invalidSTRAlleles() {
+        DbsnpVariantAlleles invalid1 = new DbsnpVariantAlleles("T", "(T)_4", Orientation.FORWARD,
+                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("T", invalid1.getReferenceInForwardStrand());
+        thrown.expect(IllegalArgumentException.class);
+        invalid1.getAllelesInForwardStrand();
+
+        DbsnpVariantAlleles invalid2 = new DbsnpVariantAlleles("T", "TGJibb_1$_erishGTA", Orientation.FORWARD,
+                                                               Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("T", invalid2.getReferenceInForwardStrand());
+        thrown.expect(IllegalArgumentException.class);
+        invalid2.getAllelesInForwardStrand();
+
+        DbsnpVariantAlleles invalid3 = new DbsnpVariantAlleles("T", "(TG)3Jibb_1$_erish(GT)2A", Orientation.FORWARD,
+                                                               Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertEquals("T", invalid3.getReferenceInForwardStrand());
+        thrown.expect(IllegalArgumentException.class);
+        invalid3.getAllelesInForwardStrand();
+    }
+
 }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/model/DbsnpVariantAllelesTest.java
@@ -183,15 +183,25 @@ public class DbsnpVariantAllelesTest {
 
     @Test
     public void unrollSTRAlleles() {
-        DbsnpVariantAlleles forwardAllelesSTR = new DbsnpVariantAlleles("T", "(T)4/5/7", Orientation.FORWARD,
+        DbsnpVariantAlleles complexSTR1 = new DbsnpVariantAlleles("T", "(T)4/5/7", Orientation.FORWARD,
                                                                         Orientation.FORWARD,
                                                                         DbsnpVariantType.MICROSATELLITE);
 
-        assertArrayEquals(new String[]{"TTTT", "TTTTT", "TTTTTTT"}, forwardAllelesSTR.unrollMicrosatelliteAlleles(new String[]{"(T)4", "(T)5", "(T)7"}));
+        assertArrayEquals(new String[]{"TTTT", "TTTTT", "TTTTTTT"}, complexSTR1.unrollMicrosatelliteAlleles(new String[]{"(T)4", "(T)5", "(T)7"}));
 
         DbsnpVariantAlleles complexSTR2 = new DbsnpVariantAlleles("T", "(T)4(ACT)3AG(C)5", Orientation.FORWARD,
                                                                   Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
 
         assertArrayEquals(new String[] {"TTTTACTACTACTAGCCCCC"}, complexSTR2.unrollMicrosatelliteAlleles(new String[]{"(T)4(ACT)3AG(C)5"}));
+
+        DbsnpVariantAlleles complexSTR3 = new DbsnpVariantAlleles("T", "AG(T)4(ACT)3(C)5", Orientation.FORWARD,
+                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertArrayEquals(new String[] {"AGTTTTACTACTACTCCCCC"}, complexSTR3.unrollMicrosatelliteAlleles(new String[]{"AG(T)4(ACT)3(C)5"}));
+
+        DbsnpVariantAlleles complexSTR4 = new DbsnpVariantAlleles("T", "(T)4(ACT)3(C)5AG", Orientation.FORWARD,
+                                                                  Orientation.FORWARD, DbsnpVariantType.MICROSATELLITE);
+
+        assertArrayEquals(new String[] {"TTTTACTACTACTCCCCCAG"}, complexSTR4.unrollMicrosatelliteAlleles(new String[]{"(T)4(ACT)3(C)5AG"}));
     }
 }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 EMBL - European Bioinformatics Institute
+ * Copyright 2018 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -232,7 +232,6 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
 
     @Test
     public void transformSnpReverseSs() throws Exception {
-
         SubSnpNoHgvs subSnpNoHgvs = new SubSnpNoHgvs(1984788946L, 14718243L, "A", "T/C", ASSEMBLY, BATCH_HANDLE,
                                                      BATCH_NAME, CHROMOSOME, CHROMOSOME_START, CONTIG_NAME,
                                                      CONTIG_START, DbsnpVariantType.SNV, Orientation.REVERSE,
@@ -247,7 +246,6 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
 
     @Test
     public void transformSnpReverseRs() throws Exception {
-
         SubSnpNoHgvs subSnpNoHgvs = new SubSnpNoHgvs(186667770L, 14730808L, "G", "C/T", ASSEMBLY, BATCH_HANDLE,
                                                      BATCH_NAME, CHROMOSOME, CHROMOSOME_START, CONTIG_NAME,
                                                      CONTIG_START, DbsnpVariantType.SNV, Orientation.FORWARD,
@@ -505,14 +503,13 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
                                                      CONTIG_START, DbsnpVariantType.MICROSATELLITE, Orientation.FORWARD,
                                                      Orientation.FORWARD, Orientation.FORWARD, false, false, false,
                                                      false, CREATED_DATE, CREATED_DATE, TAXONOMY);
-
         List<DbsnpSubmittedVariantEntity> variants = processor.process(subSnpNoHgvs).getSubmittedVariants();
-        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "T", "(T)4", false, false,
+        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "T", "TTTT", false, false,
                                1);
-        assertProcessedVariant(subSnpNoHgvs, variants.get(1), CHROMOSOME, CHROMOSOME_START, "T", "(T)5", false, false,
+        assertProcessedVariant(subSnpNoHgvs, variants.get(1), CHROMOSOME, CHROMOSOME_START, "T", "TTTTT", false, false,
                                1);
-        assertProcessedVariant(subSnpNoHgvs, variants.get(2), CHROMOSOME, CHROMOSOME_START, "T", "(T)7", false, false,
-                               1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(2), CHROMOSOME, CHROMOSOME_START, "T", "TTTTTTT", false,
+                               false, 1);
 
         subSnpNoHgvs = new SubSnpNoHgvs(244316767L, 315216130L, "TA", "(TA)14(CA)2TA/-", ASSEMBLY, BATCH_HANDLE,
                                         BATCH_NAME, CHROMOSOME, CHROMOSOME_START, CONTIG_NAME, CONTIG_START,
@@ -520,8 +517,8 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
                                         Orientation.REVERSE, false, false, false, false, CREATED_DATE, CREATED_DATE,
                                         TAXONOMY);
         variants = processor.process(subSnpNoHgvs).getSubmittedVariants();
-        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "TA", "(TA)14(CA)2TA",
-                               false, false, 1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "TA",
+                               "TATATATATATATATATATATATATATACACATA", false, false, 1);
         assertProcessedVariant(subSnpNoHgvs, variants.get(1), CHROMOSOME, CHROMOSOME_START, "TA", "", false, false, 1);
 
         subSnpNoHgvs = new SubSnpNoHgvs(702701141L, 718200201L, "A", "(A)2(TA)8/(A)2(TA)6/(A)2(TA)7/(A)4(TA)9",
@@ -530,14 +527,14 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
                                         Orientation.FORWARD, Orientation.FORWARD, false, false, false, false,
                                         CREATED_DATE, CREATED_DATE, TAXONOMY);
         variants = processor.process(subSnpNoHgvs).getSubmittedVariants();
-        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "A", "(A)2(TA)8", false,
-                               false, 1);
-        assertProcessedVariant(subSnpNoHgvs, variants.get(1), CHROMOSOME, CHROMOSOME_START, "A", "(A)2(TA)6", false,
-                               false, 1);
-        assertProcessedVariant(subSnpNoHgvs, variants.get(2), CHROMOSOME, CHROMOSOME_START, "A", "(A)2(TA)7", false,
-                               false, 1);
-        assertProcessedVariant(subSnpNoHgvs, variants.get(3), CHROMOSOME, CHROMOSOME_START, "A", "(A)4(TA)9", false,
-                               false, 1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "A", "AATATATATATATATATA",
+                               false, false, 1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(1), CHROMOSOME, CHROMOSOME_START, "A", "AATATATATATATA",
+                               false, false, 1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(2), CHROMOSOME, CHROMOSOME_START, "A", "AATATATATATATATA",
+                               false, false, 1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(3), CHROMOSOME, CHROMOSOME_START, "A",
+                               "AAAATATATATATATATATATA", false, false, 1);
     }
 
     @Test
@@ -547,12 +544,11 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
                                                      CONTIG_NAME, CONTIG_START, DbsnpVariantType.MICROSATELLITE,
                                                      Orientation.FORWARD, Orientation.REVERSE, Orientation.FORWARD,
                                                      false, false, false, false, CREATED_DATE, CREATED_DATE, TAXONOMY);
-
         List<DbsnpSubmittedVariantEntity> variants = processor.process(subSnpNoHgvs).getSubmittedVariants();
-        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "AT", "(AT)7", false,
-                               false, 1);
-        assertProcessedVariant(subSnpNoHgvs, variants.get(1), CHROMOSOME, CHROMOSOME_START, "AT", "(AT)19", false,
-                               false, 1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "AT", "ATATATATATATAT",
+                               false, false, 1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(1), CHROMOSOME, CHROMOSOME_START, "AT",
+                               "ATATATATATATATATATATATATATATATATATATAT", false, false, 1);
     }
 
     @Test
@@ -576,10 +572,10 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
                                         TAXONOMY);
 
         variants = processor.process(subSnpNoHgvs).getSubmittedVariants();
-        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "ACACACACAC", "(AC)11",
-                               false, false, 1);
-        assertProcessedVariant(subSnpNoHgvs, variants.get(1), CHROMOSOME, CHROMOSOME_START, "ACACACACAC", "(AC)14",
-                               false, false, 1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME, CHROMOSOME_START, "ACACACACAC",
+                               "ACACACACACACACACACACAC", false, false, 1);
+        assertProcessedVariant(subSnpNoHgvs, variants.get(1), CHROMOSOME, CHROMOSOME_START, "ACACACACAC",
+                               "ACACACACACACACACACACACACACAC", false, false, 1);
     }
 
     @Test


### PR DESCRIPTION
Microsatellite alleles can be expressed in different formats, some of which are compressed. This PR unrolls these compressed alleles, ensuring that they are compatible with VCF and the rest of our systems.

Examples:

`(T)4` becomes `TTTT`
`AG(T)4(ACT)3(C)5` becomes `AGTTTTACTACTACTCCCCC`