### PR TITLE
EVA-1296 Do not store Spring Data _class field

### DIFF
--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/configuration/ImportDbsnpVariantsWriterConfiguration.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/configuration/ImportDbsnpVariantsWriterConfiguration.java
@@ -20,8 +20,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
+import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.accession.dbsnp.io.DbsnpVariantsWriter;
 import uk.ac.ebi.eva.accession.dbsnp.listeners.ImportCounts;
 import uk.ac.ebi.eva.accession.dbsnp.parameters.InputParameters;
@@ -29,6 +31,7 @@ import uk.ac.ebi.eva.accession.dbsnp.parameters.InputParameters;
 import static uk.ac.ebi.eva.accession.dbsnp.configuration.BeanNames.DBSNP_VARIANT_WRITER;
 
 @Configuration
+@Import({MongoConfiguration.class})
 public class ImportDbsnpVariantsWriterConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(ImportDbsnpVariantsWriterConfiguration.class);


### PR DESCRIPTION
The `MongoConfiguration` class exposes a `MongoTemplate` bean that doesn't store a `_class` field in MongoDB. This was automatically configured in the module eva-accession-pipeline through the accessioning service configuration, but because eva-accession-import uses a plain Spring Batch writer, this configuration wasn't present.

Injecting this configuration into the appropriate writer solves the problem. The only limitation the lack of this field imposes is that polymorphism is not possible, but it is not a concern in our case.