### PR TITLE
EVA-1437 Populate properties file with provided parameters

### DIFF
--- a/eva-accession-import-automation/README.md
+++ b/eva-accession-import-automation/README.md
@@ -1,7 +1,7 @@
 # Pre-requisites
 * Install the **pandas** and **psycopg2** modules in your local python environment
     ```bash
-    pip install -r requirements
+    pip install -r requirements.txt
     ```
 # Usage
 ## Generate custom assembly report
@@ -13,7 +13,7 @@
     ```bash
     python generate_custom_assembly_report.py -d metadata_db_name -u metadata_db_user -h metadata_db_host -s bony_fish_7950 -a GCF_000966335.1 -g "/path/to/identical_genbank_refseq_4snp_assembly_report.txt"
     ```
-    ## Running tests
+* Running tests
     ```bash
     python -m test_generate_custom_assembly_report -v
     ```

--- a/eva-accession-import-automation/README.md
+++ b/eva-accession-import-automation/README.md
@@ -1,9 +1,10 @@
 # Pre-requisites
-* Install the **pandas** module in your local python environment
+* Install the **pandas** and **psycopg2** modules in your local python environment
     ```bash
-    pip install pandas --user
+    pip install -r requirements
     ```
 # Usage
+## Generate custom assembly report
 * Get help
     ```bash 
     python generate_custom_assembly_report.py -h
@@ -15,4 +16,14 @@
     ## Running tests
     ```bash
     python -m test_generate_custom_assembly_report -v
+    ```
+
+## Generate properties file
+* Get help
+    ```bash
+    python generate_properties.py --help
+    ```
+* Example
+    ```bash
+    python generate_properties.py -b 150 -a GCA_000001735.1 -r GCF_000001735.3_TAIR10_assembly_report_CUSTOM.txt  -f /path/to/fasta.fa  -d meadata_db_name -u metadata_db_user -h metadata_db_host   -H job_tracker_host -D job_tracker_db  --mongo-acc-db mongo_accessioning_db --mongo-auth-db mongo_auth_db --mongo-user mongo_user --mongo-password mongo_password  --mongo-host mongo_host --mongo-port mongo_port -s arabidopsis_3702
     ```

--- a/eva-accession-import-automation/data_ops.py
+++ b/eva-accession-import-automation/data_ops.py
@@ -71,7 +71,6 @@ def get_species_info(pg_metadata_dbname, pg_metadata_user, pg_metadata_host,
 def get_assembly_name(species_db_info, build):
     pg_conn = get_pg_conn_for_species(species_db_info)
     pg_cursor = pg_conn.cursor()
-    contiginfo_tables = get_contiginfo_table_list_for_schema(pg_cursor, species_db_info["database_name"])
 
     table_name = "dbsnp_{}.b{}_contiginfo".format(species_db_info["database_name"], build)
     pg_cursor.execute("select distinct group_label from {}".format(table_name))

--- a/eva-accession-import-automation/data_ops.py
+++ b/eva-accession-import-automation/data_ops.py
@@ -44,7 +44,8 @@ def get_species_pg_conn_info(pg_metadata_dbname, pg_metadata_user, pg_metadata_h
 def get_species_info(pg_metadata_dbname, pg_metadata_user, pg_metadata_host,
                      assembly_accession):
     """
-    Get information about an assembly accession
+    Get information about an assembly accession. This won't work for previous builds, because the
+    table 'import_progress' only contains information about the latest assembly in each species.
 
     :param pg_metadata_dbname: Metadata database name
     :param pg_metadata_user: Metadata user name

--- a/eva-accession-import-automation/data_ops.py
+++ b/eva-accession-import-automation/data_ops.py
@@ -41,34 +41,6 @@ def get_species_pg_conn_info(pg_metadata_dbname, pg_metadata_user, pg_metadata_h
     return species_set
 
 
-def get_species_info(pg_metadata_dbname, pg_metadata_user, pg_metadata_host,
-                     assembly_accession):
-    """
-    Get information about an assembly accession. This won't work for previous builds, because the
-    table 'import_progress' only contains information about the latest assembly in each species.
-
-    :param pg_metadata_dbname: Metadata database name
-    :param pg_metadata_user: Metadata user name
-    :param pg_metadata_host: Host where the metadata database resides
-    :param assembly_accession: species to query, e.g. GCA_000001735.1
-    :return: Dictionary with species information
-    """
-    pg_conn = psycopg2.connect("dbname='{0}' user='{1}' host='{2}'".
-                               format(pg_metadata_dbname, pg_metadata_user, pg_metadata_host))
-    pg_cursor = pg_conn.cursor()
-    pg_cursor.execute("select database_name, tax_id from dbsnp_ensembl_species.import_progress i "
-                      " where genbank_assembly_accession = '{}'".format(assembly_accession))
-    species = [{"database_name": result[0], "taxonomy": result[1]}
-               for result in pg_cursor.fetchall()]
-    pg_cursor.close()
-    pg_conn.close()
-    if len(species) == 0:
-        raise Exception("No species with assembly {} in table import_progress".format(assembly_accession))
-    if len(species) > 1:
-        raise Exception("More than one species with assembly {} in table import_progress".format(assembly_accession))
-    return species[0]
-
-
 def get_assembly_name(species_db_info, build):
     pg_conn = get_pg_conn_for_species(species_db_info)
     pg_cursor = pg_conn.cursor()

--- a/eva-accession-import-automation/data_ops.py
+++ b/eva-accession-import-automation/data_ops.py
@@ -50,7 +50,7 @@ def get_species_info(pg_metadata_dbname, pg_metadata_user, pg_metadata_host,
     :param pg_metadata_user: Metadata user name
     :param pg_metadata_host: Host where the metadata database resides
     :param assembly_accession: species to query, e.g. GCA_000001735.1
-    :return: List of dictionaries with species information for each species
+    :return: Dictionary with species information
     """
     pg_conn = psycopg2.connect("dbname='{0}' user='{1}' host='{2}'".
                                format(pg_metadata_dbname, pg_metadata_user, pg_metadata_host))

--- a/eva-accession-import-automation/generate_custom_assembly_report.py
+++ b/eva-accession-import-automation/generate_custom_assembly_report.py
@@ -183,7 +183,9 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--metadb", help="Postgres metadata DB", required=True)
     parser.add_argument("-u", "--metauser", help="Postgres metadata DB username", required=True)
     parser.add_argument("-h", "--metahost", help="Postgres metadata DB host", required=True)
-    parser.add_argument("-s", "--species", help="Species for which the process has to be run", required=True)
+    parser.add_argument("-s", "--species",
+                        help="Species for which the process has to be run, e.g. chicken_9031",
+                        required=True)
     parser.add_argument("-a", "--assembly-accession", help="Assembly for which the process has to be run",
                         required=True)
     parser.add_argument("-g", "--genbank-equivalents-file", help="File with GenBank equivalents for RefSeq accessions",

--- a/eva-accession-import-automation/generate_properties.py
+++ b/eva-accession-import-automation/generate_properties.py
@@ -89,7 +89,7 @@ spring.jpa.generate-ddl=true
 
 spring.data.mongodb.host={args.mongo_host}
 spring.data.mongodb.port={args.mongo_port}
-spring.data.mongodb.database={args.mongo_db}
+spring.data.mongodb.database={args.mongo_acc_db}
 spring.data.mongodb.username={args.mongo_user}
 spring.data.mongodb.password={args.mongo_password}
 spring.data.mongodb.authentication-database={args.mongo_auth_db}
@@ -101,7 +101,7 @@ logging.level.uk.ac.ebi.eva.accession.dbsnp=DEBUG
 logging.level.uk.ac.ebi.eva.accession.dbsnp.listeners=INFO
 logging.level.org.springframework.jdbc.datasource=DEBUG
 """
-    properties_filename = "{}.properties".format(args.assembly_accession)
+    properties_filename = "{}_{}.properties".format(args.build, args.assembly_accession)
     with open(properties_filename, "w") as properties_file:
         properties_file.write(template.format(args=args))
 
@@ -136,8 +136,7 @@ if __name__ == "__main__":
     parser.add_argument("-a", "--assembly-accession",
                         help="Assembly for which the process has to be run, e.g. GCA_000002315.3",
                         required=True)
-    parser.add_argument("-r", "--assembly-report",
-                        help="File with GenBank equivalents for RefSeq accessions", required=True)
+    parser.add_argument("-r", "--assembly-report", help="File with contig synonyms", required=True)
     parser.add_argument("-f", "--fasta", help="FASTA file with the reference sequence",
                         required=True)
 
@@ -150,8 +149,8 @@ if __name__ == "__main__":
     parser.add_argument("-H", "--job-tracker-host", help="Postgres host for the job repository",
                         required=True)
 
-    parser.add_argument("--mongo-db", help="MongoDB accessioning database", required=True)
-    parser.add_argument("--mongo-auth-db", help="MongoDB accessioning authentication database",
+    parser.add_argument("--mongo-acc-db", help="MongoDB accessioning database", required=True)
+    parser.add_argument("--mongo-auth-db", help="MongoDB authentication database for accessioning",
                         required=True)
     parser.add_argument("--mongo-user", help="MongoDB user", required=True)
     parser.add_argument("--mongo-password", help="MongoDB password", required=True)

--- a/eva-accession-import-automation/generate_properties.py
+++ b/eva-accession-import-automation/generate_properties.py
@@ -101,7 +101,7 @@ logging.level.uk.ac.ebi.eva.accession.dbsnp=DEBUG
 logging.level.uk.ac.ebi.eva.accession.dbsnp.listeners=INFO
 logging.level.org.springframework.jdbc.datasource=DEBUG
 """
-    properties_filename = "{}_{}.properties".format(args.build, args.assembly_accession)
+    properties_filename = "{}_b{}.properties".format(args.assembly_accession, args.build)
     with open(properties_filename, "w") as properties_file:
         properties_file.write(template.format(args=args))
 

--- a/eva-accession-import-automation/generate_properties.py
+++ b/eva-accession-import-automation/generate_properties.py
@@ -17,11 +17,12 @@ def query_missing_parameters(args):
                                              args.assembly_accession)
 
     species_db_info = \
-        filter(lambda db_info: db_info["database_name"] == species_info["database_name"],
+        list(filter(lambda db_info: db_info["database_name"] == species_info["database_name"],
                data_ops.get_species_pg_conn_info(args.metadb,
                                                  args.metauser,
                                                  args.metahost)
-               )[0]
+               ))[0]
+    species_db_info = species_db_info
 
     dbsnp_user, dbsnp_password, unused_dbsnp_port = \
         get_user_and_password_and_port_from_pgpass_for_host(species_db_info["pg_host"])

--- a/eva-accession-import-automation/generate_properties.py
+++ b/eva-accession-import-automation/generate_properties.py
@@ -11,18 +11,12 @@ def main(args):
 
 
 def query_missing_parameters(args):
-    species_info = data_ops.get_species_info(args.metadb,
-                                             args.metauser,
-                                             args.metahost,
-                                             args.assembly_accession)
-
     species_db_info = \
-        list(filter(lambda db_info: db_info["database_name"] == species_info["database_name"],
+        list(filter(lambda db_info: db_info["database_name"] == args.species,
                data_ops.get_species_pg_conn_info(args.metadb,
                                                  args.metauser,
                                                  args.metahost)
                ))[0]
-    species_db_info = species_db_info
 
     dbsnp_user, dbsnp_password, unused_dbsnp_port = \
         get_user_and_password_and_port_from_pgpass_for_host(species_db_info["pg_host"])
@@ -40,11 +34,11 @@ def query_missing_parameters(args):
     else:
         complete_args.optional_build_line = "parameters.buildNumber={}".format(args.build)
 
-    complete_args.taxonomy = species_info["taxonomy"]
+    complete_args.taxonomy = args.species.split('_')[-1]
     complete_args.dbsnp_host = species_db_info["pg_host"]
     complete_args.dbsnp_port = species_db_info["pg_port"]
     complete_args.dbsnp_build = species_db_info["dbsnp_build"]
-    complete_args.database_name = species_info["database_name"]
+    complete_args.database_name = args.species
     complete_args.dbsnp_user = dbsnp_user
     complete_args.dbsnp_password = dbsnp_password
     complete_args.job_tracker_port = jt_port
@@ -133,6 +127,9 @@ if __name__ == "__main__":
     parser.add_argument("-n", "--assembly-name",
                         help="Assembly name for which the process has to be run, e.g. Gallus_gallus-5.0"
                              ". (Can be ommited if there is only one assembly name in the build)")
+    parser.add_argument("-s", "--species",
+                        help="Species for which the process has to be run, e.g. chicken_9031",
+                        required=True)
     parser.add_argument("-a", "--assembly-accession",
                         help="Assembly for which the process has to be run, e.g. GCA_000002315.3",
                         required=True)

--- a/eva-accession-import-automation/generate_properties.py
+++ b/eva-accession-import-automation/generate_properties.py
@@ -1,0 +1,193 @@
+import logging
+import sys
+import argparse
+import data_ops
+from os.path import expanduser
+
+
+def main(parameters, evapro_credentials, job_tracker_credentials, mongo_credentials):
+    template = """
+spring.batch.job.names=IMPORT_DBSNP_VARIANTS_JOB
+
+accessioning.instanceId=instance-import
+accessioning.variant.categoryId=ss
+accessioning.monotonic.ss.nextBlockInterval=10000
+accessioning.monotonic.ss.blockStartValue=10000
+accessioning.monotonic.ss.blockSize=1000
+
+parameters.assemblyAccession={assembly_accession}
+parameters.assemblyName={assembly_name}
+parameters.assemblyReportUrl=file:{assembly_report}
+parameters.taxonomyAccession={taxonomy}
+parameters.chunkSize=1000
+parameters.pageSize=100
+#parameters.forceRestart=true
+parameters.fasta={fasta}
+{optional_build_line}
+
+spring.batch.job.names=CREATE_SUBSNP_ACCESSION_JOB
+
+dbsnp.datasource.driver-class-name=org.postgresql.Driver
+dbsnp.datasource.url=jdbc:postgresql://{dbsnp_host}:{dbsnp_port}/dbsnp_{dbsnp_build}?currentSchema=dbsnp_{dbsnp_species}
+dbsnp.datasource.username={dbsnp_user}
+dbsnp.datasource.password={dbsnp_password}
+dbsnp.datasource.tomcat.max-active=3
+
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=jdbc:postgresql://{jt_host}:{jt_port}/{jt_db}
+spring.datasource.username={jt_user}
+spring.datasource.password={jt_password}
+spring.datasource.tomcat.max-active=3
+spring.jpa.generate-ddl=true
+ 
+spring.data.mongodb.host={mongo_host}
+spring.data.mongodb.port={mongo_port}
+spring.data.mongodb.database={mongo_db}
+spring.data.mongodb.username={mongo_user}
+spring.data.mongodb.password={mongo_password}
+spring.data.mongodb.authentication-database={mongo_auth_db}
+mongodb.read-preference=primaryPreferred
+
+spring.main.web-environment=false
+
+logging.level.uk.ac.ebi.eva.accession.dbsnp=DEBUG
+logging.level.uk.ac.ebi.eva.accession.dbsnp.listeners=INFO
+logging.level.org.springframework.jdbc.datasource=DEBUG
+"""
+    species_db_info = filter(lambda db_info: db_info["database_name"] == parameters["species"],
+                             data_ops.get_species_pg_conn_info(evapro_credentials["metadb"],
+                                                               evapro_credentials["metauser"],
+                                                               evapro_credentials["metahost"])
+                             )[0]
+    pg_conn_for_species = data_ops.get_pg_conn_for_species(species_db_info)
+    dbsnp_user, dbsnp_password = get_user_and_password_from_pgpass_for_host(
+        species_db_info["pg_host"])
+    jt_user, jt_password = get_user_and_password_from_pgpass_for_host(
+        job_tracker_credentials["job_tracker_host"])
+    properties_filename = "{}.properties".format(parameters["assembly_accession"])
+    with open(properties_filename, "w") as properties_file:
+        properties_file.write(template.format(
+            assembly_accession=parameters["assembly_accession"],
+            assembly_name=parameters["assembly_name"],
+            assembly_report=parameters["assembly_report"],
+            taxonomy=parameters["taxonomy"],
+            fasta=parameters["fasta"],
+            dbsnp_host=species_db_info["pg_host"],
+            dbsnp_port=species_db_info["pg_port"],
+            dbsnp_build=species_db_info["dbsnp_build"],
+            dbsnp_species=parameters["species"],
+            optional_build_line="parameters.buildNumber={}".format(parameters["build"]) if parameters["latest_build"] else "",
+            dbsnp_user=dbsnp_user,
+            dbsnp_password=dbsnp_password,
+            jt_host=job_tracker_credentials["job_tracker_host"],
+            jt_port=job_tracker_credentials["job_tracker_port"],
+            jt_db=job_tracker_credentials["job_tracker_db"],
+            jt_user=jt_user,
+            jt_password=jt_password,
+            mongo_host=mongo_credentials["mongo_host"],
+            mongo_port=mongo_credentials["mongo_port"],
+            mongo_db=mongo_credentials["mongo_db"],
+            mongo_user=mongo_credentials["mongo_user"],
+            mongo_password=mongo_credentials["mongo_password"],
+            mongo_auth_db=mongo_credentials["mongo_auth_db"]))
+
+
+def get_user_and_password_from_pgpass_for_host(pg_host):
+    with open(expanduser("~/.pgpass")) as pgpass_file:
+        for line in pgpass_file:
+            if line.split(':', 1)[0] == pg_host:
+                fields = line.split(':')
+                return fields[3], fields[4]
+
+
+def init_logger():
+    logging.basicConfig(level=logging.INFO, format='%(asctime)-15s %(levelname)s %(message)s')
+    result_logger = logging.getLogger(__name__)
+    return result_logger
+
+
+if __name__ == "__main__":
+    logger = init_logger()
+
+    parser = argparse.ArgumentParser(
+        description='Generate a properties file that can be used for eva-accession-import',
+        add_help=False)
+    parser.add_argument("-b", "--build", help="dbSNP build number", required=True)
+    parser.add_argument("-l", "--latest-build",
+                        help="Flag that this build is the latest (relevant for dbsnp table name)",
+                        action='store_true')
+    parser.add_argument("-s", "--species",
+                        help="Species for which the process has to be run, e.g. chicken_9031",
+                        required=True)
+    parser.add_argument("-n", "--assembly-name",
+                        help="Assembly name for which the process has to be run, e.g. Gallus_gallus-5.0",
+                        required=True)
+    parser.add_argument("-a", "--assembly-accession",
+                        help="Assembly for which the process has to be run, e.g. GCA_000002315.3",
+                        required=True)
+    parser.add_argument("-r", "--assembly-report",
+                        help="File with GenBank equivalents for RefSeq accessions", required=True)
+    parser.add_argument("-t", "--taxonomy", help="Taxomomy of the species, e.g. 9031",
+                        required=True)
+    parser.add_argument("-f", "--fasta", help="FASTA file with the reference sequence",
+                        required=True)
+    parser.add_argument("-i", "--instance",
+                        help="Accessioning instance id (don't use the same instance concurrently!)",
+                        required=True)
+
+    parser.add_argument("-d", "--metadb", help="Postgres metadata DB", required=True)
+    parser.add_argument("-u", "--metauser", help="Postgres metadata DB username", required=True)
+    parser.add_argument("-h", "--metahost", help="Postgres metadata DB host", required=True)
+
+    parser.add_argument("-D", "--job-tracker-db", help="Postgres DB for the job repository",
+                        required=True)
+    parser.add_argument("-U", "--job-tracker-user",
+                        help="Postgres username for the job repository", required=True)
+    parser.add_argument("-H", "--job-tracker-host", help="Postgres host for the job repository",
+                        required=True)
+    parser.add_argument("-P", "--job-tracker-port", help="Postgres port for the job repository",
+                        required=True)
+
+    parser.add_argument("--mongo-db", help="MongoDB accessioning database", required=True)
+    parser.add_argument("--mongo-auth-db", help="MongoDB accessioning authentication database",
+                        required=True)
+    parser.add_argument("--mongo-user", help="MongoDB user", required=True)
+    parser.add_argument("--mongo-password", help="MongoDB password", required=True)
+    parser.add_argument("--mongo-host", help="MongoDB host", required=True)
+    parser.add_argument("--mongo-port", help="MongoDB port", required=True)
+    parser.add_argument('--help', action='help', help='Show this help message and exit')
+
+    try:
+        args = parser.parse_args()
+
+        parameters = {"assembly_name": args.assembly_name,
+                      "assembly_accession": args.assembly_accession,
+                      "assembly_report": args.assembly_report,
+                      "taxonomy": args.taxonomy,
+                      "species": args.species,
+                      "build": args.build,
+                      "latest_build": args.latest_build,
+                      "fasta": args.fasta}
+
+        evapro_credentials = {"metadb": args.metadb,
+                              "metauser": args.metauser,
+                              "metahost": args.metahost}
+
+        job_tracker_credentials = {"job_tracker_db": args.job_tracker_db,
+                                   "job_tracker_user": args.job_tracker_user,
+                                   "job_tracker_host": args.job_tracker_host,
+                                   "job_tracker_port": args.job_tracker_port}
+
+        mongo_credentials = {"mongo_db": args.mongo_db,
+                             "mongo_auth_db": args.mongo_auth_db,
+                             "mongo_user": args.mongo_user,
+                             "mongo_password": args.mongo_password,
+                             "mongo_host": args.mongo_host,
+                             "mongo_port": args.mongo_port}
+
+        main(parameters, evapro_credentials, job_tracker_credentials, mongo_credentials)
+    except Exception as ex:
+        logger.exception(ex)
+        sys.exit(1)
+
+    sys.exit(0)

--- a/eva-accession-import-automation/generate_properties.py
+++ b/eva-accession-import-automation/generate_properties.py
@@ -17,11 +17,11 @@ def query_missing_parameters(args):
                                              args.assembly_accession)
 
     species_db_info = \
-    filter(lambda db_info: db_info["database_name"] == species_info["database_name"],
-           data_ops.get_species_pg_conn_info(args.metadb,
-                                             args.metauser,
-                                             args.metahost)
-           )[0]
+        filter(lambda db_info: db_info["database_name"] == species_info["database_name"],
+               data_ops.get_species_pg_conn_info(args.metadb,
+                                                 args.metauser,
+                                                 args.metahost)
+               )[0]
 
     dbsnp_user, dbsnp_password, unused_dbsnp_port = \
         get_user_and_password_and_port_from_pgpass_for_host(species_db_info["pg_host"])
@@ -125,12 +125,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Generate a properties file that can be used for eva-accession-import',
         add_help=False)
-    parser.add_argument("-b", "--build", help="dbSNP build number", required=True)
+    parser.add_argument("-b", "--build", help="dbSNP build number, e.g. 151", required=True)
     parser.add_argument("-l", "--latest-build",
                         help="Flag that this build is the latest (relevant for dbsnp table name)",
                         action='store_true')
     parser.add_argument("-n", "--assembly-name",
-                        help="Assembly name for which the process has to be run, e.g. Gallus_gallus-5.0")
+                        help="Assembly name for which the process has to be run, e.g. Gallus_gallus-5.0"
+                             ". (Can be ommited if there is only one assembly name in the build)")
     parser.add_argument("-a", "--assembly-accession",
                         help="Assembly for which the process has to be run, e.g. GCA_000002315.3",
                         required=True)

--- a/eva-accession-import-automation/generate_properties.py
+++ b/eva-accession-import-automation/generate_properties.py
@@ -22,10 +22,9 @@ parameters.taxonomyAccession={taxonomy}
 parameters.chunkSize=1000
 parameters.pageSize=100
 #parameters.forceRestart=true
+#parameters.forceImport=false
 parameters.fasta={fasta}
 {optional_build_line}
-
-spring.batch.job.names=CREATE_SUBSNP_ACCESSION_JOB
 
 dbsnp.datasource.driver-class-name=org.postgresql.Driver
 dbsnp.datasource.url=jdbc:postgresql://{dbsnp_host}:{dbsnp_port}/dbsnp_{dbsnp_build}?currentSchema=dbsnp_{dbsnp_species}
@@ -39,7 +38,7 @@ spring.datasource.username={jt_user}
 spring.datasource.password={jt_password}
 spring.datasource.tomcat.max-active=3
 spring.jpa.generate-ddl=true
- 
+
 spring.data.mongodb.host={mongo_host}
 spring.data.mongodb.port={mongo_port}
 spring.data.mongodb.database={mongo_db}
@@ -96,7 +95,7 @@ def get_user_and_password_from_pgpass_for_host(pg_host):
     with open(expanduser("~/.pgpass")) as pgpass_file:
         for line in pgpass_file:
             if line.split(':', 1)[0] == pg_host:
-                fields = line.split(':')
+                fields = line.rstrip('\n').split(':')
                 return fields[3], fields[4]
 
 
@@ -130,9 +129,6 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--taxonomy", help="Taxomomy of the species, e.g. 9031",
                         required=True)
     parser.add_argument("-f", "--fasta", help="FASTA file with the reference sequence",
-                        required=True)
-    parser.add_argument("-i", "--instance",
-                        help="Accessioning instance id (don't use the same instance concurrently!)",
                         required=True)
 
     parser.add_argument("-d", "--metadb", help="Postgres metadata DB", required=True)

--- a/eva-accession-import-automation/generate_properties.py
+++ b/eva-accession-import-automation/generate_properties.py
@@ -53,7 +53,11 @@ logging.level.uk.ac.ebi.eva.accession.dbsnp=DEBUG
 logging.level.uk.ac.ebi.eva.accession.dbsnp.listeners=INFO
 logging.level.org.springframework.jdbc.datasource=DEBUG
 """
-    species_db_info = filter(lambda db_info: db_info["database_name"] == parameters["species"],
+    species_info = data_ops.get_species_info(evapro_credentials["metadb"],
+                                             evapro_credentials["metauser"],
+                                             evapro_credentials["metahost"],
+                                             parameters["assembly_accession"])
+    species_db_info = filter(lambda db_info: db_info["database_name"] == species_info["database_name"],
                              data_ops.get_species_pg_conn_info(evapro_credentials["metadb"],
                                                                evapro_credentials["metauser"],
                                                                evapro_credentials["metahost"])
@@ -69,12 +73,12 @@ logging.level.org.springframework.jdbc.datasource=DEBUG
             assembly_accession=parameters["assembly_accession"],
             assembly_name=parameters["assembly_name"],
             assembly_report=parameters["assembly_report"],
-            taxonomy=parameters["taxonomy"],
+            taxonomy=species_info["taxonomy"],
             fasta=parameters["fasta"],
             dbsnp_host=species_db_info["pg_host"],
             dbsnp_port=species_db_info["pg_port"],
             dbsnp_build=species_db_info["dbsnp_build"],
-            dbsnp_species=parameters["species"],
+            dbsnp_species=species_info["database_name"],
             optional_build_line="parameters.buildNumber={}".format(parameters["build"]) if parameters["latest_build"] else "",
             dbsnp_user=dbsnp_user,
             dbsnp_password=dbsnp_password,
@@ -115,9 +119,6 @@ if __name__ == "__main__":
     parser.add_argument("-l", "--latest-build",
                         help="Flag that this build is the latest (relevant for dbsnp table name)",
                         action='store_true')
-    parser.add_argument("-s", "--species",
-                        help="Species for which the process has to be run, e.g. chicken_9031",
-                        required=True)
     parser.add_argument("-n", "--assembly-name",
                         help="Assembly name for which the process has to be run, e.g. Gallus_gallus-5.0",
                         required=True)
@@ -126,8 +127,6 @@ if __name__ == "__main__":
                         required=True)
     parser.add_argument("-r", "--assembly-report",
                         help="File with GenBank equivalents for RefSeq accessions", required=True)
-    parser.add_argument("-t", "--taxonomy", help="Taxomomy of the species, e.g. 9031",
-                        required=True)
     parser.add_argument("-f", "--fasta", help="FASTA file with the reference sequence",
                         required=True)
 
@@ -155,8 +154,6 @@ if __name__ == "__main__":
         parameters = {"assembly_name": args.assembly_name,
                       "assembly_accession": args.assembly_accession,
                       "assembly_report": args.assembly_report,
-                      "taxonomy": args.taxonomy,
-                      "species": args.species,
                       "build": args.build,
                       "latest_build": args.latest_build,
                       "fasta": args.fasta}

--- a/eva-accession-import-automation/requirements.txt
+++ b/eva-accession-import-automation/requirements.txt
@@ -1,0 +1,1 @@
+psycopg2

--- a/eva-accession-import-automation/requirements.txt
+++ b/eva-accession-import-automation/requirements.txt
@@ -1,1 +1,2 @@
 psycopg2
+pandas


### PR DESCRIPTION
Unfortunately, most of the parameters are the databases connection credentials, but if the program finishes, the properties file (`<assembly_accession>.properties`) should be usable for the import job.

I can add another parameter for the output filename, instead of `<assembly_accession>.properties` if you think it will be easier to integrate.