### PR TITLE
EVA-1310 Import arabidopsis_3702 into accessioning

### DIFF
--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/persistence/SubmittedVariantEntity.java
@@ -90,31 +90,10 @@ public class SubmittedVariantEntity extends AccessionedDocument<ISubmittedVarian
         this.alternateAllele = alternateAllele;
         this.clusteredVariantAccession = clusteredVariantAccession;
 
-        if (supportedByEvidence == null) {
-            throw new IllegalArgumentException(
-                    "supportedByEvidence should not be null, as null is used for default values");
-        } else {
-            this.supportedByEvidence = supportedByEvidence == DEFAULT_SUPPORTED_BY_EVIDENCE ? null :
-                    supportedByEvidence;
-        }
-
-        if (assemblyMatch == null) {
-            throw new IllegalArgumentException("assemblyMatch should not be null, as null is used for default values");
-        } else {
-            this.assemblyMatch = assemblyMatch == DEFAULT_ASSEMBLY_MATCH ? null : assemblyMatch;
-        }
-
-        if (allelesMatch == null) {
-            throw new IllegalArgumentException("allelesMatch should not be null, as null is used for default values");
-        } else {
-            this.allelesMatch = allelesMatch == DEFAULT_ALLELES_MATCH ? null : allelesMatch;
-        }
-
-        if (validated == null) {
-            throw new IllegalArgumentException("validated should not be null, as null is used for default values");
-        } else {
-            this.validated = validated == DEFAULT_VALIDATED ? null : validated;
-        }
+        setSupportedByEvidence(supportedByEvidence);
+        setAssemblyMatch(assemblyMatch);
+        setAllelesMatch(allelesMatch);
+        setValidated(validated);
     }
 
     public ISubmittedVariant getModel() {
@@ -132,9 +111,17 @@ public class SubmittedVariantEntity extends AccessionedDocument<ISubmittedVarian
         return referenceSequenceAccession;
     }
 
+    public void setReferenceSequenceAccession(String referenceSequenceAccession) {
+        this.referenceSequenceAccession = referenceSequenceAccession;
+    }
+
     @Override
     public int getTaxonomyAccession() {
         return taxonomyAccession;
+    }
+
+    public void setTaxonomyAccession(int taxonomyAccession) {
+        this.taxonomyAccession = taxonomyAccession;
     }
 
     @Override
@@ -142,9 +129,17 @@ public class SubmittedVariantEntity extends AccessionedDocument<ISubmittedVarian
         return projectAccession;
     }
 
+    public void setProjectAccession(String projectAccession) {
+        this.projectAccession = projectAccession;
+    }
+
     @Override
     public String getContig() {
         return contig;
+    }
+
+    public void setContig(String contig) {
+        this.contig = contig;
     }
 
     @Override
@@ -152,9 +147,17 @@ public class SubmittedVariantEntity extends AccessionedDocument<ISubmittedVarian
         return start;
     }
 
+    public void setStart(long start) {
+        this.start = start;
+    }
+
     @Override
     public String getReferenceAllele() {
         return referenceAllele;
+    }
+
+    public void setReferenceAllele(String referenceAllele) {
+        this.referenceAllele = referenceAllele;
     }
 
     @Override
@@ -162,9 +165,17 @@ public class SubmittedVariantEntity extends AccessionedDocument<ISubmittedVarian
         return alternateAllele;
     }
 
+    public void setAlternateAllele(String alternateAllele) {
+        this.alternateAllele = alternateAllele;
+    }
+
     @Override
     public Long getClusteredVariantAccession() {
         return clusteredVariantAccession;
+    }
+
+    public void setClusteredVariantAccession(Long clusteredVariantAccession) {
+        this.clusteredVariantAccession = clusteredVariantAccession;
     }
 
     @Override
@@ -172,9 +183,27 @@ public class SubmittedVariantEntity extends AccessionedDocument<ISubmittedVarian
         return supportedByEvidence == null ? DEFAULT_SUPPORTED_BY_EVIDENCE : supportedByEvidence;
     }
 
+    private void setSupportedByEvidence(Boolean supportedByEvidence) {
+        if (supportedByEvidence == null) {
+            throw new IllegalArgumentException(
+                    "supportedByEvidence should not be null, as null is used for default values");
+        } else {
+            this.supportedByEvidence = supportedByEvidence == DEFAULT_SUPPORTED_BY_EVIDENCE ? null :
+                    supportedByEvidence;
+        }
+    }
+
     @Override
     public Boolean isAssemblyMatch() {
         return assemblyMatch == null ? DEFAULT_ASSEMBLY_MATCH : assemblyMatch;
+    }
+
+    public void setAssemblyMatch(Boolean assemblyMatch) {
+        if (assemblyMatch == null) {
+            throw new IllegalArgumentException("assemblyMatch should not be null, as null is used for default values");
+        } else {
+            this.assemblyMatch = assemblyMatch == DEFAULT_ASSEMBLY_MATCH ? null : assemblyMatch;
+        }
     }
 
     @Override
@@ -182,9 +211,25 @@ public class SubmittedVariantEntity extends AccessionedDocument<ISubmittedVarian
         return allelesMatch == null ? DEFAULT_ALLELES_MATCH : allelesMatch;
     }
 
+    public void setAllelesMatch(Boolean allelesMatch) {
+        if (allelesMatch == null) {
+            throw new IllegalArgumentException("allelesMatch should not be null, as null is used for default values");
+        } else {
+            this.allelesMatch = allelesMatch == DEFAULT_ALLELES_MATCH ? null : allelesMatch;
+        }
+    }
+
     @Override
     public Boolean isValidated() {
         return validated == null ? DEFAULT_VALIDATED : validated;
+    }
+
+    public void setValidated(Boolean validated) {
+        if (validated == null) {
+            throw new IllegalArgumentException("validated should not be null, as null is used for default values");
+        } else {
+            this.validated = validated == DEFAULT_VALIDATED ? null : validated;
+        }
     }
 
     @Override

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubmittedVariantDeclusterProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubmittedVariantDeclusterProcessor.java
@@ -95,7 +95,7 @@ public class SubmittedVariantDeclusterProcessor implements ItemProcessor<DbsnpVa
         }
     }
 
-    private DbsnpSubmittedVariantEntity decluster(DbsnpSubmittedVariantEntity nonDeclusteredVariantEntity,
+    public DbsnpSubmittedVariantEntity decluster(DbsnpSubmittedVariantEntity nonDeclusteredVariantEntity,
                                                   List<DbsnpSubmittedVariantOperationEntity> operations,
                                                   List<String> reasons) {
         //Register submitted variant decluster operation

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubmittedVariantDeclusterProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubmittedVariantDeclusterProcessor.java
@@ -82,8 +82,7 @@ public class SubmittedVariantDeclusterProcessor implements ItemProcessor<DbsnpVa
         return !reasons.isEmpty();
     }
 
-    private boolean isSameType(DbsnpClusteredVariantEntity clusteredVariant,
-                               ISubmittedVariant submittedVariant,
+    private boolean isSameType(DbsnpClusteredVariantEntity clusteredVariant, ISubmittedVariant submittedVariant,
                                DbsnpVariantType dbsnpVariantType) {
         try {
             return VariantClassifier.getVariantClassification(submittedVariant.getReferenceAllele(),
@@ -108,12 +107,13 @@ public class SubmittedVariantDeclusterProcessor implements ItemProcessor<DbsnpVa
         operation.fill(EventType.UPDATED, accession, null, reason, Collections.singletonList(inactiveEntity));
         operations.add(operation);
 
-        //Decluster submitted variant. Need to create a new one because DbsnpSubmittedVariantEntity has no setters
-        SubmittedVariant variant = new SubmittedVariant(nonDeclusteredVariantEntity);
-        variant.setClusteredVariantAccession(null);
-        String hash = hashingFunction.apply(variant);
-        int version = nonDeclusteredVariantEntity.getVersion();
+        DbsnpSubmittedVariantEntity declusteredVariantEntity =
+                new DbsnpSubmittedVariantEntity(nonDeclusteredVariantEntity.getAccession(),
+                                                nonDeclusteredVariantEntity.getHashedMessage(),
+                                                nonDeclusteredVariantEntity.getModel(),
+                                                nonDeclusteredVariantEntity.getVersion());
 
-        return new DbsnpSubmittedVariantEntity(accession, hash, variant, version);
+        declusteredVariantEntity.setClusteredVariantAccession(null);
+        return declusteredVariantEntity;
     }
 }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpVariantsWriterTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpVariantsWriterTest.java
@@ -225,8 +225,7 @@ public class DbsnpVariantsWriterTest {
     public void declusterVariantWithMismatchingAlleles() throws Exception {
         boolean allelesMatch = false;
         SubmittedVariant submittedVariant = new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START_1,
-                                                                 "reference", "alternate",
-                                                                 EXPECTED_ACCESSION,
+                                                                 "reference", "alternate", EXPECTED_ACCESSION,
                                                                  DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                  allelesMatch, DEFAULT_VALIDATED, null);
         DbsnpSubmittedVariantEntity dbsnpSubmittedVariantEntity1 =
@@ -601,12 +600,12 @@ public class DbsnpVariantsWriterTest {
         DbsnpSubmittedVariantEntity expectedSubmittedVariantEntity2 = changeRS(submittedVariantEntity2,
                                                                                clusteredVariantEntity.getAccession());
         assertSubmittedVariantsStored(2, submittedVariantEntity, expectedSubmittedVariantEntity2);
-        assertSubmittedVariantsHasActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
-                                                                   wrapper.getSubmittedVariants().get(0),
-                                                                   expectedSubmittedVariantEntity2);
+        assertSubmittedVariantsHaveActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
+                                                                    wrapper.getSubmittedVariants().get(0),
+                                                                    expectedSubmittedVariantEntity2);
         final Long[] longs = new Long[]{clusteredVariantEntity2.getAccession()};
         final int length = longs.length;
-        assertSubmittedOperationsHasClusteredVariantAccession(length, clusteredVariantEntity2.getAccession());
+        assertSubmittedOperationsHaveClusteredVariantAccession(length, clusteredVariantEntity2.getAccession());
         assertClusteredVariantMergeOperationStored(1, clusteredVariantEntity);
         assertEquals(0, mongoTemplate.count(new Query(), DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME));
     }
@@ -622,28 +621,27 @@ public class DbsnpVariantsWriterTest {
         return new DbsnpSubmittedVariantEntity(accession, hash, variant, version);
     }
 
-    private void assertSubmittedVariantsHasActiveClusteredVariantsAccession(
-            Long accession,
-            DbsnpSubmittedVariantEntity... dbsnpSubmittedVariantEntities) {
+    private void assertSubmittedVariantsHaveActiveClusteredVariantsAccession(
+            Long accession, DbsnpSubmittedVariantEntity... dbsnpSubmittedVariantEntities) {
         for (DbsnpSubmittedVariantEntity dbsnpSubmittedVariantEntity : dbsnpSubmittedVariantEntities) {
             assertEquals(accession, dbsnpSubmittedVariantEntity.getClusteredVariantAccession());
         }
     }
 
-    private void assertSubmittedOperationsHasClusteredVariantAccession(int expectedCount,
-                                                                       Long... expectedClusteredVariantAccessions) {
+    private void assertSubmittedOperationsHaveClusteredVariantAccession(int expectedCount,
+                                                                        Long... expectedClusteredVariantAccessions) {
         List<DbsnpSubmittedVariantOperationEntity> submittedOperations = mongoTemplate.find(
                 new Query(), DbsnpSubmittedVariantOperationEntity.class);
         assertEquals(expectedCount, submittedOperations.size());
-        Set<Long> oldAccessions = new HashSet<>();
+        Set<Long> oldClusteredAccessions = new HashSet<>();
         for (DbsnpSubmittedVariantOperationEntity submittedOperation : submittedOperations) {
             assertEquals(EventType.UPDATED, submittedOperation.getEventType());
             assertEquals(1, submittedOperation.getInactiveObjects().size());
-            oldAccessions.add(submittedOperation.getInactiveObjects().get(0).getClusteredVariantAccession());
+            oldClusteredAccessions.add(submittedOperation.getInactiveObjects().get(0).getClusteredVariantAccession());
         }
-        assertEquals(expectedClusteredVariantAccessions.length, oldAccessions.size());
+        assertEquals(expectedClusteredVariantAccessions.length, oldClusteredAccessions.size());
         for (Long expectedClusteredVariantAccession : expectedClusteredVariantAccessions) {
-            assertTrue(oldAccessions.contains(expectedClusteredVariantAccession));
+            assertTrue(oldClusteredAccessions.contains(expectedClusteredVariantAccession));
         }
     }
 
@@ -683,10 +681,10 @@ public class DbsnpVariantsWriterTest {
         DbsnpSubmittedVariantEntity expectedSubmittedVariantEntity2 = changeRS(submittedVariantEntity2,
                                                                                clusteredVariantEntity.getAccession());
         assertSubmittedVariantsStored(2, submittedVariantEntity, expectedSubmittedVariantEntity2);
-        assertSubmittedVariantsHasActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
-                                                                   wrapper.getSubmittedVariants().get(0),
-                                                                   expectedSubmittedVariantEntity2);
-        assertSubmittedOperationsHasClusteredVariantAccession(1, clusteredVariantEntity2.getAccession());
+        assertSubmittedVariantsHaveActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
+                                                                    wrapper.getSubmittedVariants().get(0),
+                                                                    expectedSubmittedVariantEntity2);
+        assertSubmittedOperationsHaveClusteredVariantAccession(1, clusteredVariantEntity2.getAccession());
         assertClusteredVariantMergeOperationStored(1, clusteredVariantEntity);
         assertEquals(0, mongoTemplate.count(new Query(), DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME));
     }
@@ -730,12 +728,12 @@ public class DbsnpVariantsWriterTest {
 
         assertClusteredVariantStored(1, wrapper);
         assertSubmittedVariantsStored(1, submittedVariantEntity);
-        assertSubmittedVariantsHasActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
-                                                                   wrapper.getSubmittedVariants().get(0),
-                                                                   wrapper2.getSubmittedVariants().get(0),
-                                                                   wrapper3.getSubmittedVariants().get(0));
-        assertSubmittedOperationsHasClusteredVariantAccession(2, clusteredVariantEntity2.getAccession(),
-                                                              clusteredVariantEntity3.getAccession());
+        assertSubmittedVariantsHaveActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
+                                                                    wrapper.getSubmittedVariants().get(0),
+                                                                    wrapper2.getSubmittedVariants().get(0),
+                                                                    wrapper3.getSubmittedVariants().get(0));
+        assertSubmittedOperationsHaveClusteredVariantAccession(2, clusteredVariantEntity2.getAccession(),
+                                                               clusteredVariantEntity3.getAccession());
 
         assertClusteredVariantMergeOperationStored(2, clusteredVariantEntity);
         assertEquals(0, mongoTemplate.count(new Query(), DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME));
@@ -770,58 +768,63 @@ public class DbsnpVariantsWriterTest {
     /**
      * The test data is not real, but this exact thing happened with rs193927678.
      *
-     * rs193927678 has two positions (two clustered variants with different hash and same rs accession), and
-     * accordingly two submitted variants, with different hash (and in this case, same ss accession). Each entry of this
+     * rs193927678 is mapped in 2 positions, so corresponds to 2 clustered variants with different hash and same RS
+     * accession. This results in 2 submitted variants with different hash and same SS accession. Each entry of this
      * RS also makes hash collision with rs1095750933 and rs347458720.
      *
-     * So to decide which active RS should we link in each SS, we have to
-     * take into account the hash as well. One SS will be linked to rs1095750933 and the other to rs347458720.
-     *
-     * In the test, rs193927678 is represented as CLUSTERED_VARIANT_ACCESSION_3.
+     * So to decide which active RS should we link in each SS, we have to take into account the hash as well. One SS
+     * will be linked to rs1095750933 and the other to rs347458720.
      */
     @Test
     public void mergeRs193927678() throws Exception {
+        Long clusteredVariantAccession1 = 347458720L;
+        Long clusteredVariantAccession2 = 1095750933L;
+        Long clusteredVariantAccession3 = 193927678L;
+        Long submittedVariantAccession1 = 2688593462L;
+        Long submittedVariantAccession2 = 2688600186L;
+        Long submittedVariantAccession3 = 252447620L;
+
         SubmittedVariant submittedVariant = defaultSubmittedVariant();
         DbsnpSubmittedVariantEntity submittedVariantEntity = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant), submittedVariant, 1);
+                submittedVariantAccession1, hashingFunctionSubmitted.apply(submittedVariant), submittedVariant, 1);
         ClusteredVariant clusteredVariant = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START_1,
                                                                  VARIANT_TYPE, DEFAULT_VALIDATED, null);
 
         DbsnpClusteredVariantEntity clusteredVariantEntity = new DbsnpClusteredVariantEntity(
-                CLUSTERED_VARIANT_ACCESSION_1, hashingFunctionClustered.apply(clusteredVariant), clusteredVariant);
+                clusteredVariantAccession1, hashingFunctionClustered.apply(clusteredVariant), clusteredVariant);
         DbsnpVariantsWrapper wrapper = new DbsnpVariantsWrapper();
         wrapper.setClusteredVariant(clusteredVariantEntity);
         wrapper.setSubmittedVariants(Collections.singletonList(submittedVariantEntity));
 
         SubmittedVariant submittedVariant2 = defaultSubmittedVariant();
         submittedVariant2.setStart(START_2);
-        submittedVariant2.setClusteredVariantAccession(CLUSTERED_VARIANT_ACCESSION_2);
+        submittedVariant2.setClusteredVariantAccession(clusteredVariantAccession2);
         DbsnpSubmittedVariantEntity submittedVariantEntity2 = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
+                submittedVariantAccession2, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
         ClusteredVariant clusteredVariant2 = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START_2,
                                                                  VARIANT_TYPE, DEFAULT_VALIDATED, null);
         DbsnpClusteredVariantEntity clusteredVariantEntity2 = new DbsnpClusteredVariantEntity(
-                CLUSTERED_VARIANT_ACCESSION_2, hashingFunctionClustered.apply(clusteredVariant2), clusteredVariant2);
+                clusteredVariantAccession2, hashingFunctionClustered.apply(clusteredVariant2), clusteredVariant2);
         DbsnpVariantsWrapper wrapper2 = new DbsnpVariantsWrapper();
         wrapper2.setClusteredVariant(clusteredVariantEntity2);
         wrapper2.setSubmittedVariants(Collections.singletonList(submittedVariantEntity2));
 
         SubmittedVariant submittedVariant3 = defaultSubmittedVariant();
-        submittedVariant3.setClusteredVariantAccession(CLUSTERED_VARIANT_ACCESSION_3);
+        submittedVariant3.setClusteredVariantAccession(clusteredVariantAccession3);
         submittedVariant3.setProjectAccession(PROJECT_2);
         SubmittedVariant submittedVariant4 = defaultSubmittedVariant();
         submittedVariant4.setStart(START_2);
         submittedVariant4.setProjectAccession(PROJECT_2);
-        submittedVariant4.setClusteredVariantAccession(CLUSTERED_VARIANT_ACCESSION_3);
+        submittedVariant4.setClusteredVariantAccession(clusteredVariantAccession3);
         DbsnpSubmittedVariantEntity submittedVariantEntity3 = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant3), submittedVariant3, 1);
+                submittedVariantAccession3, hashingFunctionSubmitted.apply(submittedVariant3), submittedVariant3, 1);
         DbsnpSubmittedVariantEntity submittedVariantEntity4 = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant4), submittedVariant4, 1);
+                submittedVariantAccession3, hashingFunctionSubmitted.apply(submittedVariant4), submittedVariant4, 1);
         DbsnpClusteredVariantEntity clusteredVariantEntity3 = new DbsnpClusteredVariantEntity(
-                CLUSTERED_VARIANT_ACCESSION_3, hashingFunctionClustered.apply(clusteredVariantEntity),
+                clusteredVariantAccession3, hashingFunctionClustered.apply(clusteredVariantEntity),
                 clusteredVariantEntity);
         DbsnpClusteredVariantEntity clusteredVariantEntity4 = new DbsnpClusteredVariantEntity(
-                CLUSTERED_VARIANT_ACCESSION_3, hashingFunctionClustered.apply(clusteredVariantEntity2),
+                clusteredVariantAccession3, hashingFunctionClustered.apply(clusteredVariantEntity2),
                 clusteredVariantEntity2);
         DbsnpVariantsWrapper wrapper3 = new DbsnpVariantsWrapper();
         wrapper3.setClusteredVariant(clusteredVariantEntity3);
@@ -840,11 +843,11 @@ public class DbsnpVariantsWriterTest {
                                                                                clusteredVariantEntity2.getAccession());
         assertSubmittedVariantsStored(4, submittedVariantEntity, submittedVariantEntity2,
                                       expectedSubmittedVariantEntity3, expectedSubmittedVariantEntity4);
-        assertSubmittedVariantsHasActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
-                                                                   expectedSubmittedVariantEntity3);
-        assertSubmittedVariantsHasActiveClusteredVariantsAccession(wrapper2.getClusteredVariant().getAccession(),
-                                                                   expectedSubmittedVariantEntity4);
-        assertSubmittedOperationsHasClusteredVariantAccession(2, CLUSTERED_VARIANT_ACCESSION_3);
+        assertSubmittedVariantsHaveActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
+                                                                    expectedSubmittedVariantEntity3);
+        assertSubmittedVariantsHaveActiveClusteredVariantsAccession(wrapper2.getClusteredVariant().getAccession(),
+                                                                    expectedSubmittedVariantEntity4);
+        assertSubmittedOperationsHaveClusteredVariantAccession(2, clusteredVariantAccession3);
         assertClusteredVariantMergeOperationStored(2, clusteredVariantEntity);
         assertClusteredVariantMergeOperationStored(2, clusteredVariantEntity2);
         assertEquals(0, mongoTemplate.count(new Query(), DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME));

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpVariantsWriterTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpVariantsWriterTest.java
@@ -81,7 +81,9 @@ public class DbsnpVariantsWriterTest {
 
     private static final long EXPECTED_ACCESSION = 10000000000L;
 
-    private static final int START = 100;
+    private static final int START_1 = 100;
+
+    private static final int START_2 = 200;
 
     private static final Long CLUSTERED_VARIANT_ACCESSION_1 = 12L;
 
@@ -149,14 +151,14 @@ public class DbsnpVariantsWriterTest {
     }
 
     private SubmittedVariant defaultSubmittedVariant() {
-        return new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START,
+        return new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START_1,
                                     "reference", "alternate", CLUSTERED_VARIANT_ACCESSION_1,
                                     DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                     DEFAULT_ALLELES_MATCH, DEFAULT_VALIDATED, null);
     }
 
     private DbsnpVariantsWrapper buildSimpleWrapper(List<DbsnpSubmittedVariantEntity> submittedVariantEntities) {
-        ClusteredVariant clusteredVariant = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START,
+        ClusteredVariant clusteredVariant = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START_1,
                                                                  VARIANT_TYPE, DEFAULT_VALIDATED, null);
         DbsnpClusteredVariantEntity clusteredVariantEntity = new DbsnpClusteredVariantEntity(
                 EXPECTED_ACCESSION, hashingFunctionClustered.apply(clusteredVariant), clusteredVariant);
@@ -192,7 +194,7 @@ public class DbsnpVariantsWriterTest {
     @Test
     public void writeComplexVariant() throws Exception {
         SubmittedVariant submittedVariant1 = defaultSubmittedVariant();
-        SubmittedVariant submittedVariant2 = new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START,
+        SubmittedVariant submittedVariant2 = new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START_1,
                                                                   "reference", "alternate_2",
                                                                   CLUSTERED_VARIANT_ACCESSION_1,
                                                                   DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
@@ -217,7 +219,7 @@ public class DbsnpVariantsWriterTest {
     @Test
     public void declusterVariantWithMismatchingAlleles() throws Exception {
         boolean allelesMatch = false;
-        SubmittedVariant submittedVariant = new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START,
+        SubmittedVariant submittedVariant = new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START_1,
                                                                  "reference", "alternate",
                                                                  EXPECTED_ACCESSION,
                                                                  DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
@@ -299,7 +301,7 @@ public class DbsnpVariantsWriterTest {
 
     @Test
     public void repeatedClusteredVariants() throws Exception {
-        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START,
+        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START_1,
                                                                   "reference", "alternate",
                                                                   CLUSTERED_VARIANT_ACCESSION_1);
         DbsnpSubmittedVariantEntity submittedVariantEntity1 = new DbsnpSubmittedVariantEntity(
@@ -318,7 +320,7 @@ public class DbsnpVariantsWriterTest {
     @Test
     public void repeatedClusteredVariantsPartiallyDeclustered() throws Exception {
         boolean allelesMatch = false;
-        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START,
+        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START_1,
                                                                   "reference", "alternate", null,
                                                                   DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                   allelesMatch, DEFAULT_VALIDATED, null);
@@ -342,7 +344,7 @@ public class DbsnpVariantsWriterTest {
     @Test
     public void repeatedClusteredVariantsCompletelyDeclustered() throws Exception {
         boolean allelesMatch = false;
-        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START,
+        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START_1,
                                                                   "reference", "alternate", null,
                                                                   DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                   allelesMatch, DEFAULT_VALIDATED, null);
@@ -366,7 +368,7 @@ public class DbsnpVariantsWriterTest {
     @Test
     public void multiallelicClusteredVariantsPartiallyDeclustered() throws Exception {
         boolean allelesMatch = false;
-        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START,
+        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START_1,
                                                                   "reference", "alternate", null,
                                                                   DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                   allelesMatch, DEFAULT_VALIDATED, null);
@@ -391,7 +393,7 @@ public class DbsnpVariantsWriterTest {
     @Test
     public void multiallelicClusteredVariantsCompletelyDeclustered() throws Exception {
         boolean allelesMatch = false;
-        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START,
+        SubmittedVariant submittedVariant1 = new SubmittedVariant("assembly", TAXONOMY_2, "project", "contig", START_1,
                                                                   "reference", "alternate", null,
                                                                   DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                   allelesMatch, DEFAULT_VALIDATED, null);
@@ -562,7 +564,7 @@ public class DbsnpVariantsWriterTest {
     @Test
     public void mergeDuplicateClusteredVariantsInTheSameChunk() throws Exception {
         SubmittedVariant submittedVariant = defaultSubmittedVariant();
-        ClusteredVariant clusteredVariant = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START, VARIANT_TYPE,
+        ClusteredVariant clusteredVariant = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START_1, VARIANT_TYPE,
                                                                  DEFAULT_VALIDATED, null);
 
         DbsnpSubmittedVariantEntity submittedVariantEntity = new DbsnpSubmittedVariantEntity(
@@ -576,10 +578,10 @@ public class DbsnpVariantsWriterTest {
 
 
         SubmittedVariant submittedVariant2 = defaultSubmittedVariant();
-        submittedVariant2.setTaxonomyAccession(TAXONOMY_2);
+        submittedVariant2.setStart(START_2);
         submittedVariant2.setClusteredVariantAccession(CLUSTERED_VARIANT_ACCESSION_2);
         DbsnpSubmittedVariantEntity submittedVariantEntity2 = new DbsnpSubmittedVariantEntity(
-                SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
+                SUBMITTED_VARIANT_ACCESSION_2, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
         DbsnpClusteredVariantEntity clusteredVariantEntity2 = new DbsnpClusteredVariantEntity(
                 CLUSTERED_VARIANT_ACCESSION_2, hashingFunctionClustered.apply(clusteredVariant), clusteredVariant);
 
@@ -591,16 +593,29 @@ public class DbsnpVariantsWriterTest {
         dbsnpVariantsWriter.write(Arrays.asList(wrapper, wrapper2, wrapper));
 
         assertClusteredVariantStored(1, wrapper);
-        assertSubmittedVariantsStored(2, submittedVariantEntity, submittedVariantEntity2);
-        assertSubmittedVariantsLinkToActiveClusteredVariants(wrapper.getClusteredVariant().getAccession(),
-                                                             wrapper.getSubmittedVariants().get(0),
-                                                             wrapper2.getSubmittedVariants().get(0));
+        DbsnpSubmittedVariantEntity expectedSubmittedVariantEntity2 = changeRS(submittedVariantEntity2,
+                                                                               clusteredVariantEntity.getAccession());
+        assertSubmittedVariantsStored(2, submittedVariantEntity, expectedSubmittedVariantEntity2);
+        assertSubmittedVariantsHasActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
+                                                                   wrapper.getSubmittedVariants().get(0),
+                                                                   expectedSubmittedVariantEntity2);
         assertEquals(0, mongoTemplate.count(new Query(), DbsnpSubmittedVariantOperationEntity.class));
         assertClusteredVariantMergeOperationStored(1, clusteredVariantEntity);
         assertEquals(0, mongoTemplate.count(new Query(), DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME));
     }
 
-    private void assertSubmittedVariantsLinkToActiveClusteredVariants(
+    private DbsnpSubmittedVariantEntity changeRS(DbsnpSubmittedVariantEntity submittedVariant, Long mergedInto) {
+        // Need to create a new one because DbsnpSubmittedVariantEntity has no setters
+        SubmittedVariant variant = new SubmittedVariant(submittedVariant);
+        variant.setClusteredVariantAccession(mergedInto);
+
+        Long accession = submittedVariant.getAccession();
+        String hash = submittedVariant.getHashedMessage();
+        int version = submittedVariant.getVersion();
+        return new DbsnpSubmittedVariantEntity(accession, hash, variant, version);
+    }
+
+    private void assertSubmittedVariantsHasActiveClusteredVariantsAccession(
             Long accession,
             DbsnpSubmittedVariantEntity... dbsnpSubmittedVariantEntities) {
         for (DbsnpSubmittedVariantEntity dbsnpSubmittedVariantEntity : dbsnpSubmittedVariantEntities) {
@@ -611,7 +626,7 @@ public class DbsnpVariantsWriterTest {
     @Test
     public void mergeDuplicateClusteredVariants() throws Exception {
         SubmittedVariant submittedVariant = defaultSubmittedVariant();
-        ClusteredVariant clusteredVariant = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START, VARIANT_TYPE,
+        ClusteredVariant clusteredVariant = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START_1, VARIANT_TYPE,
                                                                  DEFAULT_VALIDATED, null);
 
         DbsnpSubmittedVariantEntity submittedVariantEntity = new DbsnpSubmittedVariantEntity(
@@ -625,7 +640,7 @@ public class DbsnpVariantsWriterTest {
 
 
         SubmittedVariant submittedVariant2 = defaultSubmittedVariant();
-        submittedVariant2.setTaxonomyAccession(TAXONOMY_2);
+        submittedVariant2.setStart(START_2);
         submittedVariant2.setClusteredVariantAccession(CLUSTERED_VARIANT_ACCESSION_2);
         DbsnpSubmittedVariantEntity submittedVariantEntity2 = new DbsnpSubmittedVariantEntity(
                 SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant2), submittedVariant2, 1);
@@ -641,10 +656,12 @@ public class DbsnpVariantsWriterTest {
         dbsnpVariantsWriter.write(Arrays.asList(wrapper2));
 
         assertClusteredVariantStored(1, wrapper);
-        assertSubmittedVariantsStored(2, submittedVariantEntity);
-        assertSubmittedVariantsLinkToActiveClusteredVariants(wrapper.getClusteredVariant().getAccession(),
-                                                             wrapper.getSubmittedVariants().get(0),
-                                                             wrapper2.getSubmittedVariants().get(0));
+        DbsnpSubmittedVariantEntity expectedSubmittedVariantEntity2 = changeRS(submittedVariantEntity2,
+                                                                               clusteredVariantEntity.getAccession());
+        assertSubmittedVariantsStored(2, submittedVariantEntity, expectedSubmittedVariantEntity2);
+        assertSubmittedVariantsHasActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
+                                                                   wrapper.getSubmittedVariants().get(0),
+                                                                   expectedSubmittedVariantEntity2);
         assertClusteredVariantMergeOperationStored(1, clusteredVariantEntity);
         assertEquals(0, mongoTemplate.count(new Query(), DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME));
     }
@@ -654,7 +671,7 @@ public class DbsnpVariantsWriterTest {
         SubmittedVariant submittedVariant = defaultSubmittedVariant();
         DbsnpSubmittedVariantEntity submittedVariantEntity = new DbsnpSubmittedVariantEntity(
                 SUBMITTED_VARIANT_ACCESSION_1, hashingFunctionSubmitted.apply(submittedVariant), submittedVariant, 1);
-        ClusteredVariant clusteredVariant = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START, VARIANT_TYPE,
+        ClusteredVariant clusteredVariant = new ClusteredVariant("assembly", TAXONOMY_1, "contig", START_1, VARIANT_TYPE,
                                                                  DEFAULT_VALIDATED, null);
 
         DbsnpClusteredVariantEntity clusteredVariantEntity = new DbsnpClusteredVariantEntity(
@@ -680,10 +697,10 @@ public class DbsnpVariantsWriterTest {
 
         assertClusteredVariantStored(1, wrapper);
         assertSubmittedVariantsStored(1, submittedVariantEntity);
-        assertSubmittedVariantsLinkToActiveClusteredVariants(wrapper.getClusteredVariant().getAccession(),
-                                                             wrapper.getSubmittedVariants().get(0),
-                                                             wrapper2.getSubmittedVariants().get(0),
-                                                             wrapper3.getSubmittedVariants().get(0));
+        assertSubmittedVariantsHasActiveClusteredVariantsAccession(wrapper.getClusteredVariant().getAccession(),
+                                                                   wrapper.getSubmittedVariants().get(0),
+                                                                   wrapper2.getSubmittedVariants().get(0),
+                                                                   wrapper3.getSubmittedVariants().get(0));
         assertClusteredVariantMergeOperationStored(2, clusteredVariantEntity);
         assertEquals(0, mongoTemplate.count(new Query(), DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME));
     }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpVariantsWriterTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/io/DbsnpVariantsWriterTest.java
@@ -48,8 +48,10 @@ import uk.ac.ebi.eva.accession.core.summary.ClusteredVariantSummaryFunction;
 import uk.ac.ebi.eva.accession.core.summary.SubmittedVariantSummaryFunction;
 import uk.ac.ebi.eva.accession.dbsnp.listeners.ImportCounts;
 import uk.ac.ebi.eva.accession.dbsnp.persistence.DbsnpVariantsWrapper;
+import uk.ac.ebi.eva.accession.dbsnp.processors.SubmittedVariantDeclusterProcessor;
 import uk.ac.ebi.eva.commons.core.models.VariantType;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -216,17 +218,22 @@ public class DbsnpVariantsWriterTest {
     public void declusterVariantWithMismatchingAlleles() throws Exception {
         boolean allelesMatch = false;
         SubmittedVariant submittedVariant = new SubmittedVariant("assembly", TAXONOMY_1, "project", "contig", START,
-                                                                 "reference", "alternate", null,
+                                                                 "reference", "alternate",
+                                                                 EXPECTED_ACCESSION,
                                                                  DEFAULT_SUPPORTED_BY_EVIDENCE, DEFAULT_ASSEMBLY_MATCH,
                                                                  allelesMatch, DEFAULT_VALIDATED, null);
         DbsnpSubmittedVariantEntity dbsnpSubmittedVariantEntity1 =
                 new DbsnpSubmittedVariantEntity(SUBMITTED_VARIANT_ACCESSION_1,
                                                 hashingFunctionSubmitted.apply(submittedVariant),
                                                 submittedVariant, 1);
+        ArrayList<DbsnpSubmittedVariantOperationEntity> operations = new ArrayList<>();
+        dbsnpSubmittedVariantEntity1 = new SubmittedVariantDeclusterProcessor().decluster(dbsnpSubmittedVariantEntity1,
+                                                                                          operations,
+                                                                                          new ArrayList<>());
 
         DbsnpVariantsWrapper wrapper = buildSimpleWrapper(Collections.singletonList(dbsnpSubmittedVariantEntity1));
 
-        DbsnpSubmittedVariantOperationEntity operationEntity = createOperation(submittedVariant);
+        DbsnpSubmittedVariantOperationEntity operationEntity = operations.get(0);
         wrapper.setOperations(Collections.singletonList(operationEntity));
 
         dbsnpVariantsWriter.write(Collections.singletonList(wrapper));


### PR DESCRIPTION
If an RS (for instance rs1) is merged into another RS (for instance rs2), update SSs (in rs1) to point to the active RS (rs2), and add an update in the SubmittedVariantOperation collection with the old RS.

If the RS was merged into several RSs (for instance, the pipeline merges  [rs193927678](https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=193927678) into [rs1095750933 ](https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1095750933 ) and [rs347458720](https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=347458720)), update each SS with the corresponding RS, and put the operation for each SS (even if the old RS is the same).


