### PR TITLE
EVA-1458 Aggregate log messages (contig not found in FASTA file)

### DIFF
--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/AssemblyCheckerProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/AssemblyCheckerProcessor.java
@@ -22,14 +22,20 @@ import org.springframework.batch.item.ItemProcessor;
 import uk.ac.ebi.eva.accession.core.io.FastaSynonymSequenceReader;
 import uk.ac.ebi.eva.accession.dbsnp.model.SubSnpNoHgvs;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class AssemblyCheckerProcessor implements ItemProcessor<SubSnpNoHgvs, SubSnpNoHgvs> {
 
     private static Logger logger = LoggerFactory.getLogger(AssemblyCheckerProcessor.class);
 
     private FastaSynonymSequenceReader fastaReader;
 
+    private Set<String> processedContigs;
+
     public AssemblyCheckerProcessor(FastaSynonymSequenceReader fastaReader) {
         this.fastaReader = fastaReader;
+        this.processedContigs = new HashSet<>();
     }
 
     @Override
@@ -49,7 +55,10 @@ public class AssemblyCheckerProcessor implements ItemProcessor<SubSnpNoHgvs, Sub
             String sequence = fastaReader.getSequenceToUpperCase(contig, start, end);
             matches = sequence.equals(referenceAllele.toUpperCase());
         } catch (IllegalArgumentException ex) {
-            logger.warn(ex.getLocalizedMessage());
+            if (!processedContigs.contains(contig)) {
+                processedContigs.add(contig);
+                logger.warn(ex.getLocalizedMessage());
+            }
         } finally {
             subSnpNoHgvs.setAssemblyMatch(matches);
         }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/AssemblyCheckerProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/AssemblyCheckerProcessor.java
@@ -57,7 +57,7 @@ public class AssemblyCheckerProcessor implements ItemProcessor<SubSnpNoHgvs, Sub
         } catch (IllegalArgumentException ex) {
             if (!processedContigs.contains(contig)) {
                 processedContigs.add(contig);
-                logger.warn(ex.getLocalizedMessage());
+                logger.warn(ex.getMessage());
             }
         } finally {
             subSnpNoHgvs.setAssemblyMatch(matches);


### PR DESCRIPTION
`Contig not found in FASTA` messages are logged in the `assembly checker` processor and `renormalization` processor