### PR TITLE
EVA-1436 Prepare FASTA file with all INSDC sequences in an assembly report

### DIFF
--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -20,7 +20,7 @@ do
 
     # Download each GenBank accession in the assembly report from ENA into a separate file
     # Delete the accession prefix from the header line
-    wget -q -O - "https://www.ebi.ac.uk/ena/data/view/${genbank_contig}&display=fasta" | sed 's/ENA|.*|//g' > ${genbank_contig}
+    wget -q -O - "https://www.ebi.ac.uk/ena/browser/api/fasta/${genbank_contig}" | sed 's/ENA|.*|//g' > ${genbank_contig}
 
     # If a file has more than one line, then it is concatenated into the full assembly FASTA file
     # (empty sequences can't be indexed)

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -2,7 +2,7 @@
 
 # Usage: create_fasta_from_assembly_report.sh </path/to/assembly_report.txt>
 
-if [ "$#" -lt 3 ]
+if [ "$#" -ne 3 ]
 then
     echo "Please provide the assembly accession, the path to the assembly report and the output folder."
     exit 1
@@ -22,7 +22,7 @@ do
 
     # If a file has more than one line, then it is concatenated into the full assembly FASTA file
     # (empty sequences can't be indexed)
-    lines=`wc -l ${i} | cut -f1 -d' '`
+    lines=`head -n 2 ${i} | wc -l`
     if [ $lines -ne 1 ]
     then
         cat ${i} >> ${output_folder}/${assembly_accession}.fa

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: create_fasta_from_assembly_report.sh </path/to/assembly_report.txt>
+# Usage: create_fasta_from_assembly_report.sh <assembly accession> </path/to/assembly_report.txt> <output folder>
 
 if [ "$#" -ne 3 ]
 then

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -12,31 +12,31 @@ assembly_accession=$1
 assembly_report=$2
 output_folder=$3
 
-for i in `grep -v -e "^#" ${assembly_report} | cut -f5`;
+for genbank_contig in `grep -v -e "^#" ${assembly_report} | cut -f5`;
 do
-    echo ${i}
+    echo ${genbank_contig}
 
     # Download each GenBank accession in the assembly report from ENA into a separate file
     # Delete the accession prefix from the header line
-    wget -q -O - "https://www.ebi.ac.uk/ena/data/view/${i}&display=fasta" | sed 's/ENA|.*|//g' > ${i}
+    wget -q -O - "https://www.ebi.ac.uk/ena/data/view/${genbank_contig}&display=fasta" | sed 's/ENA|.*|//g' > ${genbank_contig}
 
     # If a file has more than one line, then it is concatenated into the full assembly FASTA file
     # (empty sequences can't be indexed)
-    lines=`head -n 2 ${i} | wc -l`
+    lines=`head -n 2 ${genbank_contig} | wc -l`
     if [ $lines -ne 1 ]
     then
-        cat ${i} >> ${output_folder}/${assembly_accession}.fa
+        cat ${genbank_contig} >> ${output_folder}/${assembly_accession}.fa
     else
-        echo FASTA sequence not available for ${i}
+        echo FASTA sequence not available for ${genbank_contig}
     fi
 
     # Check that an accession is present no more than once in the output FASTA file, otherwise it 
     # means there are unexpected aliases in the assembly report, which need to be checked
-    acc=`head -n 1 ${i} | cut -f1 -d' ' | cut -f1 -d'.' | cut -f2 -d'>'`
+    acc=`head -n 1 ${genbank_contig} | cut -f1 -d' ' | cut -f1 -d'.' | cut -f2 -d'>'`
     matches=`grep -c "${acc}" ${output_folder}/${assembly_accession}.fa`
     if [ $matches -gt 1 ]
     then
-        echo WARNING: Sequence ${i} found more than once in the output FASTA file
+        echo WARNING: Sequence ${genbank_contig} found more than once in the output FASTA file
     fi
 done
 

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -32,8 +32,8 @@ do
 
     # Check that an accession is present no more than once in the output FASTA file, otherwise it 
     # means there are unexpected aliases in the assembly report, which need to be checked
-    acc=`head -n 1 ${genbank_contig} | cut -f1 -d' ' | cut -f1 -d'.' | cut -f2 -d'>'`
-    matches=`grep -c "${acc}" ${output_folder}/${assembly_accession}.fa`
+    accession=`head -n 1 ${genbank_contig} | cut -f1 -d' ' | cut -f1 -d'.' | cut -f2 -d'>'`
+    matches=`grep -c "${accession}" ${output_folder}/${assembly_accession}.fa`
     if [ $matches -gt 1 ]
     then
         echo WARNING: Sequence ${genbank_contig} found more than once in the output FASTA file

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -12,6 +12,8 @@ assembly_accession=$1
 assembly_report=$2
 output_folder=$3
 
+exit_code=0
+
 for genbank_contig in `grep -v -e "^#" ${assembly_report} | cut -f5`;
 do
     echo ${genbank_contig}
@@ -37,6 +39,9 @@ do
     if [ $matches -gt 1 ]
     then
         echo WARNING: Sequence ${genbank_contig} found more than once in the output FASTA file
+        exit_code=1
     fi
 done
+
+exit $exit_code
 

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Usage: create_fasta_from_assembly_report.sh </path/to/assembly_report.txt>
+
+if [ "$#" -lt 3 ]
+then
+    echo "Please provide the assembly accession, the path to the assembly report and the output folder."
+    exit 1
+fi
+
+assembly_accession=$1
+assembly_report=$2
+output_folder=$3
+
+for i in `grep -v -e "^#" ${assembly_report} | cut -f5`;
+do
+    echo ${i}
+
+    # Download each GenBank accession in the assembly report from ENA into a separate file
+    # Delete the accession prefix from the header line
+    wget -q -O - "https://www.ebi.ac.uk/ena/data/view/${i}&display=fasta" | sed 's/ENA|.*|//g' > ${i}
+
+    # If a file has more than one line, then it is concatenated into the full assembly FASTA file
+    # (empty sequences can't be indexed)
+    lines=`wc -l ${i} | cut -f1 -d' '`
+    if [ $lines -ne 1 ]
+    then
+        cat ${i} >> ${output_folder}/${assembly_accession}.fa
+    else
+        echo FASTA sequence not available for ${i}
+    fi
+
+    # Check that an accession is present no more than once in the output FASTA file, otherwise it 
+    # means there are aliases in the assembly report
+    acc=`head -n 1 ${i} | cut -f1 -d' ' | cut -f1 -d'.' | cut -f2 -d'>'`
+    matches=`grep -c "${acc}" ${output_folder}/${assembly_accession}.fa`
+    if [ $matches -gt 1 ]
+    then
+        echo WARNING: Sequence ${i} found more than once in the output FASTA file
+    fi
+done
+

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -31,7 +31,7 @@ do
     fi
 
     # Check that an accession is present no more than once in the output FASTA file, otherwise it 
-    # means there are aliases in the assembly report
+    # means there are unexpected aliases in the assembly report, which need to be checked
     acc=`head -n 1 ${i} | cut -f1 -d' ' | cut -f1 -d'.' | cut -f2 -d'>'`
     matches=`grep -c "${acc}" ${output_folder}/${assembly_accession}.fa`
     if [ $matches -gt 1 ]


### PR DESCRIPTION
Given an assembly report, download the FASTA sequence for all the GenBank accessions listed in it, and build a FASTA file that should cover all those present in the dbSNP database.

This script only works for RefSeq sequences which have GenBank equivalents. It is not possible to download RefSeq-only sequences from ENA, and there is no easy way to retrieve them from NCBI either :disappointed: 