### PR TITLE
EVA-1433 - Use full genbank equivalents file instead of just assembly related ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,12 @@ matrix:
         - mongod --dbpath=data/db &
         - mongod --version
     - language: "python"
-      python: "2.7"
+      python: "3.4"
       install:
-        - pip install pandas
-        - pip install psycopg2
+        - pip install numpy==1.12.1
+        - pip install pandas==0.20
+        - pip install psycopg2-binary
+        - pip install pgpasslib
       before_script:
         - cd eva-accession-import-automation
       script:

--- a/eva-accession-import-automation/generate_custom_assembly_report.py
+++ b/eva-accession-import-automation/generate_custom_assembly_report.py
@@ -24,6 +24,7 @@ def get_dataframe_for_assembly_report(assembly_report_path):
 def get_dataframe_for_genbank_equivalents(genbank_equivalents_file_path):
     result_dataframe = pandas.read_csv(genbank_equivalents_file_path, dtype=str, sep='\t')
     result_dataframe = result_dataframe.set_index('rs_acc', drop=False)
+    result_dataframe = result_dataframe[~result_dataframe.index.duplicated()]
     result_dataframe = result_dataframe.sort_index()
     return result_dataframe
 

--- a/eva-accession-import-automation/tests/test_generate_custom_assembly_report.py
+++ b/eva-accession-import-automation/tests/test_generate_custom_assembly_report.py
@@ -12,8 +12,7 @@ class TestGenerateCustomAssemblyReport(unittest.TestCase):
         self.assembly_report_path = self.config["assembly_report_path"]
         self.assembly_report_dataframe, self.genbank_equivalents_dataframe = \
             get_dataframe_for_assembly_report(self.assembly_report_path), \
-            get_dataframe_for_genbank_equivalents(self.config["genbank_equivalents_file"],
-                                                  self.config["assembly_accession"])
+            get_dataframe_for_genbank_equivalents(self.config["genbank_equivalents_file"])
 
     def test_get_refseq_accessions_without_equivalent_genbank_accessions(self):
         self.setupTestConfig("tests/config/test-config-bony-fish-7950.json")


### PR DESCRIPTION
This PR still uses the genbank equivalent text file from the EBI cluster file system instead of a database table since the memory usage was not prohibitive (around 1GB - and this will be run as a bsub job in conjunction with the main java pipeline which will need more than that anyway)