### PR TITLE
EVA-1460 - Aggregate SubSNPSeq table lines + dummy contigloc tables for species

### DIFF
--- a/eva-accession-import-automation/data_ops.py
+++ b/eva-accession-import-automation/data_ops.py
@@ -34,20 +34,23 @@ def get_contiginfo_table_list_for_schema(pg_cursor, schema_name):
     return results[0][0].split(",")
 
 
-def get_species_pg_conn_info(pg_metadata_dbname, pg_metadata_user, pg_metadata_host):
+def get_species_pg_conn_info(pg_metadata_dbname, pg_metadata_user, pg_metadata_host,
+                             species_info_table="import_progress"):
     """
     Get Postgres connection information for all the mirrored dbSNP species
 
     :param pg_metadata_dbname: Metadata database name
     :param pg_metadata_user: Metadata user name
     :param pg_metadata_host: Host where the metadata database resides
+    :param species_info_table: Table to use to obtain species info - default to import_progress
     :return: List of dictionaries with connection information for each species
     """
     pg_conn = psycopg2.connect("dbname='{0}' user='{1}' host='{2}'".
                                format(pg_metadata_dbname, pg_metadata_user, pg_metadata_host))
     pg_cursor = pg_conn.cursor()
-    pg_cursor.execute("select database_name,dbsnp_build,pg_host,pg_port from dbsnp_ensembl_species.import_progress a "
-                      "join dbsnp_ensembl_species.dbsnp_build_instance b on b.dbsnp_build = a.ebi_pg_dbsnp_build")
+    pg_cursor.execute("select database_name,dbsnp_build,pg_host,pg_port from dbsnp_ensembl_species.{0} a "
+                      "join dbsnp_ensembl_species.dbsnp_build_instance b on b.dbsnp_build = a.ebi_pg_dbsnp_build"
+                      .format(species_info_table))
     species_set = [{"database_name": result[0], "dbsnp_build":result[1], "pg_host":result[2], "pg_port":result[3]}
                    for result in pg_cursor.fetchall()]
     pg_cursor.close()

--- a/eva-accession-import-unmapped/generate-unmapped-variants-report.py
+++ b/eva-accession-import-unmapped/generate-unmapped-variants-report.py
@@ -145,9 +145,12 @@ def get_report_creation_query(species_info):
             from
                 dbsnp_{database_name}.snpsubsnplink as lnk
                 join dbsnp_{database_name}.unmapped_subsnps on lnk.subsnp_id = unmapped_subsnps.subsnp_id
-                left join dbsnp_{database_name}.subsnpseq3_with_agg_lines as seq3 on lnk.subsnp_id = seq3.subsnp_id 
+                left join dbsnp_{database_name}.subsnpseq3_with_agg_lines as seq3 on lnk.subsnp_id = seq3.subsnp_id
+                --Left join condition explanation: If there is/are SEQ3 entry(ies) for this SubSNP, join with a SEQ3 entry 
+                --of a "compatible" type (see https://github.com/EBIvariation/eva-accession/pull/120#issuecomment-474083460)
                 left join dbsnp_{database_name}.subsnpseq5_with_agg_lines as seq5 on lnk.subsnp_id = seq5.subsnp_id and
-                    ((seq5.seq5_type = 1 and seq3.seq3_type = 4) or (seq5.seq5_type = 2 and seq3.seq3_type = 3))
+                    ((seq5.seq5_type = 1 and seq3.seq3_type = 4) or (seq5.seq5_type = 2 and seq3.seq3_type = 3) or 
+                    (seq3.subsnp_id is null)) --If SEQ3 entry does not exist for the SubSNP, join without worries 
         );
         """.format(**species_info)
 

--- a/eva-accession-import-unmapped/generate-unmapped-variants-report.py
+++ b/eva-accession-import-unmapped/generate-unmapped-variants-report.py
@@ -145,8 +145,9 @@ def get_report_creation_query(species_info):
             from
                 dbsnp_{database_name}.snpsubsnplink as lnk
                 join dbsnp_{database_name}.unmapped_subsnps on lnk.subsnp_id = unmapped_subsnps.subsnp_id
-                left join dbsnp_{database_name}.subsnpseq3_with_agg_lines as seq3 on lnk.subsnp_id = seq3.subsnp_id
-                left join dbsnp_{database_name}.subsnpseq5_with_agg_lines as seq5 on lnk.subsnp_id = seq5.subsnp_id
+                left join dbsnp_{database_name}.subsnpseq3_with_agg_lines as seq3 on lnk.subsnp_id = seq3.subsnp_id 
+                left join dbsnp_{database_name}.subsnpseq5_with_agg_lines as seq5 on lnk.subsnp_id = seq5.subsnp_id and
+                    ((seq5.seq5_type = 1 and seq3.seq3_type = 4) or (seq5.seq5_type = 2 and seq3.seq3_type = 3))
         );
         """.format(**species_info)
 


### PR DESCRIPTION
* data_ops.py - Provisions to use custom base table to get species information - see [here](https://www.ebi.ac.uk/panda/jira/browse/EVA-1460?focusedCommentId=272237&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-272237)
* generate-unmapped-variants-report.py - 
  - Create dummy ContigLoc tables for species that don't have it
  - Aggregate flanking sequence lines in SubSNPSeq tables into a single string