### PR TITLE
EVA-1362 Write output VCF report (indels bug)

### DIFF
--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/ExcludeInvalidVariantsProcessor.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/ExcludeInvalidVariantsProcessor.java
@@ -40,10 +40,6 @@ public class ExcludeInvalidVariantsProcessor implements ItemProcessor<Variant, V
 
     @Override
     public Variant process(Variant variant) throws Exception {
-        if (variant.getReference().isEmpty() || variant.getAlternate().isEmpty()) {
-            throw new IllegalArgumentException(REFERENCE_AND_ALTERNATE_ALLELES_CANNOT_BE_EMPTY);
-        }
-
         Matcher matcher = ALLELES_PATTERN.matcher(variant.getReference() + variant.getAlternate());
         if(matcher.matches()) {
             return variant;

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/ExcludeInvalidVariantsProcessorTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/ExcludeInvalidVariantsProcessorTest.java
@@ -24,6 +24,7 @@ import org.junit.rules.ExpectedException;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static uk.ac.ebi.eva.accession.release.steps.processors.ExcludeInvalidVariantsProcessor.REFERENCE_AND_ALTERNATE_ALLELES_CANNOT_BE_EMPTY;
 
@@ -148,16 +149,12 @@ public class ExcludeInvalidVariantsProcessorTest {
     @Test
     public void referenceAlleleEmpty() throws Exception {
         Variant variant = newVariant(EMPTY_ALLELE, VALID_ALLELE);
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(REFERENCE_AND_ALTERNATE_ALLELES_CANNOT_BE_EMPTY);
-        processor.process(variant);
+        assertEquals(variant, processor.process(variant));
     }
 
     @Test
     public void alternateAlleleEmpty() throws Exception {
         Variant variant = newVariant(VALID_ALLELE, EMPTY_ALLELE);
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(REFERENCE_AND_ALTERNATE_ALLELES_CANNOT_BE_EMPTY);
-        processor.process(variant);
+        assertEquals(variant, processor.process(variant));
     }
 }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/VariantToVariantContextProcessorTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/VariantToVariantContextProcessorTest.java
@@ -103,6 +103,14 @@ public class VariantToVariantContextProcessorTest {
     }
 
     @Test
+    public void throwsIfAllelesAreEmpty() throws Exception {
+        Variant variant = buildVariant(CHR_1, 1100, "", "G", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
+        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+
+        expectedException.expect(IllegalArgumentException.class);
+        variantConverter.process(variant);
+    }
+    @Test
     public void singleStudySingleNucleotideInsertion() throws Exception {
         Variant variant = buildVariant(CHR_1, 1100, "T", "TG", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
 


### PR DESCRIPTION
There was an impossible cycle where ExcludeInvalidVariantsProcessor complained
if the alleles were empty, but the ContextNucleotideAdditionProcessor is
put afterwards, to avoid adding nucleotides to alleles with strange characters.

we can remove the check from ExcludeInvalidVariantsProcessor because the
VariantToVariantContextProcessor is after the other processors and also
checks for empty alleles