### PR TITLE
EVA-1373 Re initialization of blocks at application start

### DIFF
--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpClusteredVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpClusteredVariantAccessioningDatabaseService.java
@@ -18,8 +18,7 @@
 package uk.ac.ebi.eva.accession.core.persistence;
 
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicRange;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.services.BasicSpringDataRepositoryDatabaseService;
+import uk.ac.ebi.ampt2d.commons.accession.service.BasicSpringDataRepositoryMonotonicDatabaseService;
 
 import uk.ac.ebi.eva.accession.core.IClusteredVariant;
 import uk.ac.ebi.eva.accession.core.service.DbsnpClusteredVariantInactiveService;
@@ -27,8 +26,7 @@ import uk.ac.ebi.eva.accession.core.service.DbsnpClusteredVariantInactiveService
 import java.util.Collection;
 
 public class DbsnpClusteredVariantAccessioningDatabaseService
-        extends BasicSpringDataRepositoryDatabaseService<IClusteredVariant, Long, DbsnpClusteredVariantEntity>
-        implements MonotonicDatabaseService<IClusteredVariant, String> {
+        extends BasicSpringDataRepositoryMonotonicDatabaseService<IClusteredVariant, DbsnpClusteredVariantEntity> {
 
     public DbsnpClusteredVariantAccessioningDatabaseService(DbsnpClusteredVariantAccessioningRepository repository,
                                                             DbsnpClusteredVariantInactiveService inactiveService) {

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/DbsnpSubmittedVariantAccessioningDatabaseService.java
@@ -19,8 +19,7 @@ package uk.ac.ebi.eva.accession.core.persistence;
 
 import uk.ac.ebi.ampt2d.commons.accession.core.models.AccessionWrapper;
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicRange;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.services.BasicSpringDataRepositoryDatabaseService;
+import uk.ac.ebi.ampt2d.commons.accession.service.BasicSpringDataRepositoryMonotonicDatabaseService;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.service.DbsnpSubmittedVariantInactiveService;
@@ -30,9 +29,7 @@ import java.util.Collection;
 import java.util.List;
 
 public class DbsnpSubmittedVariantAccessioningDatabaseService
-        extends BasicSpringDataRepositoryDatabaseService<ISubmittedVariant, Long, DbsnpSubmittedVariantEntity>
-        implements MonotonicDatabaseService<ISubmittedVariant, String> {
-
+        extends BasicSpringDataRepositoryMonotonicDatabaseService<ISubmittedVariant, DbsnpSubmittedVariantEntity> {
 
     private final DbsnpSubmittedVariantAccessioningRepository repository;
 

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningDatabaseService.java
@@ -18,14 +18,12 @@
 package uk.ac.ebi.eva.accession.core.persistence;
 
 import uk.ac.ebi.ampt2d.commons.accession.core.models.AccessionWrapper;
-import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicRange;
 import uk.ac.ebi.ampt2d.commons.accession.service.BasicSpringDataRepositoryMonotonicDatabaseService;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.service.SubmittedVariantInactiveService;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class SubmittedVariantAccessioningDatabaseService
@@ -42,11 +40,6 @@ public class SubmittedVariantAccessioningDatabaseService
                                                              accessionWrapper.getVersion()),
               inactiveAccessionService);
         this.repository = repository;
-    }
-
-    @Override
-    public long[] getAccessionsInRanges(Collection<MonotonicRange> ranges) {
-        return new long[0];
     }
 
     public List<AccessionWrapper<ISubmittedVariant, String, Long>> findByClusteredVariantAccessionIn(

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantAccessioningDatabaseService.java
@@ -19,8 +19,7 @@ package uk.ac.ebi.eva.accession.core.persistence;
 
 import uk.ac.ebi.ampt2d.commons.accession.core.models.AccessionWrapper;
 import uk.ac.ebi.ampt2d.commons.accession.generators.monotonic.MonotonicRange;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
-import uk.ac.ebi.ampt2d.commons.accession.persistence.services.BasicSpringDataRepositoryDatabaseService;
+import uk.ac.ebi.ampt2d.commons.accession.service.BasicSpringDataRepositoryMonotonicDatabaseService;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.service.SubmittedVariantInactiveService;
@@ -30,8 +29,7 @@ import java.util.Collection;
 import java.util.List;
 
 public class SubmittedVariantAccessioningDatabaseService
-        extends BasicSpringDataRepositoryDatabaseService<ISubmittedVariant, Long, SubmittedVariantEntity>
-        implements MonotonicDatabaseService<ISubmittedVariant, String> {
+        extends BasicSpringDataRepositoryMonotonicDatabaseService<ISubmittedVariant, SubmittedVariantEntity> {
 
     private final SubmittedVariantAccessioningRepository repository;
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-mongodb</artifactId>
-                <version>0.5.1</version>
+                <version>0.5.2</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-monotonic-generator-jpa</artifactId>
-                <version>0.5.1</version>
+                <version>0.5.2</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>


### PR DESCRIPTION
- Updated to accession commons 0.5.2
- Used `BasicSpringDataRepositoryMonotonicDatabaseService` instead of `BasicSpringDataRepositoryDatabaseService`