### PR TITLE
EVA-1287 Pilot for import into accessioning service - corner cases (unknown orientation again)

### DIFF
--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/SubSnpNoHgvs.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/SubSnpNoHgvs.java
@@ -88,21 +88,23 @@ public class SubSnpNoHgvs {
         this.taxonomyId = taxonomyId;
         this.anyOrientationUnknown = (subsnpOrientation.getValue() * snpOrientation.getValue()
                 * contigOrientation.getValue()) == 0;
-        Orientation allelesOrientation = Orientation.getOrientation(
-                composeOrientationAssumingForwardIfUnknown(subsnpOrientation, snpOrientation, contigOrientation));
+        Orientation allelesOrientation = composeOrientation(subsnpOrientation, snpOrientation, contigOrientation);
         this.dbSnpVariantAlleles = new DbsnpVariantAlleles(reference, alleles, contigOrientation, allelesOrientation,
                                                            this.dbsnpVariantType);
     }
 
-    private int composeOrientationAssumingForwardIfUnknown(Orientation subsnpOrientation, Orientation snpOrientation,
-                                                           Orientation contigOrientation) {
+    /**
+     * Composes the 3 orientations. If any of those is UNKNOWN orientation, take that particular one as if it were
+     * FORWARD, and then compose it with the others.
+     */
+    private Orientation composeOrientation(Orientation subsnpOrientation, Orientation snpOrientation,
+                                           Orientation contigOrientation) {
         int orientation = 1;
         orientation *= subsnpOrientation == Orientation.REVERSE ? -1 : 1;
         orientation *= snpOrientation == Orientation.REVERSE ? -1 : 1;
         orientation *= contigOrientation == Orientation.REVERSE ? -1 : 1;
-        return orientation;
+        return Orientation.getOrientation(orientation);
     }
-
 
     public Long getSsId() {
         return ssId;

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/SubSnpNoHgvs.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/SubSnpNoHgvs.java
@@ -23,8 +23,6 @@ import java.util.stream.Collectors;
 
 public class SubSnpNoHgvs {
 
-    public static final String STR_SEQUENCE_REGEX_GROUP = "sequence";
-
     private Long ssId;
 
     private Long rsId;
@@ -44,6 +42,8 @@ public class SubSnpNoHgvs {
     private long contigStart;
 
     private final DbsnpVariantAlleles dbSnpVariantAlleles;
+
+    private final boolean anyOrientationUnknown;
 
     private DbsnpVariantType dbsnpVariantType;
 
@@ -86,6 +86,8 @@ public class SubSnpNoHgvs {
         this.ssCreateTime = ssCreateTime;
         this.rsCreateTime = rsCreateTime;
         this.taxonomyId = taxonomyId;
+        this.anyOrientationUnknown = (subsnpOrientation.getValue() * snpOrientation.getValue()
+                * contigOrientation.getValue()) == 0;
         Orientation allelesOrientation = Orientation.getOrientation(
                 composeOrientationAssumingForwardIfUnknown(subsnpOrientation, snpOrientation, contigOrientation));
         this.dbSnpVariantAlleles = new DbsnpVariantAlleles(reference, alleles, contigOrientation, allelesOrientation,
@@ -246,6 +248,10 @@ public class SubSnpNoHgvs {
         this.assemblyMatch = assemblyMatch;
     }
 
+    public boolean isAnyOrientationUnknown() {
+        return anyOrientationUnknown;
+    }
+
     public String getReferenceInForwardStrand() {
         return dbSnpVariantAlleles.getReferenceInForwardStrand();
     }
@@ -274,5 +280,6 @@ public class SubSnpNoHgvs {
             return new Region(getContigName(), getContigStart());
         }
     }
+
 
 }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/SubSnpNoHgvs.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/model/SubSnpNoHgvs.java
@@ -87,10 +87,20 @@ public class SubSnpNoHgvs {
         this.rsCreateTime = rsCreateTime;
         this.taxonomyId = taxonomyId;
         Orientation allelesOrientation = Orientation.getOrientation(
-                subsnpOrientation.getValue() * snpOrientation.getValue() * contigOrientation.getValue());
+                composeOrientationAssumingForwardIfUnknown(subsnpOrientation, snpOrientation, contigOrientation));
         this.dbSnpVariantAlleles = new DbsnpVariantAlleles(reference, alleles, contigOrientation, allelesOrientation,
                                                            this.dbsnpVariantType);
     }
+
+    private int composeOrientationAssumingForwardIfUnknown(Orientation subsnpOrientation, Orientation snpOrientation,
+                                                           Orientation contigOrientation) {
+        int orientation = 1;
+        orientation *= subsnpOrientation == Orientation.REVERSE ? -1 : 1;
+        orientation *= snpOrientation == Orientation.REVERSE ? -1 : 1;
+        orientation *= contigOrientation == Orientation.REVERSE ? -1 : 1;
+        return orientation;
+    }
+
 
     public Long getSsId() {
         return ssId;

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessor.java
@@ -96,7 +96,8 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessor implements ItemProcesso
                                     variantRegion.getStart(), subSnpNoHgvs.getReferenceInForwardStrand(), alternate,
                                     subSnpNoHgvs.getRsId(),
                                     subSnpNoHgvs.isFrequencyExists() || subSnpNoHgvs.isGenotypeExists(),
-                                    subSnpNoHgvs.isAssemblyMatch(), subSnpNoHgvs.doAllelesMatch(),
+                                    subSnpNoHgvs.isAssemblyMatch() ,
+                                    subSnpNoHgvs.doAllelesMatch() && !subSnpNoHgvs.isAnyOrientationUnknown(),
                                     subSnpNoHgvs.isSubsnpValidated());
     }
 

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
@@ -302,6 +302,22 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
     }
 
     @Test
+    public void transformDeletionUnknonwOrientation() throws Exception {
+        String reference = "A";
+        SubSnpNoHgvs subSnpNoHgvs = new SubSnpNoHgvs(820982442L, 794525917L, reference, "T/-", ASSEMBLY, BATCH_HANDLE,
+                                                     BATCH_NAME, CHROMOSOME, CHROMOSOME_START, CONTIG_NAME,
+                                                     CONTIG_START, DbsnpVariantType.DIV, Orientation.FORWARD,
+                                                     Orientation.REVERSE, Orientation.UNKNOWN, false, false, false,
+                                                     false, CREATED_DATE, CREATED_DATE, TAXONOMY);
+
+        List<DbsnpSubmittedVariantEntity> variants = processor.process(subSnpNoHgvs).getSubmittedVariants();
+
+        assertEquals(reference, variants.get(0).getReferenceAllele());
+        assertEquals("", variants.get(0).getAlternateAllele());
+
+    }
+
+    @Test
     public void transformInsertion() throws Exception {
         SubSnpNoHgvs subSnpNoHgvs = new SubSnpNoHgvs(1052228949L, 794529293L, "-", "-/T", ASSEMBLY, BATCH_HANDLE,
                                                      BATCH_NAME, CHROMOSOME, CHROMOSOME_START, CONTIG_NAME,

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -312,9 +313,10 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
 
         List<DbsnpSubmittedVariantEntity> variants = processor.process(subSnpNoHgvs).getSubmittedVariants();
 
+        assertEquals(1, variants.size());
         assertEquals(reference, variants.get(0).getReferenceAllele());
         assertEquals("", variants.get(0).getAlternateAllele());
-
+        assertFalse(variants.get(0).isAllelesMatch());
     }
 
     @Test

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
 
@@ -52,6 +53,8 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
     private static final String BATCH_NAME = "NAME";
 
     private static final String CHROMOSOME = "10";
+
+    private static final String CHROMOSOME_2 = "22";
 
     private static final long CHROMOSOME_START = 1000000L;
 
@@ -303,10 +306,11 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
     }
 
     @Test
-    public void transformDeletionUnknonwOrientation() throws Exception {
+    public void transformDeletionUnknownOrientationSetsAlleleMismatch() throws Exception {
         String reference = "A";
+        long position = 7L;
         SubSnpNoHgvs subSnpNoHgvs = new SubSnpNoHgvs(820982442L, 794525917L, reference, "T/-", ASSEMBLY, BATCH_HANDLE,
-                                                     BATCH_NAME, CHROMOSOME, CHROMOSOME_START, CONTIG_NAME,
+                                                     BATCH_NAME, CHROMOSOME_2, position, CONTIG_NAME,
                                                      CONTIG_START, DbsnpVariantType.DIV, Orientation.FORWARD,
                                                      Orientation.REVERSE, Orientation.UNKNOWN, false, false, false,
                                                      false, CREATED_DATE, CREATED_DATE, TAXONOMY);
@@ -314,9 +318,9 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
         List<DbsnpSubmittedVariantEntity> variants = processor.process(subSnpNoHgvs).getSubmittedVariants();
 
         assertEquals(1, variants.size());
-        assertEquals(reference, variants.get(0).getReferenceAllele());
-        assertEquals("", variants.get(0).getAlternateAllele());
-        assertFalse(variants.get(0).isAllelesMatch());
+        boolean allelesMatch = false;
+        assertProcessedVariant(subSnpNoHgvs, variants.get(0), CHROMOSOME_2, position, reference, "", false,
+                               allelesMatch, 1);
     }
 
     @Test


### PR DESCRIPTION
we forgot one place where the unknown orientation was producing unexpected behaviour. This PR makes the code:

- assume FORWARD **always** that there's an unknown orientation.
- flag a subsnp as alleles mismatch if there was at least one unknown orientation (or if the reference allele was not found in the list of alleles, which was the only reason to use this flag before).