### PR TITLE
EVA-1296 Improve reporting of assembly check errors

### DIFF
--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/AssemblyCheckerProcessorTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/AssemblyCheckerProcessorTest.java
@@ -163,4 +163,12 @@ public class AssemblyCheckerProcessorTest {
         assertTrue(processorUcsc.process(input).isAssemblyMatch());
     }
 
+    // Other
+
+    @Test
+    public void validReferenceSeqNameInvalidCoordinates() throws Exception {
+        SubSnpNoHgvs input = newSubSnpNoHgvs(null, 0, UCSC_1, Integer.MAX_VALUE, REFERENCE_ALLELE_1, DbsnpVariantType.SNV);
+        assertFalse(processorSeqName.process(input).isAssemblyMatch());
+    }
+
 }


### PR DESCRIPTION
Report differently assembly check fails due to sequence not found or coordinates too large. The 'alleles mismatch' flag is appropriately set, instead of throwing an exception and making the pipeline fail.