### PR TITLE
EVA-1436 Only write to FASTA file if more than 1 line is downloaded

### DIFF
--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -40,7 +40,7 @@ do
     matches=`grep -c "${accession}" ${output_folder}/${assembly_accession}.fa`
     if [ $matches -gt 1 ]
     then
-        echo WARNING: Sequence ${genbank_contig} found more than once in the output FASTA file
+        echo Sequence ${genbank_contig} found more than once in the output FASTA file
         exit_code=2
     fi
 done

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -30,6 +30,7 @@ do
         cat ${genbank_contig} >> ${output_folder}/${assembly_accession}.fa
     else
         echo FASTA sequence not available for ${genbank_contig}
+        exit_code=1
         continue
     fi
 
@@ -40,7 +41,7 @@ do
     if [ $matches -gt 1 ]
     then
         echo WARNING: Sequence ${genbank_contig} found more than once in the output FASTA file
-        exit_code=1
+        exit_code=2
     fi
 done
 

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -25,11 +25,12 @@ do
     # If a file has more than one line, then it is concatenated into the full assembly FASTA file
     # (empty sequences can't be indexed)
     lines=`head -n 2 ${genbank_contig} | wc -l`
-    if [ $lines -ne 1 ]
+    if [ $lines -gt 1 ]
     then
         cat ${genbank_contig} >> ${output_folder}/${assembly_accession}.fa
     else
         echo FASTA sequence not available for ${genbank_contig}
+        continue
     fi
 
     # Check that an accession is present no more than once in the output FASTA file, otherwise it 


### PR DESCRIPTION
When the ENA API does not return any results, the line count will be zero.

The previous code would still try to write to the FASTA file, then display a misleading message when `grep` couldn't find the string.