### PR TITLE
EVA-1432 Fix problem when not passing forceImport parameter

### DIFF
--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/deciders/ForceImportDecider.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/deciders/ForceImportDecider.java
@@ -35,7 +35,7 @@ public class ForceImportDecider implements JobExecutionDecider {
 
     @Override
     public FlowExecutionStatus decide(JobExecution jobExecution, StepExecution stepExecution) {
-        String forceImport = inputParameters.getForceImport().toUpperCase();
+        String forceImport = Boolean.toString(inputParameters.isForceImport()).toUpperCase();
         logger.info("Continue importing if a contig is not found in assembly report: {}", forceImport);
         return new FlowExecutionStatus(forceImport);
     }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/parameters/InputParameters.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/parameters/InputParameters.java
@@ -38,7 +38,7 @@ public class InputParameters {
 
     private int pageSize;
 
-    private String forceImport;
+    private boolean forceImport;
 
     public JobParameters toJobParameters() {
         return new JobParametersBuilder()
@@ -125,11 +125,11 @@ public class InputParameters {
         this.buildNumber = buildNumber;
     }
 
-    public String getForceImport() {
+    public boolean isForceImport() {
         return forceImport;
     }
 
-    public void setForceImport(String forceImport) {
+    public void setForceImport(boolean forceImport) {
         this.forceImport = forceImport;
     }
 }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/configuration/ImportDbsnpVariantsJobConfigurationFailValidationStepTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/configuration/ImportDbsnpVariantsJobConfigurationFailValidationStepTest.java
@@ -54,7 +54,7 @@ public class ImportDbsnpVariantsJobConfigurationFailValidationStepTest {
     @Test
     @DirtiesContext
     public void executeJobTrueForceImport() throws Exception {
-        inputParameters.setForceImport("true");
+        inputParameters.setForceImport(true);
         JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
         List<String> expectedSteps = Collections.singletonList(IMPORT_DBSNP_VARIANTS_STEP);
@@ -65,7 +65,7 @@ public class ImportDbsnpVariantsJobConfigurationFailValidationStepTest {
     @Test
     @DirtiesContext
     public void executeJobFalseForceImport() throws Exception {
-        inputParameters.setForceImport("false");
+        inputParameters.setForceImport(false);
         JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
         List<String> expectedSteps = Collections.singletonList(VALIDATE_CONTIGS_STEP);

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/configuration/ImportDbsnpVariantsJobConfigurationTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/configuration/ImportDbsnpVariantsJobConfigurationTest.java
@@ -55,7 +55,7 @@ public class ImportDbsnpVariantsJobConfigurationTest {
     @Test
     @DirtiesContext
     public void executeJobTrueForceImport() throws Exception {
-        inputParameters.setForceImport("true");
+        inputParameters.setForceImport(true);
         JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
         List<String> expectedSteps = Collections.singletonList(IMPORT_DBSNP_VARIANTS_STEP);
@@ -66,7 +66,17 @@ public class ImportDbsnpVariantsJobConfigurationTest {
     @Test
     @DirtiesContext
     public void executeJobFalseForceImport() throws Exception {
-        inputParameters.setForceImport("false");
+        inputParameters.setForceImport(false);
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+
+        List<String> expectedSteps = Arrays.asList(VALIDATE_CONTIGS_STEP, IMPORT_DBSNP_VARIANTS_STEP);
+        assertStepsExecuted(expectedSteps, jobExecution);
+        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+    }
+
+    @Test
+    @DirtiesContext
+    public void executeJobEmptyForceImport() throws Exception {
         JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
         List<String> expectedSteps = Arrays.asList(VALIDATE_CONTIGS_STEP, IMPORT_DBSNP_VARIANTS_STEP);

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/runner/DbsnpImportVariantsJobLauncherCommandLineRunnerTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/runner/DbsnpImportVariantsJobLauncherCommandLineRunnerTest.java
@@ -66,7 +66,7 @@ public class DbsnpImportVariantsJobLauncherCommandLineRunnerTest {
     @Test
     @DirtiesContext
     public void runSuccessfulJob() throws Exception {
-        inputParameters.setForceImport("true");
+        inputParameters.setForceImport(true);
         runner.run();
         assertEquals(DbsnpImportVariantsJobLauncherCommandLineRunner.EXIT_WITHOUT_ERRORS, runner.getExitCode());
     }
@@ -74,7 +74,7 @@ public class DbsnpImportVariantsJobLauncherCommandLineRunnerTest {
     @Test
     @DirtiesContext
     public void runFailingJob() throws Exception {
-        inputParameters.setForceImport("false");
+        inputParameters.setForceImport(false);
         runner.run();
         assertEquals(DbsnpImportVariantsJobLauncherCommandLineRunner.EXIT_WITH_ERRORS, runner.getExitCode());
     }
@@ -82,13 +82,13 @@ public class DbsnpImportVariantsJobLauncherCommandLineRunnerTest {
     @Test
     @DirtiesContext
     public void resumeFailingJob() throws Exception {
-        inputParameters.setForceImport("false");
+        inputParameters.setForceImport(false);
         runner.run();
         long instanceIdAfterFailingJob = jobExplorer.getJobInstances(IMPORT_DBSNP_VARIANTS_JOB, 0, 1).get(0)
                                                     .getInstanceId();
         assertEquals(DbsnpImportVariantsJobLauncherCommandLineRunner.EXIT_WITH_ERRORS, runner.getExitCode());
 
-        inputParameters.setForceImport("true");
+        inputParameters.setForceImport(true);
         runner.run();
         long instanceIdAfterSuccessfulJob = jobExplorer.getJobInstances(IMPORT_DBSNP_VARIANTS_JOB, 0, 1).get(0)
                                                        .getInstanceId();

--- a/eva-accession-import/src/test/resources/validate-contigs.properties
+++ b/eva-accession-import/src/test/resources/validate-contigs.properties
@@ -14,6 +14,5 @@ parameters.taxonomyAccession=9031
 parameters.forceRestart=false
 parameters.chunkSize=100
 parameters.pageSize=100
-parameters.forceImport=false
 
 mongodb.read-preference=primary


### PR DESCRIPTION
Pipeline was failing if `forceImport` parameter was not set in the properties file.

The type for the input parameter `forceImport` was changed from String to boolean, default value will be false. 