### PR TITLE
EVA-1188 Store duplicate variants as merge events in history tracking (1)

### DIFF
--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/configuration/ImportDbsnpVariantsWriterConfiguration.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/configuration/ImportDbsnpVariantsWriterConfiguration.java
@@ -24,6 +24,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantAccessioningRepository;
+import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantOperationRepository;
 import uk.ac.ebi.eva.accession.dbsnp.io.DbsnpVariantsWriter;
 import uk.ac.ebi.eva.accession.dbsnp.listeners.ImportCounts;
 import uk.ac.ebi.eva.accession.dbsnp.parameters.InputParameters;
@@ -38,11 +40,12 @@ public class ImportDbsnpVariantsWriterConfiguration {
 
     @Bean(name = DBSNP_VARIANT_WRITER)
     @StepScope
-    DbsnpVariantsWriter dbsnpVariantWriter(InputParameters parameters,
-                                           MongoTemplate mongoTemplate,
-                                           ImportCounts importCounts) throws Exception {
-
+    DbsnpVariantsWriter dbsnpVariantWriter(InputParameters parameters, MongoTemplate mongoTemplate,
+                                           ImportCounts importCounts,
+                                           DbsnpSubmittedVariantOperationRepository operationRepository,
+                                           DbsnpSubmittedVariantAccessioningRepository submittedVariantRepository)
+            throws Exception {
         logger.info("Injecting dbsnpVariantWriter with parameters: {}", parameters);
-        return new DbsnpVariantsWriter(mongoTemplate, importCounts);
+        return new DbsnpVariantsWriter(mongoTemplate, operationRepository, submittedVariantRepository, importCounts);
     }
 }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpClusteredVariantDeclusteredWriter.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpClusteredVariantDeclusteredWriter.java
@@ -33,7 +33,8 @@ import java.util.List;
  */
 public class DbsnpClusteredVariantDeclusteredWriter implements ItemWriter<DbsnpClusteredVariantEntity> {
 
-    static final String DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME = "dbsnpClusteredVariantEntityDeclustered";
+    static final String DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME =
+            "dbsnpClusteredVariantEntityDeclustered";
 
     private MongoTemplate mongoTemplate;
 

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpSubmittedVariantWriter.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpSubmittedVariantWriter.java
@@ -52,16 +52,8 @@ public class DbsnpSubmittedVariantWriter implements ItemWriter<DbsnpSubmittedVar
         } catch (BulkOperationException e) {
             BulkWriteResult bulkWriteResult = e.getResult();
             importCounts.addSubmittedVariantsWritten(bulkWriteResult.getInsertedCount());
-            // TODO: this duplicate key errors should be added as merge operations in EVA-1188
-            List<BulkWriteError> duplicateKeyErrors = e.getErrors().stream().filter(this::isDuplicateKeyError).collect(
-                    Collectors.toList());
             throw e;
         }
-    }
-
-    private boolean isDuplicateKeyError(BulkWriteError error) {
-        ErrorCategory errorCategory = ErrorCategory.fromErrorCode(error.getCode());
-        return errorCategory.equals(ErrorCategory.DUPLICATE_KEY);
     }
 
 }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/persistence/DbsnpVariantsWrapper.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/persistence/DbsnpVariantsWrapper.java
@@ -21,6 +21,7 @@ import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantOperationEntity;
 import uk.ac.ebi.eva.accession.dbsnp.model.DbsnpVariantType;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -31,6 +32,8 @@ import java.util.List;
  * - Zero or one clustered variant (RS)
  *
  * - Zero or more operations, depending on whether deprecations, declustering and/or merges need to applied
+ *
+ * TODO Consider replacing setters with 'add' methods
  */
 public class DbsnpVariantsWrapper {
 
@@ -67,6 +70,14 @@ public class DbsnpVariantsWrapper {
 
     public void setOperations(List<DbsnpSubmittedVariantOperationEntity> operations) {
         this.operations = operations;
+    }
+
+    public void addOperation(DbsnpSubmittedVariantOperationEntity operation) {
+        if (operations == null) {
+            setOperations(new ArrayList<>());
+        }
+
+        operations.add(operation);
     }
 
     public DbsnpVariantType getDbsnpVariantType() {

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubmittedVariantDeclusterProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubmittedVariantDeclusterProcessor.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
 
 public class SubmittedVariantDeclusterProcessor implements ItemProcessor<DbsnpVariantsWrapper, DbsnpVariantsWrapper> {
 
-    static final String DECLUSTERED = "Declustered: ";
+    public static final String DECLUSTERED = "Declustered: ";
 
     static final String DECLUSTERED_ALLELES_MISMATCH =
             "None of the variant alleles match the reference allele.";

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpVariantsWriterTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpVariantsWriterTest.java
@@ -48,8 +48,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -79,7 +77,9 @@ public class DbsnpVariantsWriterTest {
 
     private static final VariantType VARIANT_TYPE = VariantType.SNV;
 
-    private static final Long SUBMITTED_VARIANT_ACCESSION = 15L;
+    private static final Long SUBMITTED_VARIANT_ACCESSION_1 = 15L;
+
+    private static final Long SUBMITTED_VARIANT_ACCESSION_2 = 16L;
 
     private DbsnpVariantsWriter dbsnpVariantsWriter;
 
@@ -111,7 +111,7 @@ public class DbsnpVariantsWriterTest {
                                                                  DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                  DEFAULT_ALLELES_MATCH, DEFAULT_VALIDATED);
         DbsnpSubmittedVariantEntity submittedVariantEntity = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION, hashingFunctionSubmitted.apply(submittedVariant), submittedVariant, 1);
+                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant), submittedVariant, 1);
 
         DbsnpVariantsWrapper wrapper = buildSimpleWrapper(Collections.singletonList(submittedVariantEntity));
         dbsnpVariantsWriter.write(Collections.singletonList(wrapper));
@@ -162,11 +162,11 @@ public class DbsnpVariantsWriterTest {
                                                                   DEFAULT_ALLELES_MATCH, DEFAULT_VALIDATED);
 
         DbsnpSubmittedVariantEntity dbsnpSubmittedVariantEntity1 =
-                new DbsnpSubmittedVariantEntity(SUBMITTED_VARIANT_ACCESSION,
+                new DbsnpSubmittedVariantEntity(SUBMITTED_VARIANT_ACCESSION_1,
                                                 hashingFunctionSubmitted.apply(submittedVariant1),
                                                 submittedVariant1, 1);
         DbsnpSubmittedVariantEntity dbsnpSubmittedVariantEntity2 =
-                new DbsnpSubmittedVariantEntity(SUBMITTED_VARIANT_ACCESSION,
+                new DbsnpSubmittedVariantEntity(SUBMITTED_VARIANT_ACCESSION_1,
                                                 hashingFunctionSubmitted.apply(submittedVariant2),
                                                 submittedVariant2, 1);
 
@@ -185,7 +185,7 @@ public class DbsnpVariantsWriterTest {
                                                                  DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                  allelesMatch, DEFAULT_VALIDATED);
         DbsnpSubmittedVariantEntity dbsnpSubmittedVariantEntity1 =
-                new DbsnpSubmittedVariantEntity(SUBMITTED_VARIANT_ACCESSION,
+                new DbsnpSubmittedVariantEntity(SUBMITTED_VARIANT_ACCESSION_1,
                                                 hashingFunctionSubmitted.apply(submittedVariant),
                                                 submittedVariant, 1);
 
@@ -205,10 +205,10 @@ public class DbsnpVariantsWriterTest {
     private DbsnpSubmittedVariantOperationEntity createOperation(SubmittedVariant submittedVariant1) {
         DbsnpSubmittedVariantOperationEntity operationEntity = new DbsnpSubmittedVariantOperationEntity();
         DbsnpSubmittedVariantEntity dbsnpSubmittedVariantEntity = new DbsnpSubmittedVariantEntity
-                (SUBMITTED_VARIANT_ACCESSION, hashingFunctionSubmitted.apply(submittedVariant1), submittedVariant1, 1);
+                (SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant1), submittedVariant1, 1);
         DbsnpSubmittedVariantInactiveEntity dbsnpSubmittedVariantInactiveEntity =
                 new DbsnpSubmittedVariantInactiveEntity(dbsnpSubmittedVariantEntity);
-        operationEntity.fill(EventType.UPDATED, SUBMITTED_VARIANT_ACCESSION, null, "Declustered",
+        operationEntity.fill(EventType.UPDATED, SUBMITTED_VARIANT_ACCESSION_1, null, "Declustered",
                              Collections.singletonList(dbsnpSubmittedVariantInactiveEntity));
         return operationEntity;
     }
@@ -252,7 +252,7 @@ public class DbsnpVariantsWriterTest {
                                                                   DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                   allelesMatch, DEFAULT_VALIDATED);
         DbsnpSubmittedVariantEntity submittedVariantEntity1 = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION, hashingFunctionSubmitted.apply(submittedVariant1), submittedVariant1, 1);
+                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant1), submittedVariant1, 1);
         DbsnpVariantsWrapper wrapper1 = buildSimpleWrapper(Collections.singletonList(submittedVariantEntity1));
 
         SubmittedVariant submittedVariant2 = new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START,
@@ -260,7 +260,7 @@ public class DbsnpVariantsWriterTest {
                                                                   DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                   DEFAULT_ALLELES_MATCH, DEFAULT_VALIDATED);
         DbsnpSubmittedVariantEntity submittedVariantEntity2 = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
+                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
         DbsnpVariantsWrapper wrapper2 = buildSimpleWrapper(Collections.singletonList(submittedVariantEntity2));
 
         dbsnpVariantsWriter.write(Arrays.asList(wrapper1, wrapper2));
@@ -275,7 +275,7 @@ public class DbsnpVariantsWriterTest {
                                                                   DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                   allelesMatch, DEFAULT_VALIDATED);
         DbsnpSubmittedVariantEntity submittedVariantEntity1 = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION, hashingFunctionSubmitted.apply(submittedVariant1), submittedVariant1, 1);
+                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant1), submittedVariant1, 1);
         DbsnpVariantsWrapper wrapper1 = buildSimpleWrapper(Collections.singletonList(submittedVariantEntity1));
 
         SubmittedVariant submittedVariant2 = new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START,
@@ -283,7 +283,7 @@ public class DbsnpVariantsWriterTest {
                                                                   DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                   DEFAULT_ALLELES_MATCH, DEFAULT_VALIDATED);
         DbsnpSubmittedVariantEntity submittedVariantEntity2 = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
+                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
         DbsnpVariantsWrapper wrapper2 = buildSimpleWrapper(Collections.singletonList(submittedVariantEntity2));
 
         DbsnpSubmittedVariantOperationEntity operationEntity1 = createOperation(submittedVariant1);
@@ -303,23 +303,28 @@ public class DbsnpVariantsWriterTest {
                                                                  DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                  DEFAULT_ALLELES_MATCH, DEFAULT_VALIDATED);
         DbsnpSubmittedVariantEntity submittedVariantEntity = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION, hashingFunctionSubmitted.apply(submittedVariant), submittedVariant, 1);
+                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant), submittedVariant, 1);
         DbsnpVariantsWrapper wrapper = buildSimpleWrapper(Collections.singletonList(submittedVariantEntity));
 
         // Try to write twice, the second time it will be considered a duplicate
         dbsnpVariantsWriter.write(Arrays.asList(wrapper));
 
-        SubmittedVariant submittedVariant2 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START,
-                                                                  "reference", "alternate", CLUSTERED_VARIANT_ACCESSION,
-                                                                  DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
-                                                                  DEFAULT_ALLELES_MATCH, DEFAULT_VALIDATED);
         DbsnpSubmittedVariantEntity submittedVariantEntity2 = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
+                SUBMITTED_VARIANT_ACCESSION_2, hashingFunctionSubmitted.apply(submittedVariant), submittedVariant, 1);
         DbsnpVariantsWrapper wrapper2 = buildSimpleWrapper(Collections.singletonList(submittedVariantEntity2));
 
         dbsnpVariantsWriter.write(Arrays.asList(wrapper, wrapper2, wrapper));
 
         assertClusteredVariantStored(wrapper);
+
+        List<DbsnpSubmittedVariantEntity> ssEntities = mongoTemplate.find(new Query(),
+                                                                          DbsnpSubmittedVariantEntity.class);
+        assertTrue(ssEntities.contains(submittedVariantEntity));
+        assertEquals(1, importCounts.getSubmittedVariantsWritten());
+
+        List<DbsnpSubmittedVariantOperationEntity> operationEntities = mongoTemplate.find(
+                new Query(), DbsnpSubmittedVariantOperationEntity.class);
+        assertEquals(1, operationEntities.size());
     }
 
 }


### PR DESCRIPTION
This PR makes equivalent subsnps to be merged, keeping the older in the main collection and writing the merge event in the operations collection.