### PR TITLE
EVA-1322 Created date appropriately set when available on SS, RS or none

### DIFF
--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToClusteredVariantProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToClusteredVariantProcessor.java
@@ -122,11 +122,10 @@ public class SubSnpNoHgvsToClusteredVariantProcessor
     }
 
     private LocalDateTime getCreatedDate(SubSnpNoHgvs subSnpNoHgvs) {
-        LocalDateTime createdDate;
-        if ((createdDate = subSnpNoHgvs.getRsCreateTime().toLocalDateTime()) != null) {
-            return createdDate;
-        } else if ((createdDate = subSnpNoHgvs.getSsCreateTime().toLocalDateTime()) != null) {
-            return createdDate;
+        if (subSnpNoHgvs.getRsCreateTime() != null) {
+            return subSnpNoHgvs.getRsCreateTime().toLocalDateTime();
+        } else if (subSnpNoHgvs.getSsCreateTime() != null) {
+            return subSnpNoHgvs.getSsCreateTime().toLocalDateTime();
         } else {
             return LocalDateTime.now();
         }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessor.java
@@ -115,11 +115,10 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessor implements ItemProcesso
     }
 
     private LocalDateTime getCreatedDate(SubSnpNoHgvs subSnpNoHgvs) {
-        LocalDateTime createdDate;
-        if ((createdDate = subSnpNoHgvs.getSsCreateTime().toLocalDateTime()) != null) {
-            return createdDate;
-        } else if ((createdDate = subSnpNoHgvs.getRsCreateTime().toLocalDateTime()) != null) {
-            return createdDate;
+        if (subSnpNoHgvs.getSsCreateTime() != null) {
+            return subSnpNoHgvs.getSsCreateTime().toLocalDateTime();
+        } else if (subSnpNoHgvs.getRsCreateTime() != null) {
+            return subSnpNoHgvs.getRsCreateTime().toLocalDateTime();
         } else {
             return LocalDateTime.now();
         }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
@@ -633,7 +633,7 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
                                                      null, TAXONOMY);
 
         DbsnpVariantsWrapper dbsnpVariantsWrapper = processor.process(subSnpNoHgvs);
-        assertNotNull(dbsnpVariantsWrapper.getClusteredVariant().getCreatedDate());
+        assertEquals(SS_CREATED_DATE.toLocalDateTime(), dbsnpVariantsWrapper.getClusteredVariant().getCreatedDate());
         dbsnpVariantsWrapper.getSubmittedVariants().stream().forEach(
                 ss -> assertEquals(SS_CREATED_DATE.toLocalDateTime(), ss.getCreatedDate()));
     }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/processors/SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest.java
@@ -37,10 +37,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
 
@@ -610,6 +608,50 @@ public class SubSnpNoHgvsToDbsnpVariantsWrapperProcessorTest {
 
         assertProcessedVariant(subSnpNoHgvs, variants.get(0), CONTIG_NAME, CONTIG_START, "T", "A", false, false, 1);
         assertProcessedVariant(subSnpNoHgvs, variants.get(1), CONTIG_NAME, CONTIG_START, "T", "C", false, false, 1);
+    }
+
+    @Test
+    public void processSubSnpNullDate() throws Exception {
+        SubSnpNoHgvs subSnpNoHgvs = new SubSnpNoHgvs(25928972L, 14718243L, "A", "C", ASSEMBLY, BATCH_HANDLE, BATCH_NAME,
+                                                     CHROMOSOME, CHROMOSOME_START, CONTIG_NAME, CONTIG_START,
+                                                     DbsnpVariantType.SNV, Orientation.FORWARD, Orientation.FORWARD,
+                                                     Orientation.FORWARD, false, false, false, false, null,
+                                                     RS_CREATED_DATE, TAXONOMY);
+
+        DbsnpVariantsWrapper dbsnpVariantsWrapper = processor.process(subSnpNoHgvs);
+        assertEquals(RS_CREATED_DATE.toLocalDateTime(), dbsnpVariantsWrapper.getClusteredVariant().getCreatedDate());
+        dbsnpVariantsWrapper.getSubmittedVariants().stream().forEach(
+                ss -> assertEquals(RS_CREATED_DATE.toLocalDateTime(), ss.getCreatedDate()));
+    }
+
+    @Test
+    public void processRefSnpNullDate() throws Exception {
+        SubSnpNoHgvs subSnpNoHgvs = new SubSnpNoHgvs(25928972L, 14718243L, "A", "C", ASSEMBLY, BATCH_HANDLE, BATCH_NAME,
+                                                     CHROMOSOME, CHROMOSOME_START, CONTIG_NAME, CONTIG_START,
+                                                     DbsnpVariantType.SNV, Orientation.FORWARD, Orientation.FORWARD,
+                                                     Orientation.FORWARD, false, false, false, false, SS_CREATED_DATE,
+                                                     null, TAXONOMY);
+
+        DbsnpVariantsWrapper dbsnpVariantsWrapper = processor.process(subSnpNoHgvs);
+        assertNotNull(dbsnpVariantsWrapper.getClusteredVariant().getCreatedDate());
+        dbsnpVariantsWrapper.getSubmittedVariants().stream().forEach(
+                ss -> assertEquals(SS_CREATED_DATE.toLocalDateTime(), ss.getCreatedDate()));
+    }
+
+    @Test
+    public void processSubSnpAndRefSnpNullDate() throws Exception {
+        SubSnpNoHgvs subSnpNoHgvs = new SubSnpNoHgvs(25928972L, 14718243L, "A", "C", ASSEMBLY, BATCH_HANDLE, BATCH_NAME,
+                                                     CHROMOSOME, CHROMOSOME_START, CONTIG_NAME, CONTIG_START,
+                                                     DbsnpVariantType.SNV, Orientation.FORWARD, Orientation.FORWARD,
+                                                     Orientation.FORWARD, false, false, false, false, null, null,
+                                                     TAXONOMY);
+
+        DbsnpVariantsWrapper dbsnpVariantsWrapper = processor.process(subSnpNoHgvs);
+        assertNotNull(dbsnpVariantsWrapper.getClusteredVariant().getCreatedDate());
+        dbsnpVariantsWrapper.getSubmittedVariants().stream().forEach(ss -> assertNotNull(ss.getCreatedDate()));
+        dbsnpVariantsWrapper.getSubmittedVariants().stream().forEach(
+                ss -> assertEquals(ss.getCreatedDate().toLocalDate(),
+                                   dbsnpVariantsWrapper.getClusteredVariant().getCreatedDate().toLocalDate()));
     }
 
 }


### PR DESCRIPTION
A NullPointerException was raised when any of the creation dates were null. This has been corrected and relevant tests added.