### PR TITLE
EVA-1436 Include WGS sequences in FASTA

### DIFF
--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -39,15 +39,15 @@ do
     set -o pipefail
     times_wget_failed=0
     max_allowed_attempts=5
-	
-	# Check if the contig belong to a WGS sequence that was already downloaded
-	already_downloaded=`grep -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
-	if [ $already_downloaded -eq 1 ]
-	then
+
+    # Check if the contig belong was already downloaded
+    already_downloaded=`grep -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
+    if [ $already_downloaded -eq 1 ]
+    then
         echo 'contig already in the FASTA file'
         continue
-	fi
-	
+    fi
+
     while [ $times_wget_failed -lt $max_allowed_attempts ]
     do
         # Download each GenBank accession in the assembly report from ENA into a separate file

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -41,10 +41,10 @@ do
     max_allowed_attempts=5
 
     # Check if the contig has already been downloaded
-    already_downloaded=`grep -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
+    already_downloaded=`grep -F -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
     if [ $already_downloaded -eq 1 ]
     then
-        echo Contig ${genbank_contig} is already present in the FASTA file and doesn't need to be downloaded again.
+        echo Contig ${genbank_contig} is already present in the FASTA file and doesnt need to be downloaded again.
         continue
     fi
 
@@ -52,7 +52,7 @@ do
     do
         # Download each GenBank accession in the assembly report from ENA into a separate file
         # Delete the accession prefix from the header line
-        wget -q -O - "https://wwwdev.ebi.ac.uk/ena/browser/api/fasta/${genbank_contig}" | sed 's/ENA|.*|//g' > ${output_folder}/${genbank_contig}
+        wget -q -O - "https://www.ebi.ac.uk/ena/browser/api/fasta/${genbank_contig}" | sed 's/ENA|.*|//g' > ${output_folder}/${genbank_contig}
         whole_pipe_result=$?
         if [ $whole_pipe_result -eq 0 ]
         then
@@ -88,7 +88,7 @@ do
             matches=`grep -m 1 -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
             if [ $matches -eq 0 ]
             then
-                # Check if is a gws. If it is the file will be compressed
+                # If the downloaded file contains a WGS, it will be compressed
                 is_wgs=$(file ${output_folder}/${genbank_contig} | grep -c 'gzip')
                 if [ $is_wgs -eq 1 ]
                 then

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -30,6 +30,7 @@ exit_code=0
 # To ensure the file exists before running `grep -c`, otherwise it will always fail
 touch ${output_folder}/${species}_custom.fa
 touch ${output_folder}/written_contigs.txt
+touch ${output_folder}/downloaded_wgs.txt
 
 for genbank_contig in `grep -v -e "^#" ${assembly_report} | cut -f5`;
 do
@@ -39,14 +40,35 @@ do
     set -o pipefail
     times_wget_failed=0
     max_allowed_attempts=5
+	
+	# Check if the contig belong to a WGS sequence that was already downloaded
+	sequence_name=`echo "${genbank_contig}" | awk '{print substr ($0, 0, 7)}'`
+	already_downloaded=`grep -c $sequence_name ${output_folder}/downloaded_wgs.txt`
+	#already_downloaded=`grep -c "${genbank_contig}" ${output_folder}/${species}_custom.fa` 
+	if [ $already_downloaded -eq 1 ]
+	then
+        echo 'contig already downloaded'
+        echo "${genbank_contig}" >> ${output_folder}/written_contigs.txt
+        continue
+	fi
+	
     while [ $times_wget_failed -lt $max_allowed_attempts ]
     do
         # Download each GenBank accession in the assembly report from ENA into a separate file
         # Delete the accession prefix from the header line
-        wget -q -O - "https://www.ebi.ac.uk/ena/browser/api/fasta/${genbank_contig}" | sed 's/ENA|.*|//g' > ${output_folder}/${genbank_contig}
+        wget -q -O - "https://wwwdev.ebi.ac.uk/ena/browser/api/fasta/${genbank_contig}" | sed 's/ENA|.*|//g' > ${output_folder}/${genbank_contig}
         whole_pipe_result=$?
         if [ $whole_pipe_result -eq 0 ]
         then
+            is_compressed=$(file ${output_folder}/${genbank_contig} | grep -c 'gzip')
+            if [ $is_compressed -eq 1 ]
+            then
+                # Uncompress file
+                mv ${output_folder}/${genbank_contig} ${output_folder}/${genbank_contig}.gz
+                gunzip ${output_folder}/${genbank_contig}.gz
+                # Mark WGS sequence as downloaded
+                echo $sequence_name >> ${output_folder}/downloaded_wgs.txt
+            fi
             # it was correctly downloaded
             break
         fi
@@ -90,7 +112,9 @@ do
 done
 
 echo `grep -v "^#" ${assembly_report}  | wc -l` "contigs were present in the assembly report"
-echo `cat ${output_folder}/written_contigs.txt | wc -l` "contigs were successfully retrieved and written in the FASTA file"
+#echo `cat ${output_folder}/written_contigs.txt | wc -l` "contigs were successfully retrieved and written in the FASTA file"
+echo `grep -c '>' ${output_folder}/${species}_custom.fa` "contigs were successfully retrieved and written in the FASTA file"
 rm ${output_folder}/written_contigs.txt
+rm ${output_folder}/downloaded_wgs.txt
 
 exit $exit_code

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -41,7 +41,7 @@ do
     max_allowed_attempts=5
 
     # Check if the contig has already been downloaded
-    already_downloaded=`grep -F -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
+    already_downloaded=`grep -F -w -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
     if [ $already_downloaded -eq 1 ]
     then
         echo Contig ${genbank_contig} is already present in the FASTA file and doesnt need to be downloaded again.
@@ -85,7 +85,7 @@ do
         else
             # Write the sequence associated with an accession to a FASTA file only once
             # grep explanation: -m 1 means "stop after finding first match". -c means "output the number of matches"
-            matches=`grep -m 1 -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
+            matches=`grep -F -w -m 1 -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
             if [ $matches -eq 0 ]
             then
                 # If the downloaded file contains a WGS, it will be compressed

--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -40,11 +40,11 @@ do
     times_wget_failed=0
     max_allowed_attempts=5
 
-    # Check if the contig belong was already downloaded
+    # Check if the contig has already been downloaded
     already_downloaded=`grep -c "${genbank_contig}" ${output_folder}/written_contigs.txt`
     if [ $already_downloaded -eq 1 ]
     then
-        echo 'contig already in the FASTA file'
+        echo Contig ${genbank_contig} is already present in the FASTA file and doesn't need to be downloaded again.
         continue
     fi
 


### PR DESCRIPTION
The ENA API feature about redirecting to the FTP when retrieving a contig that belongs to a WGS sequence is still not deployed in production. Once it is the URL must be changed to use `www` instead of `wwwdev`