### PR TITLE
EVA-1436 Fix grep pointing to the correct path

### DIFF
--- a/eva-accession-import-automation/create_fasta_from_assembly_report.sh
+++ b/eva-accession-import-automation/create_fasta_from_assembly_report.sh
@@ -101,7 +101,7 @@ do
                 # Register written contigs
                 if [ $is_wgs -eq 1 ]
                 then
-                    grep '>' "${genbank_contig}" | cut -d'|' -f3 | cut -d' ' -f1 >> ${output_folder}/written_contigs.txt
+                    grep '>' ${output_folder}/${genbank_contig} | cut -d'|' -f3 | cut -d' ' -f1 >> ${output_folder}/written_contigs.txt
                 else
                     echo "${genbank_contig}" >> ${output_folder}/written_contigs.txt
                 fi


### PR DESCRIPTION
It was failing when the path of the output folder was not where the script was being run