### PR TITLE
EVA-1358 Get list of variants in an assembly

### DIFF
--- a/eva-accession-release/pom.xml
+++ b/eva-accession-release/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>nosqlunit-mongodb</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>variation-commons-batch</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/eva-accession-release/pom.xml
+++ b/eva-accession-release/pom.xml
@@ -14,6 +14,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>eva-accession-core</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-batch</artifactId>
         </dependency>
@@ -33,6 +38,11 @@
         <dependency>
             <groupId>com.github.samtools</groupId>
             <artifactId>htsjdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.lordofthejars</groupId>
+            <artifactId>nosqlunit-mongodb</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/AccessionedVariantMongoReaderConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/AccessionedVariantMongoReaderConfiguration.java
@@ -4,6 +4,7 @@ import com.mongodb.MongoClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.boot.autoconfigure.mongo.MongoProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +13,8 @@ import org.springframework.context.annotation.Import;
 import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.accession.release.io.AccessionedVariantMongoReader;
 import uk.ac.ebi.eva.accession.release.parameters.InputParameters;
+import uk.ac.ebi.eva.commons.batch.io.UnwindingItemStreamReader;
+import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
 import static uk.ac.ebi.eva.accession.release.configuration.BeanNames.ACCESSIONED_VARIANT_READER;
 
@@ -21,7 +24,13 @@ public class AccessionedVariantMongoReaderConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(AccessionedVariantMongoReader.class);
 
-    @Bean(name = ACCESSIONED_VARIANT_READER)
+    @Bean(ACCESSIONED_VARIANT_READER)
+    @StepScope
+    public ItemStreamReader<Variant> unwindingReader(AccessionedVariantMongoReader accessionedVariantMongoReader) {
+        return new UnwindingItemStreamReader<>(accessionedVariantMongoReader);
+    }
+
+    @Bean
     @StepScope
     AccessionedVariantMongoReader accessionedVariantMongoReader(InputParameters parameters, MongoClient mongoClient,
                                                                 MongoProperties mongoProperties) {

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/AccessionedVariantMongoReaderConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/AccessionedVariantMongoReaderConfiguration.java
@@ -1,0 +1,32 @@
+package uk.ac.ebi.eva.accession.release.configuration;
+
+import com.mongodb.MongoClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
+import uk.ac.ebi.eva.accession.release.io.AccessionedVariantMongoReader;
+import uk.ac.ebi.eva.accession.release.parameters.InputParameters;
+
+import static uk.ac.ebi.eva.accession.release.configuration.BeanNames.ACCESSIONED_VARIANT_READER;
+
+@Configuration
+@Import({MongoConfiguration.class})
+public class AccessionedVariantMongoReaderConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(AccessionedVariantMongoReader.class);
+
+    @Bean(name = ACCESSIONED_VARIANT_READER)
+    @StepScope
+    AccessionedVariantMongoReader accessionedVariantMongoReader(InputParameters parameters, MongoClient mongoClient,
+                                                                MongoProperties mongoProperties) {
+        logger.info("Injecting AccessionedVariantMongoReader with parameters: {}", parameters);
+        return new AccessionedVariantMongoReader(parameters.getAssemblyAccession(), mongoClient,
+                                                 mongoProperties.getDatabase());
+    }
+}

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/BeanNames.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/BeanNames.java
@@ -4,4 +4,5 @@ public class BeanNames {
 
     public static final String EXCLUDE_VARIANTS_LISTENER = "EXCLUDE_VARIANTS_LISTENER";
 
+    public static final String ACCESSIONED_VARIANT_READER = "ACCESSIONED_VARIANT_READER";
 }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/InputParametersConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/InputParametersConfiguration.java
@@ -1,0 +1,17 @@
+package uk.ac.ebi.eva.accession.release.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import uk.ac.ebi.eva.accession.release.parameters.InputParameters;
+
+@Configuration
+public class InputParametersConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "release")
+    public InputParameters inputParameters() {
+        return new InputParameters();
+    }
+}

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/InputParametersConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/InputParametersConfiguration.java
@@ -10,7 +10,7 @@ import uk.ac.ebi.eva.accession.release.parameters.InputParameters;
 public class InputParametersConfiguration {
 
     @Bean
-    @ConfigurationProperties(prefix = "release")
+    @ConfigurationProperties(prefix = "parameters")
     public InputParameters inputParameters() {
         return new InputParameters();
     }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/ListenersConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/ListenersConfiguration.java
@@ -12,7 +12,7 @@ import static uk.ac.ebi.eva.accession.release.configuration.BeanNames.EXCLUDE_VA
 public class ListenersConfiguration {
 
     @Bean(EXCLUDE_VARIANTS_LISTENER)
-    public StepListenerSupport importDbsnpVariantsProgressListener() {
+    public StepListenerSupport excludeVariantsListener() {
         return new ExcludeVariantsListener();
     }
 }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
@@ -1,0 +1,96 @@
+package uk.ac.ebi.eva.accession.release.io;
+
+import com.mongodb.BasicDBObject;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.NonTransientResourceException;
+import org.springframework.batch.item.ParseException;
+import org.springframework.batch.item.UnexpectedInputException;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.LookupOperation;
+import org.springframework.data.mongodb.core.aggregation.MatchOperation;
+import org.springframework.data.mongodb.core.aggregation.SortOperation;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
+import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.match;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.newAggregation;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.newAggregationOptions;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.sort;
+
+public class AccessionedVariantMongoReader implements ItemReader<Variant> {
+
+    private MongoTemplate mongoTemplate;
+
+    private AggregationResults<BasicDBObject> clusteredVariants;
+
+    public AccessionedVariantMongoReader(MongoTemplate mongoTemplate){
+        this.mongoTemplate = mongoTemplate;
+        initializeReader();
+    }
+
+    private void initializeReader() {
+        Aggregation aggregation = buildAggregation();
+        clusteredVariants = mongoTemplate.aggregate(aggregation, "dbsnpClusteredVariantEntity", BasicDBObject.class);
+    }
+
+    private Aggregation buildAggregation() {
+        MatchOperation matchOperation = match(Criteria.where("asm").is("GCF_000409795.2"));
+
+        LookupOperation lookupOperation = LookupOperation.newLookup()
+                                                         .from("dbsnpSubmittedVariantEntity")
+                                                         .localField("accession")
+                                                         .foreignField("rs")
+                                                         .as("ssInfo");
+
+        SortOperation sortOperation = sort(Sort.Direction.ASC, "contig", "start");
+
+        AggregationOptions options = newAggregationOptions().allowDiskUse(true).build();
+
+        return newAggregation(matchOperation, lookupOperation, sortOperation).withOptions(options);
+    }
+
+    @Override
+    public Variant read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+        return getVariant(clusteredVariants.getMappedResults().get(0));
+    }
+
+    private Variant getVariant(BasicDBObject clusteredVariant) {
+        String contig = (String) clusteredVariant.get("contig");
+        long start = (long) clusteredVariant.get("start");
+        long rs = (long) clusteredVariant.get("accession");
+        String reference = "";
+        String alternate = "";
+        long end = 0L;
+        List<VariantSourceEntry> studies = new ArrayList<>();
+
+        List<BasicDBObject> submittedVariants = (List) clusteredVariant.get("ssInfo");
+        for (BasicDBObject submitedVariant : submittedVariants) {
+            reference = (String) submitedVariant.get("ref");
+            alternate = (String) submitedVariant.get("alt");
+            end = calculateEnd(reference, alternate, start);
+            String study = (String) submitedVariant.get("study");
+            studies.add(new VariantSourceEntry(study, study));
+        }
+
+        Variant variant = new Variant(contig, start, end, reference, alternate);
+        variant.setMainId(Objects.toString(rs));
+        variant.addSourceEntries(studies);
+        return variant;
+    }
+
+    private long calculateEnd(String reference, String alternate, long start) {
+        long referenceLength = reference.length() - 1;
+        long alternateLength = alternate.length() - 1;
+        return (referenceLength >= alternateLength) ? start + referenceLength : start + alternateLength;
+    }
+}

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
@@ -1,70 +1,68 @@
 package uk.ac.ebi.eva.accession.release.io;
 
-import com.mongodb.BasicDBObject;
-import org.springframework.batch.item.ItemReader;
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.NonTransientResourceException;
 import org.springframework.batch.item.ParseException;
 import org.springframework.batch.item.UnexpectedInputException;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
-import org.springframework.data.mongodb.core.aggregation.AggregationResults;
-import org.springframework.data.mongodb.core.aggregation.LookupOperation;
-import org.springframework.data.mongodb.core.aggregation.MatchOperation;
-import org.springframework.data.mongodb.core.aggregation.SortOperation;
-import org.springframework.data.mongodb.core.query.Criteria;
 
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.match;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.newAggregation;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.newAggregationOptions;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.sort;
+import static com.mongodb.client.model.Sorts.ascending;
+import static com.mongodb.client.model.Sorts.orderBy;
 
-public class AccessionedVariantMongoReader implements ItemReader<Variant> {
+public class AccessionedVariantMongoReader implements ItemStreamReader<Variant> {
 
-    private MongoTemplate mongoTemplate;
+    private MongoCursor<Document> cursor;
 
-    private AggregationResults<BasicDBObject> clusteredVariants;
-
-    public AccessionedVariantMongoReader(MongoTemplate mongoTemplate){
-        this.mongoTemplate = mongoTemplate;
-        initializeReader();
+    public AccessionedVariantMongoReader(){
     }
 
-    private void initializeReader() {
-        Aggregation aggregation = buildAggregation();
-        clusteredVariants = mongoTemplate.aggregate(aggregation, "dbsnpClusteredVariantEntity", BasicDBObject.class);
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        MongoClient mongoClient = new MongoClient(new ServerAddress("localhost", 27017));
+        MongoDatabase db = mongoClient.getDatabase("test-db");
+
+        MongoCollection<Document> collection = db.getCollection("dbsnpClusteredVariantEntity");
+        AggregateIterable<Document> clusteredVariants = collection.aggregate(buildAggregation())
+                                                                  .allowDiskUse(true)
+                                                                  .useCursor(true);
+        cursor = clusteredVariants.iterator();
     }
 
-    private Aggregation buildAggregation() {
-        MatchOperation matchOperation = match(Criteria.where("asm").is("GCF_000409795.2"));
-
-        LookupOperation lookupOperation = LookupOperation.newLookup()
-                                                         .from("dbsnpSubmittedVariantEntity")
-                                                         .localField("accession")
-                                                         .foreignField("rs")
-                                                         .as("ssInfo");
-
-        SortOperation sortOperation = sort(Sort.Direction.ASC, "contig", "start");
-
-        AggregationOptions options = newAggregationOptions().allowDiskUse(true).build();
-
-        return newAggregation(matchOperation, lookupOperation, sortOperation).withOptions(options);
+    private List<Bson> buildAggregation() {
+//        Bson match = Aggregates.match(Filters.eq("asm", "GCF_000001215.2")); //fruitfly 5M rs
+//        Bson match = Aggregates.match(Filters.eq("asm", "GCF_000409795.2")); //green monkey 500K rs
+//        Bson match = Aggregates.match(Filters.eq("asm", "GCF_000309985.1")); //field mustard 164 rs
+        Bson match = Aggregates.match(Filters.eq("asm", "GCF_000409795.2"));
+        Bson lookup = Aggregates.lookup("dbsnpSubmittedVariantEntity", "accession", "rs", "ssInfo");
+        Bson sort = Aggregates.sort(orderBy(ascending("contig", "start")));
+        return Arrays.asList(match, lookup, sort);
     }
 
     @Override
     public Variant read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
-        return getVariant(clusteredVariants.getMappedResults().get(0));
+        return cursor.hasNext() ? getVariant(cursor.next()) : null;
     }
 
-    private Variant getVariant(BasicDBObject clusteredVariant) {
+    private Variant getVariant(Document clusteredVariant) {
         String contig = (String) clusteredVariant.get("contig");
         long start = (long) clusteredVariant.get("start");
         long rs = (long) clusteredVariant.get("accession");
@@ -73,13 +71,14 @@ public class AccessionedVariantMongoReader implements ItemReader<Variant> {
         long end = 0L;
         List<VariantSourceEntry> studies = new ArrayList<>();
 
-        List<BasicDBObject> submittedVariants = (List) clusteredVariant.get("ssInfo");
-        for (BasicDBObject submitedVariant : submittedVariants) {
+        List<Document> submittedVariants = (List) clusteredVariant.get("ssInfo");
+        for (Document submitedVariant : submittedVariants) {
             reference = (String) submitedVariant.get("ref");
             alternate = (String) submitedVariant.get("alt");
             end = calculateEnd(reference, alternate, start);
             String study = (String) submitedVariant.get("study");
             studies.add(new VariantSourceEntry(study, study));
+            //TODO: Add variant class
         }
 
         Variant variant = new Variant(contig, start, end, reference, alternate);
@@ -88,9 +87,19 @@ public class AccessionedVariantMongoReader implements ItemReader<Variant> {
         return variant;
     }
 
-    private long calculateEnd(String reference, String alternate, long start) {
+    long calculateEnd(String reference, String alternate, long start) {
         long referenceLength = reference.length() - 1;
         long alternateLength = alternate.length() - 1;
         return (referenceLength >= alternateLength) ? start + referenceLength : start + alternateLength;
+    }
+
+    @Override
+    public void close() throws ItemStreamException {
+        cursor.close();
+    }
+
+    @Override
+    public void update(ExecutionContext executionContext) throws ItemStreamException {
+
     }
 }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
@@ -56,9 +56,9 @@ public class AccessionedVariantMongoReader implements ItemStreamReader<Variant> 
 
     private static final String SS_INFO_FIELD = "ssInfo";
 
-    private static final String VARIANT_CLASS_KEY = "VC";
+    static final String VARIANT_CLASS_KEY = "VC";
 
-    private static final String STUDY_ID_KEY = "SID";
+    static final String STUDY_ID_KEY = "SID";
 
     private String assemblyAccession;
 
@@ -104,7 +104,7 @@ public class AccessionedVariantMongoReader implements ItemStreamReader<Variant> 
         long rs = clusteredVariant.getLong(ACCESSION_FIELD);
         String reference = "";
         String alternate = "";
-        long end = 0L;
+        long end = start;
         List<VariantSourceEntry> sourceEntries = new ArrayList<>();
         String type = clusteredVariant.getString(TYPE_FIELD);
         String sequenceOntology = VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.valueOf(type));

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
@@ -56,6 +56,10 @@ public class AccessionedVariantMongoReader implements ItemStreamReader<Variant> 
 
     private static final String SS_INFO_FIELD = "ssInfo";
 
+    private static final String VARIANT_CLASS_KEY = "VC";
+
+    private static final String STUDY_ID_KEY = "SID";
+
     private String assemblyAccession;
 
     private MongoClient mongoClient;
@@ -104,7 +108,6 @@ public class AccessionedVariantMongoReader implements ItemStreamReader<Variant> 
         List<VariantSourceEntry> sourceEntries = new ArrayList<>();
         String type = clusteredVariant.getString(TYPE_FIELD);
         String sequenceOntology = VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.valueOf(type));
-        sourceEntries.add(new VariantSourceEntry(sequenceOntology, sequenceOntology));
 
         Collection<Document> submittedVariants = (Collection<Document>)clusteredVariant.get(SS_INFO_FIELD);
         for (Document submitedVariant : submittedVariants) {
@@ -112,7 +115,7 @@ public class AccessionedVariantMongoReader implements ItemStreamReader<Variant> 
             alternate = submitedVariant.getString(ALTERNATE_ALLELE_FIELD);
             end = calculateEnd(reference, alternate, start);
             String study = submitedVariant.getString(STUDY_FIELD);
-            sourceEntries.add(new VariantSourceEntry(study, study));
+            sourceEntries.add(buildVariantSourceEntry(study, sequenceOntology));
         }
 
         Variant variant = new Variant(contig, start, end, reference, alternate);
@@ -124,6 +127,13 @@ public class AccessionedVariantMongoReader implements ItemStreamReader<Variant> 
     private long calculateEnd(String reference, String alternate, long start) {
         long length = Math.max(reference.length(), alternate.length());
         return start + length - 1;
+    }
+
+    private VariantSourceEntry buildVariantSourceEntry(String study, String sequenceOntology) {
+        VariantSourceEntry sourceEntry = new VariantSourceEntry(study, study);
+        sourceEntry.addAttribute(VARIANT_CLASS_KEY, sequenceOntology);
+        sourceEntry.addAttribute(STUDY_ID_KEY, study);
+        return sourceEntry;
     }
 
     @Override

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
@@ -116,7 +116,7 @@ public class AccessionedVariantMongoReader implements ItemStreamReader<List<Vari
             String study = submittedVariant.getString(STUDY_FIELD);
             VariantSourceEntry sourceEntry = buildVariantSourceEntry(study, sequenceOntology);
 
-            String variantId = contig + "_" + start + "_" + reference + "_" + alternate;
+            String variantId = (contig + "_" + start + "_" + reference + "_" + alternate).toUpperCase();
             if (variants.containsKey(variantId)) {
                 variants.get(variantId).addSourceEntry(sourceEntry);
             } else {

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/parameters/InputParameters.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/parameters/InputParameters.java
@@ -1,0 +1,19 @@
+package uk.ac.ebi.eva.accession.release.parameters;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+
+public class InputParameters {
+
+    private String assemblyAccession;
+
+    public JobParameters toJobParameters() {
+        return new JobParametersBuilder()
+                .addString("assemblyAccession", assemblyAccession)
+                .toJobParameters();
+    }
+
+    public String getAssemblyAccession() {
+        return assemblyAccession;
+    }
+}

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
@@ -123,9 +123,9 @@ public class AccessionedVariantMongoReaderTest {
         List<Variant> variants = new ArrayList<>();
         while (cursor.hasNext()) {
             Document clusteredVariant = cursor.next();
-            variants = reader.getVariants(clusteredVariant);
+            variants.addAll(reader.getVariants(clusteredVariant));
         }
-        assertEquals(2, variants.size());
+        assertEquals(3, variants.size());
      }
 
     @Test
@@ -170,8 +170,8 @@ public class AccessionedVariantMongoReaderTest {
     }
 
     private String getStringId(Variant variant) {
-        return variant.getChromosome() + "_" + variant.getStart() + "_" + variant.getReference() + "_"
-                + variant.getAlternate();
+        return (variant.getChromosome() + "_" + variant.getStart() + "_" + variant.getReference() + "_"
+                + variant.getAlternate()).toUpperCase();
     }
 
     @Test

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
@@ -213,11 +213,11 @@ public class AccessionedVariantMongoReaderTest {
         reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_4, mongoClient, TEST_DB);
         List<Variant> variants = readIntoList();
         assertEquals(1, variants.size());
-        String snpSequenceOntology = "SO:0000667";
+        String insertionSequenceOntology = "SO:0000667";
         assertTrue(variants.get(0)
                            .getSourceEntries()
                            .stream()
-                           .allMatch(se -> snpSequenceOntology.equals(se.getAttribute(VARIANT_CLASS_KEY))));
+                           .allMatch(se -> insertionSequenceOntology.equals(se.getAttribute(VARIANT_CLASS_KEY))));
     }
 
     @Test

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.release.io;
+
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
+import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantEntity;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(SpringRunner.class)
+@TestPropertySource("classpath:accession-release-test.properties")
+@UsingDataSet(locations = {
+        "/test-data/dbsnpClusteredVariantEntity.json",
+        "/test-data/dbsnpSubmittedVariantEntity.json"})
+@ContextConfiguration(classes = {MongoConfiguration.class})
+public class AccessionedVariantMongoReaderTest {
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    //Required by nosql-unit
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void loadTestData() {
+        List<SubmittedVariantEntity> submittedVariants =
+                mongoTemplate.findAll(SubmittedVariantEntity.class, "dbsnpSubmittedVariantEntity");
+
+        assertNotEquals(0, submittedVariants.size());
+    }
+}

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
@@ -16,6 +16,9 @@
 package uk.ac.ebi.eva.accession.release.io;
 
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbConfigurationBuilder;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +30,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.release.test.configuration.MongoTestConfiguration;
+import uk.ac.ebi.eva.accession.release.test.rule.FixSpringMongoDbRule;
 
 import java.util.List;
 
@@ -36,8 +41,9 @@ import static org.junit.Assert.assertNotEquals;
 @TestPropertySource("classpath:accession-release-test.properties")
 @UsingDataSet(locations = {
         "/test-data/dbsnpClusteredVariantEntity.json",
-        "/test-data/dbsnpSubmittedVariantEntity.json"})
-@ContextConfiguration(classes = {MongoConfiguration.class})
+        "/test-data/dbsnpSubmittedVariantEntity.json",
+        "/test-data/test-ss.json"})
+@ContextConfiguration(classes = {MongoConfiguration.class, MongoTestConfiguration.class})
 public class AccessionedVariantMongoReaderTest {
 
     @Autowired
@@ -46,6 +52,10 @@ public class AccessionedVariantMongoReaderTest {
     //Required by nosql-unit
     @Autowired
     private ApplicationContext applicationContext;
+
+    @Rule
+    public MongoDbRule mongoDbRule = new FixSpringMongoDbRule(
+            MongoDbConfigurationBuilder.mongoDb().databaseName("test-db2").build());
 
     @Test
     public void loadTestData() {

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
@@ -32,17 +32,18 @@ import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.accession.core.persistence.SubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.release.test.configuration.MongoTestConfiguration;
 import uk.ac.ebi.eva.accession.release.test.rule.FixSpringMongoDbRule;
+import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
 import java.util.List;
 
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource("classpath:accession-release-test.properties")
 @UsingDataSet(locations = {
         "/test-data/dbsnpClusteredVariantEntity.json",
-        "/test-data/dbsnpSubmittedVariantEntity.json",
-        "/test-data/test-ss.json"})
+        "/test-data/dbsnpSubmittedVariantEntity.json"})
 @ContextConfiguration(classes = {MongoConfiguration.class, MongoTestConfiguration.class})
 public class AccessionedVariantMongoReaderTest {
 
@@ -55,7 +56,7 @@ public class AccessionedVariantMongoReaderTest {
 
     @Rule
     public MongoDbRule mongoDbRule = new FixSpringMongoDbRule(
-            MongoDbConfigurationBuilder.mongoDb().databaseName("test-db2").build());
+            MongoDbConfigurationBuilder.mongoDb().databaseName("test-db").build());
 
     @Test
     public void loadTestData() {
@@ -63,5 +64,12 @@ public class AccessionedVariantMongoReaderTest {
                 mongoTemplate.findAll(SubmittedVariantEntity.class, "dbsnpSubmittedVariantEntity");
 
         assertNotEquals(0, submittedVariants.size());
+    }
+
+    @Test
+    public void readerTest() throws Exception {
+        AccessionedVariantMongoReader reader = new AccessionedVariantMongoReader(mongoTemplate);
+        Variant variant = reader.read();
+        assertNotNull(variant);
     }
 }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/test/configuration/MongoTestConfiguration.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/test/configuration/MongoTestConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.release.test.configuration;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EntityScan(basePackages = {"uk.ac.ebi.eva.accession.core.persistence"})
+@EnableMongoRepositories(basePackages = {
+        "uk.ac.ebi.eva.accession.core.persistence",
+        "uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.repository"})
+@EnableMongoAuditing
+@AutoConfigureDataMongo
+public class MongoTestConfiguration {
+
+}

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/test/rule/FixSpringMongoDbRule.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/test/rule/FixSpringMongoDbRule.java
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.release.test.rule;
+
+import com.lordofthejars.nosqlunit.mongodb.MongoDbConfiguration;
+import com.lordofthejars.nosqlunit.mongodb.SpringMongoDbRule;
+
+/**
+ * Temporary fix until nosql unit rc-6 or final is released
+ */
+public class FixSpringMongoDbRule extends SpringMongoDbRule {
+
+    public FixSpringMongoDbRule(MongoDbConfiguration mongoDbConfiguration) {
+        super(mongoDbConfiguration);
+    }
+
+    public FixSpringMongoDbRule(MongoDbConfiguration mongoDbConfiguration, Object object) {
+        super(mongoDbConfiguration, object);
+    }
+
+    @Override
+    public void close() {
+        // DO NOT CLOSE the connection (Spring will do it when destroying the context)
+    }
+
+}

--- a/eva-accession-release/src/test/resources/accession-release-test.properties
+++ b/eva-accession-release/src/test/resources/accession-release-test.properties
@@ -1,0 +1,11 @@
+accessioning.instanceId=test-instance-01
+accessioning.submitted.categoryId=test-release-ss
+
+accessioning.monotonic.test-pipeline-ss.blockSize=100000
+accessioning.monotonic.test-pipeline-ss.blockStartValue=5000000000
+accessioning.monotonic.test-pipeline-ss.nextBlockInterval=1000000000
+
+spring.jpa.show-sql=true
+
+spring.data.mongodb.database=test-db
+mongodb.read-preference=primary

--- a/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
@@ -49,6 +49,18 @@
       "accession" : NumberLong(796064877),
       "version" : 1,
       "createdDate" : ISODate("2015-08-19T09:34:00Z")
+    },
+    {
+      "_id" : "F1E098016B20007A09C5773C5C4CA95E4A6B1AF1",
+      "asm" : "GCF_000309985.1",
+      "tax" : 3711,
+      "contig" : "CM001642.1",
+      "start" : NumberLong(7356605),
+      "type" : "INS",
+      "accession" : NumberLong(268233057),
+      "version" : 1,
+      "createdDate" : ISODate("2012-08-16T23:34:00Z")
     }
+
   ]
 }

--- a/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
@@ -38,6 +38,17 @@
       "createdDate": ISODate(
       "2013-03-20T15:55:49.673Z"
       )
+    },
+    {
+      "_id" : "5C44B8E760D038D41CCAACCE4654B4B940604136",
+      "asm" : "GCF_000372685.1",
+      "tax" : 7994,
+      "contig" : "KB882311.1",
+      "start" : NumberLong(1232078),
+      "type" : "SNV",
+      "accession" : NumberLong(796064877),
+      "version" : 1,
+      "createdDate" : ISODate("2015-08-19T09:34:00Z")
     }
   ]
 }

--- a/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
@@ -1,0 +1,43 @@
+{
+  "dbsnpClusteredVariantEntity": [
+    {
+      "_id": "F475F4F6657CF52CE8BF8416AA945EF669CB1BCD",
+      "asm": "GCF_000409795.2",
+      "tax": 60711,
+      "contig": "CM001954.1",
+      "start": NumberLong(92701040),
+      "type": "SNV",
+      "accession": NumberLong(869808637),
+      "version": 1,
+      "createdDate": ISODate(
+      "2016-05-16T13:07:00Z"
+      )
+    },
+    {
+      "_id": "EFC783A3165EFA99F22D20238257DE280BCE48BF",
+      "asm": "GCF_000409795.2",
+      "tax": 60711,
+      "contig": "CM001941.2",
+      "start": NumberLong(13247923),
+      "type": "SNV",
+      "accession": NumberLong(869927931),
+      "version": 1,
+      "createdDate": ISODate(
+      "2016-05-16T13:07:00Z"
+      )
+    },
+    {
+      "_id": "488EA6AC249A14ECC80E020353D2CFBE366DD324",
+      "asm": "GCF_000001735.3",
+      "tax": 3702,
+      "contig": "CP002685.1",
+      "start": NumberLong(4758626),
+      "type": "SNV",
+      "accession": NumberLong(347048227),
+      "version": 1,
+      "createdDate": ISODate(
+      "2013-03-20T15:55:49.673Z"
+      )
+    }
+  ]
+}

--- a/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -17,10 +17,10 @@
       )
     },
     {
-      "_id": "267171186884F74FFCFAF6EDFD7A80379DF2F6E0",
+      "_id": "D6E93A861A45942E591879572995BB50B9485AEE",
       "seq": "GCF_000409795.2",
       "tax": 60711,
-      "study": "PRJEB7923",
+      "study": "PRJEB9999",
       "contig": "CM001954.1",
       "start": NumberLong(92701040),
       "ref": "G",

--- a/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -17,6 +17,22 @@
       )
     },
     {
+      "_id": "267171186884F74FFCFAF6EDFD7A80379DF2F6E0",
+      "seq": "GCF_000409795.2",
+      "tax": 60711,
+      "study": "PRJEB7923",
+      "contig": "CM001954.1",
+      "start": NumberLong(92701040),
+      "ref": "G",
+      "alt": "T",
+      "rs": NumberLong(869808637),
+      "accession": NumberLong(1991577882),
+      "version": 1,
+      "createdDate": ISODate(
+      "2016-05-05T13:43:00Z"
+      )
+    },
+    {
       "_id": "40F6E23B8F90B05D4E89B93126AB08ADEB366C14",
       "seq": "GCF_000409795.2",
       "tax": 60711,

--- a/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -33,6 +33,22 @@
       )
     },
     {
+      "_id": "58731F96EC160846B969D5D3EA88BCDF209D2D2D",
+      "seq": "GCF_000409795.2",
+      "tax": 60711,
+      "study": "PRJEB1111",
+      "contig": "CM001954.1",
+      "start": NumberLong(92701040),
+      "ref": "G",
+      "alt": "T",
+      "rs": NumberLong(869808637),
+      "accession": NumberLong(1991577882),
+      "version": 1,
+      "createdDate": ISODate(
+      "2016-05-05T13:43:00Z"
+      )
+    },
+    {
       "_id": "40F6E23B8F90B05D4E89B93126AB08ADEB366C14",
       "seq": "GCF_000409795.2",
       "tax": 60711,

--- a/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -1,0 +1,124 @@
+{
+  "dbsnpSubmittedVariantEntity": [
+    {
+      "_id": "81901D6C149D283D8E00859E8BADC1C89750F88D",
+      "seq": "GCF_000409795.2",
+      "tax": 60711,
+      "study": "PRJEB7923",
+      "contig": "CM001954.1",
+      "start": NumberLong(92701040),
+      "ref": "G",
+      "alt": "A",
+      "rs": NumberLong(869808637),
+      "accession": NumberLong(1991577882),
+      "version": 1,
+      "createdDate": ISODate(
+      "2016-05-05T13:43:00Z"
+      )
+    },
+    {
+      "_id": "40F6E23B8F90B05D4E89B93126AB08ADEB366C14",
+      "seq": "GCF_000409795.2",
+      "tax": 60711,
+      "study": "PRJEB7923",
+      "contig": "CM001941.2",
+      "start": NumberLong(13247923),
+      "ref": "T",
+      "alt": "G",
+      "rs": NumberLong(869927931),
+      "accession": NumberLong(1991294603),
+      "version": 1,
+      "createdDate": ISODate(
+      "2016-05-05T13:31:00Z"
+      )
+    },
+    {
+      "_id": "A3CE9DB4B332C6CD29E6A3A25F4665995E62C5B1",
+      "seq": "GCF_000001735.3",
+      "tax": 3702,
+      "study": "EVA_ARABIDOPSIS_1001_EVA_ARABIDOPSIS_1001_A",
+      "contig": "CP002685.1",
+      "start": NumberLong(4758626),
+      "ref": "G",
+      "alt": "A",
+      "rs": NumberLong(347048227),
+      "accession": NumberLong(
+      "2687490505"
+      ),
+      "version": 1,
+      "createdDate": ISODate(
+      "2017-02-10T14:52:00Z"
+      )
+    },
+    {
+      "_id": "BE58C4DC4D02356FEFDFDE9E1DC335D1000BFA90",
+      "seq": "GCF_000001735.3",
+      "tax": 3702,
+      "study": "EVA_ARABIDOPSIS_1001_EVA_ARABIDOPSIS_1001_A",
+      "contig": "CP002685.1",
+      "start": NumberLong(4758626),
+      "ref": "G",
+      "alt": "T",
+      "rs": NumberLong(347048227),
+      "accession": NumberLong(
+      "2687490504"
+      ),
+      "version": 1,
+      "createdDate": ISODate(
+      "2017-02-10T14:52:00Z"
+      )
+    },
+    {
+      "_id": "5F7794CEDEAFEF55DC5D7ADFA76F424A0587A613",
+      "seq": "GCF_000001735.3",
+      "tax": 3702,
+      "study": "GRAMENE_ARABIDOPSIS_2010 PROJECT-1001 GENOMES",
+      "contig": "CP002685.1",
+      "start": NumberLong(4758626),
+      "ref": "G",
+      "alt": "T",
+      "rs": NumberLong(347048227),
+      "evidence": false,
+      "accession": NumberLong(492411912),
+      "version": 1,
+      "createdDate": ISODate(
+      "2012-03-08T18:51:00Z"
+      )
+    },
+    {
+      "_id": "9EFF976D1A0BFACA9305961962C39CFA330C720B",
+      "seq": "GCF_000001735.3",
+      "tax": 3702,
+      "study": "GRAMENE_ARABIDOPSIS_2010 PROJECT-1001 GENOMES",
+      "contig": "CP002685.1",
+      "start": NumberLong(4758626),
+      "ref": "G",
+      "alt": "A",
+      "rs": NumberLong(347048227),
+      "evidence": false,
+      "accession": NumberLong(492411912),
+      "version": 1,
+      "createdDate": ISODate(
+      "2012-03-08T18:51:00Z"
+      )
+    },
+    {
+      "_id": "A76F3107039B41C98B66A5D692D14525D4172DC4",
+      "seq": "GCF_000001735.3",
+      "tax": 3702,
+      "study": "EVA_ARABIDOPSIS_1001_EVA_ARABIDOPSIS_1001_A",
+      "contig": "CP002685.1",
+      "start": NumberLong(4758626),
+      "ref": "G",
+      "alt": "C",
+      "rs": NumberLong(347048227),
+      "accession": NumberLong(
+      "2687490506"
+      ),
+      "version": 1,
+      "createdDate": ISODate(
+      "2017-02-10T14:52:00Z"
+      )
+    }
+  ]
+}

--- a/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -135,6 +135,22 @@
       "createdDate": ISODate(
       "2017-02-10T14:52:00Z"
       )
+    },
+    {
+      "_id" : "36DCF444101DEC1EBEF3D97F443BF9FA247C9B3A",
+      "seq" : "GCF_000309985.1",
+      "tax" : 3711,
+      "study" : "WENDELL_2012-VNTR",
+      "contig" : "CM001642.1",
+      "start" : NumberLong(7356604),
+      "ref" : "",
+      "alt" : "AGAGCTATGATCTTCGGAAGGAGAAGGAGAAGGAAAAGATTCATGACGTCCAC",
+      "rs" : NumberLong(268233057),
+      "evidence" : false,
+      "validated" : true,
+      "accession" : NumberLong(490570267),
+      "version" : 1,
+      "createdDate" : ISODate("2012-02-17T10:01:00Z")
     }
   ]
 }


### PR DESCRIPTION
Perform the aggregation (with the `$lookup`) to query clustered variants.

**Note**: In another ticket, we need to do a processor to exclude clustered variants that don't have any submitted variants.

The raw MongoDB java driver was used, as our version of Spring Data MongoDB returned the results in a list, not in a cursor. Newer versions of Spring Data MongoDB have what we want, but we would have to migrate to Spring Boot 2.