### PR TITLE
EVA-1436 create FASTA: add retry logic for wget

### DIFF
--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -50,8 +50,14 @@ do
             # it was correctly downloaded
             break
         fi
-        echo Download for ${genbank_contig} failed. Retrying...
+
         times_wget_failed=$(($times_wget_failed + 1))
+
+        # log the error only once
+        if [ $times_wget_failed -eq 1 ]
+        then
+            echo Download for ${genbank_contig} failed. Retrying...
+        fi
     done
 
     # If a file has more than one line, then it is concatenated into the full assembly FASTA file


### PR DESCRIPTION
with a previous versions I found a silent error where a contig was downloaded partially. I expect wget returns an error exit code in that case.

**Note**: if a contig is not available at all, I kept the behaviour of logging it and continue. the script only stops if there was something downloaded and wget returned non-zero exit code