### PR TITLE
EVA-1520 Adapt to deprecation bug in dbsnp import

### DIFF
--- a/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecableClusteredVariantsReaderConfiguration.java
+++ b/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecableClusteredVariantsReaderConfiguration.java
@@ -49,9 +49,10 @@ public class DeprecableClusteredVariantsReaderConfiguration {
         }
         if (assembliesProvided) {
             return new DeprecableClusteredVariantsReader(mongoClient, mongoProperties.getDatabase(), mongoTemplate,
-                                                         parameters.getAssemblyAccession());
+                                                         parameters.getAssemblyAccession(), parameters.getChunkSize());
         } else {
-            return new DeprecableClusteredVariantsReader(mongoClient, mongoProperties.getDatabase(), mongoTemplate);
+            return new DeprecableClusteredVariantsReader(mongoClient, mongoProperties.getDatabase(), mongoTemplate,
+                                                         parameters.getChunkSize());
         }
     }
 }

--- a/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReader.java
+++ b/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReader.java
@@ -73,22 +73,26 @@ public class DeprecableClusteredVariantsReader implements ItemStreamReader<Dbsnp
     
     private MongoConverter converter;
 
+    private int chunkSize;
+
     /**
      * Constructs a reader for all variants in the collection DBSNP_CLUSTERED_VARIANT_ENTITY_DECLUSTERED, irrespective of the assembly.
      */
-    public DeprecableClusteredVariantsReader(MongoClient mongoClient, String database, MongoTemplate mongoTemplate) {
-        this(mongoClient, database, mongoTemplate, null);
+    public DeprecableClusteredVariantsReader(MongoClient mongoClient, String database, MongoTemplate mongoTemplate,
+                                             int chunkSize) {
+        this(mongoClient, database, mongoTemplate, null, chunkSize);
     }
 
     /**
      * Constructs a reader that retrieves variants mapped only against the specified assemblies.
      */
     public DeprecableClusteredVariantsReader(MongoClient mongoClient, String database, MongoTemplate mongoTemplate,
-                                             List<String> assemblyAccessions) {
+                                             List<String> assemblyAccessions, int chunkSize) {
         this.mongoClient = mongoClient;
         this.database = database;
         this.mongoTemplate = mongoTemplate;
         this.assemblies = assemblyAccessions;
+        this.chunkSize = chunkSize;
     }
 
     @Override
@@ -97,7 +101,8 @@ public class DeprecableClusteredVariantsReader implements ItemStreamReader<Dbsnp
         MongoCollection<Document> collection = db.getCollection(DBSNP_CLUSTERED_VARIANT_ENTITY_DECLUSTERED);
         AggregateIterable<Document> declusteredVariants = collection.aggregate(buildAggregation())
                                                                     .allowDiskUse(true)
-                                                                    .useCursor(true);
+                                                                    .useCursor(true)
+                                                                    .batchSize(chunkSize);
         cursor = declusteredVariants.iterator();
         converter = mongoTemplate.getConverter();
     }

--- a/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReader.java
+++ b/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReader.java
@@ -36,7 +36,6 @@ import org.springframework.data.mongodb.core.convert.MongoConverter;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -50,11 +49,13 @@ public class DeprecableClusteredVariantsReader implements ItemStreamReader<Dbsnp
 
     private static final Logger logger = LoggerFactory.getLogger(DeprecableClusteredVariantsReader.class);
 
-    private static final String DBSNP_CLUSTERED_VARIANT_ENTITY = "dbsnpClusteredVariantEntity";
+    private static final String DBSNP_SUBMITTED_VARIANT_ENTITY = "dbsnpSubmittedVariantEntity";
 
     private static final String DBSNP_CLUSTERED_VARIANT_ENTITY_DECLUSTERED = "dbsnpClusteredVariantEntityDeclustered";
 
     private static final String ACCESSION_FIELD = "accession";
+
+    private static final String CLUSTERED_VARIANT_ACCESSION_FIELD = "rs";
 
     private static final String ACTIVE = "active";
 
@@ -106,7 +107,9 @@ public class DeprecableClusteredVariantsReader implements ItemStreamReader<Dbsnp
         if (assemblies != null && !assemblies.isEmpty()) {
             aggregation.add(Aggregates.match(Filters.in(ASSEMBLY_FIELD, assemblies)));
         }
-        aggregation.add(Aggregates.lookup(DBSNP_CLUSTERED_VARIANT_ENTITY, ACCESSION_FIELD, ACCESSION_FIELD, ACTIVE));
+        aggregation.add(
+                Aggregates.lookup(DBSNP_SUBMITTED_VARIANT_ENTITY, ACCESSION_FIELD, CLUSTERED_VARIANT_ACCESSION_FIELD,
+                                  ACTIVE));
         aggregation.add(Aggregates.match(Filters.eq(ACTIVE, Collections.EMPTY_LIST)));
 
         logger.info("Issuing aggregation: {}", aggregation);

--- a/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecationWriter.java
+++ b/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecationWriter.java
@@ -84,12 +84,12 @@ public class DeprecationWriter implements ItemWriter<DbsnpClusteredVariantEntity
      * and different id (hash) that we haven't read yet).
      */
     private void removeDeprecableClusteredVariantsDeprecated(
-            List<? extends DbsnpClusteredVariantEntity> deprecableClusteredVatiants) {
+            List<? extends DbsnpClusteredVariantEntity> deprecableClusteredVariants) {
         BulkOperations bulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
                                                               DbsnpClusteredVariantEntity.class,
                                                               DBSNP_CLUSTERED_VARIANT_DECLUSTERED_COLLECTION_NAME);
         Query query = new Query();
-        query.addCriteria(Criteria.where(ID_FIELD).in(getIds(deprecableClusteredVatiants)));
+        query.addCriteria(Criteria.where(ID_FIELD).in(getIds(deprecableClusteredVariants)));
         bulkOperations.remove(query);
         bulkOperations.execute();
     }

--- a/eva-accession-deprecate/src/main/resources/application.properties
+++ b/eva-accession-deprecate/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.batch.job.names=DEPRECATE_CLUSTERED_VARIANTS_JOB
 
 parameters.assemblyAccession=
 parameters.deprecateAll=false
-parameters.chunkSize=1000
+parameters.chunkSize=100
 
 # job repository datasource
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateClusteredVariantsJobConfigurationTest.java
+++ b/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateClusteredVariantsJobConfigurationTest.java
@@ -48,6 +48,7 @@ import static uk.ac.ebi.eva.accession.deprecate.configuration.BeanNames.DEPRECAT
 @ContextConfiguration(classes = {BatchTestConfiguration.class, MongoTestConfiguration.class})
 @UsingDataSet(locations = {
         "/test-data/dbsnpClusteredVariantEntity.json",
+        "/test-data/dbsnpSubmittedVariantEntity.json",
         "/test-data/dbsnpClusteredVariantEntityDeclustered.json"})
 @TestPropertySource("classpath:application.properties")
 public class DeprecateClusteredVariantsJobConfigurationTest {

--- a/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateClusteredVariantsStepConfigurationTest.java
+++ b/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateClusteredVariantsStepConfigurationTest.java
@@ -47,6 +47,7 @@ import static uk.ac.ebi.eva.accession.deprecate.configuration.BeanNames.DEPRECAT
 @ContextConfiguration(classes = {BatchTestConfiguration.class, MongoTestConfiguration.class})
 @UsingDataSet(locations = {
         "/test-data/dbsnpClusteredVariantEntity.json",
+        "/test-data/dbsnpSubmittedVariantEntity.json",
         "/test-data/dbsnpClusteredVariantEntityDeclustered.json"})
 @TestPropertySource("classpath:application.properties")
 public class DeprecateClusteredVariantsStepConfigurationTest {

--- a/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateClusteredVariantsStepConfigurationTest.java
+++ b/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateClusteredVariantsStepConfigurationTest.java
@@ -58,7 +58,7 @@ public class DeprecateClusteredVariantsStepConfigurationTest {
 
     private static final long EXPECTED_VARIANTS_TO_BE_NOT_FULLY_DECLUSTERED = 4;
 
-    private static final long EXPECTED_OPERATIONS = 4;
+    private static final long EXPECTED_OPERATIONS = 5;
 
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;

--- a/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateSubsetClusteredVariantsStepConfigurationTest.java
+++ b/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateSubsetClusteredVariantsStepConfigurationTest.java
@@ -47,6 +47,7 @@ import static uk.ac.ebi.eva.accession.deprecate.configuration.BeanNames.DEPRECAT
 @ContextConfiguration(classes = {BatchTestConfiguration.class, MongoTestConfiguration.class})
 @UsingDataSet(locations = {
         "/test-data/dbsnpClusteredVariantEntity.json",
+        "/test-data/dbsnpSubmittedVariantEntity.json",
         "/test-data/dbsnpClusteredVariantEntityDeclustered.json"})
 @TestPropertySource("classpath:application_species_subset.properties")
 public class DeprecateSubsetClusteredVariantsStepConfigurationTest {
@@ -57,7 +58,8 @@ public class DeprecateSubsetClusteredVariantsStepConfigurationTest {
 
     private static final long EXPECTED_VARIANTS_TO_BE_NOT_FULLY_DECLUSTERED = 7;
 
-    // from those listed in assemblyAccessions, only GCA_000000003.1 is not present in dbsnpClusteredVariantEntity
+    // from those listed in assemblyAccession (in the properties file), only GCA_000000003.1 is not present in
+    // dbsnpSubmittedVariantEntity
     private static final long EXPECTED_OPERATIONS = 1;
 
     @Autowired

--- a/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateSubsetClusteredVariantsStepConfigurationTest.java
+++ b/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/configuration/DeprecateSubsetClusteredVariantsStepConfigurationTest.java
@@ -56,7 +56,7 @@ public class DeprecateSubsetClusteredVariantsStepConfigurationTest {
 
     private static final String DBSNP_CLUSTERED_VARIANT_ENTITY_DECLUSTERED = "dbsnpClusteredVariantEntityDeclustered";
 
-    private static final long EXPECTED_VARIANTS_TO_BE_NOT_FULLY_DECLUSTERED = 7;
+    private static final long EXPECTED_VARIANTS_TO_BE_NOT_FULLY_DECLUSTERED = 8;
 
     // from those listed in assemblyAccession (in the properties file), only GCA_000000003.1 is not present in
     // dbsnpSubmittedVariantEntity

--- a/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReaderTest.java
+++ b/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReaderTest.java
@@ -68,6 +68,8 @@ public class DeprecableClusteredVariantsReaderTest {
 
     private static final String ASM_4 = "GCA_000000004.1";
 
+    private static final int CHUNK_SIZE = 5;
+
     private ExecutionContext executionContext;
 
     private DeprecableClusteredVariantsReader reader;
@@ -89,7 +91,7 @@ public class DeprecableClusteredVariantsReaderTest {
     @Before
     public void setUp() {
         executionContext = new ExecutionContext();
-        reader = new DeprecableClusteredVariantsReader(mongoClient, TEST_DB, mongoTemplate);
+        reader = new DeprecableClusteredVariantsReader(mongoClient, TEST_DB, mongoTemplate, CHUNK_SIZE);
         reader.open(executionContext);
     }
 
@@ -119,7 +121,7 @@ public class DeprecableClusteredVariantsReaderTest {
     @Test
     public void readSubsetOfAssemblies() {
         reader = new DeprecableClusteredVariantsReader(mongoClient, TEST_DB, mongoTemplate,
-                                                       Arrays.asList(ASM_2, ASM_3));
+                                                       Arrays.asList(ASM_2, ASM_3), CHUNK_SIZE);
         reader.open(executionContext);
         List<DbsnpClusteredVariantEntity> variants = readIntoList();
         assertEquals(1, variants.size());

--- a/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReaderTest.java
+++ b/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReaderTest.java
@@ -49,6 +49,7 @@ import static org.junit.Assert.assertFalse;
 @TestPropertySource("classpath:application.properties")
 @UsingDataSet(locations = {
         "/test-data/dbsnpClusteredVariantEntity.json",
+        "/test-data/dbsnpSubmittedVariantEntity.json",
         "/test-data/dbsnpClusteredVariantEntityDeclustered.json"})
 @ContextConfiguration(classes = {MongoConfiguration.class, MongoTestConfiguration.class})
 public class DeprecableClusteredVariantsReaderTest {

--- a/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReaderTest.java
+++ b/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecableClusteredVariantsReaderTest.java
@@ -102,7 +102,7 @@ public class DeprecableClusteredVariantsReaderTest {
     @Test
     public void readDeprecateClusteredVariants() {
         List<DbsnpClusteredVariantEntity> variants = readIntoList();
-        assertEquals(4, variants.size());
+        assertEquals(5, variants.size());
         assertTrue(variants.stream().anyMatch(x -> x.getId().equals(ID_1)));
         assertTrue(variants.stream().anyMatch(x -> x.getId().equals(ID_2)));
     }

--- a/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecationWriterTest.java
+++ b/eva-accession-deprecate/src/test/java/uk/ac/ebi/eva/accession/deprecate/io/DeprecationWriterTest.java
@@ -26,8 +26,6 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -41,7 +39,6 @@ import uk.ac.ebi.eva.accession.core.IClusteredVariant;
 import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantOperationEntity;
-import uk.ac.ebi.eva.accession.core.persistence.DbsnpSubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.summary.ClusteredVariantSummaryFunction;
 import uk.ac.ebi.eva.accession.deprecate.test.configuration.MongoTestConfiguration;
 import uk.ac.ebi.eva.accession.deprecate.test.rule.FixSpringMongoDbRule;
@@ -57,8 +54,8 @@ import java.util.stream.Collectors;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.springframework.data.mongodb.core.query.Criteria.*;
-import static org.springframework.data.mongodb.core.query.Query.*;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource("classpath:application.properties")

--- a/eva-accession-deprecate/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
+++ b/eva-accession-deprecate/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
@@ -23,6 +23,17 @@
       "createdDate" : ISODate("2015-11-21T13:13:00.000Z")
     },
     {
+      "_id" : "BCAB105FD3C0108A54354BB6B661C3146C874F4B",
+      "asm" : "GCA_000331145.1",
+      "tax" : 3827,
+      "contig" : "CM001767.1",
+      "start" : NumberLong(45273241),
+      "type" : "SNV",
+      "accession" : NumberLong(853357167),
+      "version" : 1,
+      "createdDate" : ISODate("2015-11-21T13:13:00.000Z")
+    },
+    {
       "_id" : "HASH_1",
       "asm" : "GCA_000000001.1",
       "tax" : 3827,
@@ -41,6 +52,17 @@
       "start" : NumberLong(853461378),
       "type" : "SNV",
       "accession" : NumberLong(2),
+      "version" : 1,
+      "createdDate" : ISODate("2015-11-21T13:13:00.000Z")
+    },
+    {
+      "_id" : "HASH_3",
+      "asm" : "GCA_000000003.1",
+      "tax" : 3827,
+      "contig" : "CM001768.1",
+      "start" : NumberLong(31898089),
+      "type" : "SNV",
+      "accession" : NumberLong(3),
       "version" : 1,
       "createdDate" : ISODate("2015-11-21T13:13:00.000Z")
     }

--- a/eva-accession-deprecate/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
+++ b/eva-accession-deprecate/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
@@ -65,6 +65,17 @@
       "accession" : NumberLong(3),
       "version" : 1,
       "createdDate" : ISODate("2015-11-21T13:13:00.000Z")
+    },
+    {
+      "_id" : "HASH_3_2",
+      "asm" : "GCA_000000003.1",
+      "tax" : 3827,
+      "contig" : "CM001768.1",
+      "start" : NumberLong(31898090),
+      "type" : "SNV",
+      "accession" : NumberLong(3),
+      "version" : 1,
+      "createdDate" : ISODate("2015-11-21T13:13:00.000Z")
     }
   ]
 }

--- a/eva-accession-deprecate/src/test/resources/test-data/dbsnpClusteredVariantEntityDeclustered.json
+++ b/eva-accession-deprecate/src/test/resources/test-data/dbsnpClusteredVariantEntityDeclustered.json
@@ -45,6 +45,17 @@
       "createdDate" : ISODate("2015-11-21T13:13:00.000Z")
     },
     {
+      "_id" : "75D415B9C75A025054387E09A600707B1317FC2A",
+      "asm" : "GCA_000331145.1",
+      "tax" : 3827,
+      "contig" : "CM001768.1",
+      "start" : NumberLong(31898090),
+      "type" : "SNV",
+      "accession" : NumberLong(853461378),
+      "version" : 1,
+      "createdDate" : ISODate("2015-11-21T13:13:00.000Z")
+    },
+    {
       "_id" : "HASH_1",
       "asm" : "GCA_000000001.1",
       "tax" : 3827,

--- a/eva-accession-deprecate/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-deprecate/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -1,0 +1,64 @@
+{
+  "dbsnpSubmittedVariantEntity": [
+    {
+      "_id": "009FD5186628C3448F66BABF0CF24A66A771C6F0",
+      "seq": "GCA_000331145.1",
+      "tax": 3827,
+      "study": "NIPGR_RESEQUENCING-BASED SNP DISCOVERY",
+      "contig": "CM001766.1",
+      "start": NumberLong(10950885),
+      "ref": "G",
+      "alt": "A",
+      "rs": NumberLong(853567325),
+      "evidence": false,
+      "validated": true,
+      "accession": NumberLong(1940161236),
+      "version": 1,
+      "createdDate": ISODate( "2015-10-26T13:33:00Z" )
+    },
+    {
+      "_id": "B9FD05F0B669D6E3267738A852FD27F3B813AE36",
+      "seq": "GCA_000331145.1",
+      "tax": 3827,
+      "study": "NIPGR_RESEQUENCING-BASED SNP DISCOVERY",
+      "contig": "CM001765.1",
+      "start": NumberLong(35288581),
+      "ref": "G",
+      "alt": "A",
+      "rs": NumberLong(853683894),
+      "evidence": false,
+      "validated": true,
+      "accession": NumberLong(1940158177),
+      "version": 1,
+      "createdDate": ISODate( "2015-10-26T13:33:00Z" )
+    },
+    {
+      "_id": "HASH_1",
+      "seq": "GCA_000000001.1",
+      "tax": 3827,
+      "study": "study1",
+      "contig": "CM001765.1",
+      "start": NumberLong(35288581),
+      "ref": "A",
+      "alt": "T",
+      "accession": NumberLong(101),
+      "rs": NumberLong(1),
+      "version": 1,
+      "createdDate": ISODate( "2015-11-21T13:13:00.000Z" )
+    },
+    {
+      "_id": "HASH_2",
+      "asm": "GCA_000000002.1",
+      "tax": 3827,
+      "study": "study2",
+      "contig": "CM001765.1",
+      "start": NumberLong(853461378),
+      "ref": "A",
+      "alt": "T",
+      "accession": NumberLong(102),
+      "rs": NumberLong(2),
+      "version": 1,
+      "createdDate": ISODate( "2015-11-21T13:13:00.000Z" )
+    }
+  ]
+}

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/readers/AccessionedVariantMongoReaderConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/readers/AccessionedVariantMongoReaderConfiguration.java
@@ -52,6 +52,6 @@ public class AccessionedVariantMongoReaderConfiguration {
                                                                 MongoProperties mongoProperties) {
         logger.info("Injecting AccessionedVariantMongoReader with parameters: {}", parameters);
         return new AccessionedVariantMongoReader(parameters.getAssemblyAccession(), mongoClient,
-                                                 mongoProperties.getDatabase());
+                                                 mongoProperties.getDatabase(), parameters.getChunkSize());
     }
 }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/readers/MergedDeprecatedVariantMongoReaderConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/readers/MergedDeprecatedVariantMongoReaderConfiguration.java
@@ -41,7 +41,8 @@ public class MergedDeprecatedVariantMongoReaderConfiguration {
             InputParameters parameters, MongoClient mongoClient, MongoTemplate mongoTemplate,
             MongoProperties mongoProperties) {
         return new MergedDeprecatedVariantMongoReader(parameters.getAssemblyAccession(), mongoClient,
-                                                      mongoProperties.getDatabase(), mongoTemplate.getConverter());
+                                                      mongoProperties.getDatabase(), mongoTemplate.getConverter(),
+                                                      parameters.getChunkSize());
     }
 
 }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/readers/MergedVariantMongoReaderConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/readers/MergedVariantMongoReaderConfiguration.java
@@ -52,6 +52,6 @@ public class MergedVariantMongoReaderConfiguration {
                                                       MongoProperties mongoProperties) {
         logger.info("Injecting MergedVariantMongoReader with parameters: {}", parameters);
         return new MergedVariantMongoReader(parameters.getAssemblyAccession(), mongoClient,
-                                            mongoProperties.getDatabase());
+                                            mongoProperties.getDatabase(), parameters.getChunkSize());
     }
 }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
@@ -51,8 +51,9 @@ public class AccessionedVariantMongoReader extends VariantMongoAggregationReader
 
     private static final String DBSNP_CLUSTERED_VARIANT_ENTITY = "dbsnpClusteredVariantEntity";
 
-    public AccessionedVariantMongoReader(String assemblyAccession, MongoClient mongoClient, String database) {
-        super(assemblyAccession, mongoClient, database);
+    public AccessionedVariantMongoReader(String assemblyAccession, MongoClient mongoClient, String database,
+                                         int chunkSize) {
+        super(assemblyAccession, mongoClient, database, chunkSize);
     }
 
     @Override

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/MergedDeprecatedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/MergedDeprecatedVariantMongoReader.java
@@ -78,12 +78,15 @@ public class MergedDeprecatedVariantMongoReader implements ItemStreamReader<Dbsn
 
     private MongoConverter mongoConverter;
 
+    private int chunkSize;
+
     public MergedDeprecatedVariantMongoReader(String assemblyAccession, MongoClient mongoClient, String database,
-                                              MongoConverter mongoConverter) {
+                                              MongoConverter mongoConverter, int chunkSize) {
         this.assemblyAccession = assemblyAccession;
         this.mongoClient = mongoClient;
         this.database = database;
         this.mongoConverter = mongoConverter;
+        this.chunkSize = chunkSize;
     }
 
     @Override
@@ -96,7 +99,8 @@ public class MergedDeprecatedVariantMongoReader implements ItemStreamReader<Dbsn
         MongoCollection<Document> collection = db.getCollection(collectionName);
         AggregateIterable<Document> clusteredVariants = collection.aggregate(buildAggregation())
                                                                   .allowDiskUse(true)
-                                                                  .useCursor(true);
+                                                                  .useCursor(true)
+                                                                  .batchSize(chunkSize);
         cursor = clusteredVariants.iterator();
     }
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/MergedDeprecatedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/MergedDeprecatedVariantMongoReader.java
@@ -54,7 +54,7 @@ public class MergedDeprecatedVariantMongoReader implements ItemStreamReader<Dbsn
 
     private static final String DBSNP_CLUSTERED_VARIANT_OPERATION_ENTITY = "dbsnpClusteredVariantOperationEntity";
 
-    private static final String DBSNP_CLUSTERED_VARIANT_ENTITY = "dbsnpClusteredVariantEntity";
+    private static final String DBSNP_SUBMITTED_VARIANT_ENTITY = "dbsnpSubmittedVariantEntity";
 
     private static final String INACTIVE_OBJECTS = "inactiveObjects";
 
@@ -64,9 +64,9 @@ public class MergedDeprecatedVariantMongoReader implements ItemStreamReader<Dbsn
 
     private static final String ASSEMBLY_FIELD = "asm";
 
-    private static final String CLUSTERED_VARIANT_ACCESSION_FIELD = "accession";
+    private static final String CLUSTERED_VARIANT_ACCESSION_FIELD = "rs";
 
-    private static final String RS_INFO_FIELD = "rsInfo";
+    private static final String SS_INFO_FIELD = "ssInfo";
 
     private final String assemblyAccession;
 
@@ -103,9 +103,9 @@ public class MergedDeprecatedVariantMongoReader implements ItemStreamReader<Dbsn
     private List<Bson> buildAggregation() {
         Bson matchAssembly = Aggregates.match(Filters.eq(getInactiveField(ASSEMBLY_FIELD), assemblyAccession));
         Bson matchMerged = Aggregates.match(Filters.eq(EVENT_TYPE_FIELD, EventType.MERGED.toString()));
-        Bson lookup = Aggregates.lookup(DBSNP_CLUSTERED_VARIANT_ENTITY, MERGE_INTO_FIELD,
-                                        CLUSTERED_VARIANT_ACCESSION_FIELD, RS_INFO_FIELD);
-        Bson matchEmpty = Aggregates.match(Filters.eq(RS_INFO_FIELD, Collections.EMPTY_LIST));
+        Bson lookup = Aggregates.lookup(DBSNP_SUBMITTED_VARIANT_ENTITY, MERGE_INTO_FIELD,
+                                        CLUSTERED_VARIANT_ACCESSION_FIELD, SS_INFO_FIELD);
+        Bson matchEmpty = Aggregates.match(Filters.eq(SS_INFO_FIELD, Collections.EMPTY_LIST));
         List<Bson> aggregation = Arrays.asList(matchAssembly, matchMerged, lookup, matchEmpty);
         logger.info("Issuing aggregation: {}", aggregation);
         return aggregation;

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReader.java
@@ -58,8 +58,8 @@ public class MergedVariantMongoReader extends VariantMongoAggregationReader {
 
     private static final String EVENT_TYPE_FIELD = "eventType";
 
-    public MergedVariantMongoReader(String assemblyAccession, MongoClient mongoClient, String database) {
-        super(assemblyAccession, mongoClient, database);
+    public MergedVariantMongoReader(String assemblyAccession, MongoClient mongoClient, String database, int chunkSize) {
+        super(assemblyAccession, mongoClient, database, chunkSize);
     }
 
     @Override

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantMongoAggregationReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantMongoAggregationReader.java
@@ -94,10 +94,14 @@ public abstract class VariantMongoAggregationReader implements ItemStreamReader<
 
     protected MongoCursor<Document> cursor;
 
-    public VariantMongoAggregationReader(String assemblyAccession, MongoClient mongoClient, String database) {
+    private int chunkSize;
+
+    public VariantMongoAggregationReader(String assemblyAccession, MongoClient mongoClient, String database,
+                                         int chunkSize) {
         this.assemblyAccession = assemblyAccession;
         this.mongoClient = mongoClient;
         this.database = database;
+        this.chunkSize = chunkSize;
     }
 
     protected void aggregate(String collectionName) {
@@ -105,7 +109,8 @@ public abstract class VariantMongoAggregationReader implements ItemStreamReader<
         MongoCollection<Document> collection = db.getCollection(collectionName);
         AggregateIterable<Document> clusteredVariants = collection.aggregate(buildAggregation())
                                                                   .allowDiskUse(true)
-                                                                  .useCursor(true);
+                                                                  .useCursor(true)
+                .batchSize(chunkSize);
         cursor = clusteredVariants.iterator();
     }
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantMongoAggregationReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantMongoAggregationReader.java
@@ -110,7 +110,7 @@ public abstract class VariantMongoAggregationReader implements ItemStreamReader<
         AggregateIterable<Document> clusteredVariants = collection.aggregate(buildAggregation())
                                                                   .allowDiskUse(true)
                                                                   .useCursor(true)
-                .batchSize(chunkSize);
+                                                                  .batchSize(chunkSize);
         cursor = clusteredVariants.iterator();
     }
 

--- a/eva-accession-release/src/main/resources/application.properties
+++ b/eva-accession-release/src/main/resources/application.properties
@@ -5,7 +5,7 @@ parameters.fasta=
 parameters.assemblyReportUrl=
 parameters.outputFolder=
 parameters.forceRestart=false
-parameters.chunkSize=1000
+parameters.chunkSize=100
 
 # job repository datasource
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
@@ -102,6 +102,8 @@ public class AccessionedVariantMongoReaderTest {
 
     private static final int EXPECTED_LINES = 5;
 
+    private static final int CHUNK_SIZE = 5;
+
     private AccessionedVariantMongoReader reader;
 
     private ExecutionContext executionContext;
@@ -120,7 +122,7 @@ public class AccessionedVariantMongoReaderTest {
     @Before
     public void setUp() throws Exception {
         executionContext = new ExecutionContext();
-        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_1, mongoClient, TEST_DB);
+        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_1, mongoClient, TEST_DB, CHUNK_SIZE);
     }
 
     @Test
@@ -190,7 +192,7 @@ public class AccessionedVariantMongoReaderTest {
 
     @Test
     public void queryOtherAssembly() throws Exception {
-        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_2, mongoClient, TEST_DB);
+        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_2, mongoClient, TEST_DB, CHUNK_SIZE);
         Map<String, Variant> variants = readIntoMap();
 
         assertEquals(3, variants.size());
@@ -224,7 +226,7 @@ public class AccessionedVariantMongoReaderTest {
 
     @Test
     public void insertionVariantClassAttribute() throws Exception {
-        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_4, mongoClient, TEST_DB);
+        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_4, mongoClient, TEST_DB, CHUNK_SIZE);
         List<Variant> variants = readIntoList();
         assertEquals(1, variants.size());
         String insertionSequenceOntology = "SO:0000667";
@@ -236,7 +238,7 @@ public class AccessionedVariantMongoReaderTest {
 
     @Test
     public void otherVariantClasses() throws Exception {
-        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_5, mongoClient, TEST_DB);
+        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_5, mongoClient, TEST_DB, CHUNK_SIZE);
         List<Variant> variants = readIntoList();
         assertEquals(4, variants.size());
         String indelSequenceOntology = "SO:1000032";
@@ -267,7 +269,7 @@ public class AccessionedVariantMongoReaderTest {
 
     @Test
     public void clusteredVariantWithoutSubmittedVariants() throws Exception {
-        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_3, mongoClient, TEST_DB);
+        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_3, mongoClient, TEST_DB, CHUNK_SIZE);
         List<Variant> variants = readIntoList();
         assertEquals(0, variants.size());
     }
@@ -305,7 +307,7 @@ public class AccessionedVariantMongoReaderTest {
 
     @Test
     public void includeValidatedNonDefaultFlag() throws Exception {
-        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_5, mongoClient, TEST_DB);
+        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_5, mongoClient, TEST_DB, CHUNK_SIZE);
         assertFlagEqualsInAllVariants(SUBMITTED_VARIANT_VALIDATED_KEY, true);
         assertFlagEqualsInRS(CLUSTERED_VARIANT_VALIDATED_KEY, false, RS_4);
         assertFlagEqualsInRS(CLUSTERED_VARIANT_VALIDATED_KEY, true, RS_5);
@@ -325,19 +327,19 @@ public class AccessionedVariantMongoReaderTest {
 
     @Test
     public void includeAssemblyMatchNonDefaultFlag() throws Exception {
-        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_4, mongoClient, TEST_DB);
+        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_4, mongoClient, TEST_DB, CHUNK_SIZE);
         assertFlagEqualsInAllVariants(ASSEMBLY_MATCH_KEY, false);
     }
 
     @Test
     public void includeAllelesMatchNonDefaultFlag() throws Exception {
-        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_4, mongoClient, TEST_DB);
+        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_4, mongoClient, TEST_DB, CHUNK_SIZE);
         assertFlagEqualsInAllVariants(ALLELES_MATCH_KEY, false);
     }
 
     @Test
     public void includeEvidenceNonDefaultFlag() throws Exception {
-        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_5, mongoClient, TEST_DB);
+        reader = new AccessionedVariantMongoReader(ASSEMBLY_ACCESSION_5, mongoClient, TEST_DB, CHUNK_SIZE);
         assertFlagEqualsInAllVariants(SUPPORTED_BY_EVIDENCE_KEY, false);
     }
 }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/MergedDeprecatedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/MergedDeprecatedVariantMongoReaderTest.java
@@ -59,6 +59,8 @@ public class MergedDeprecatedVariantMongoReaderTest {
 
     private static final String ASSEMBLY = "GCF_000409795.2";
 
+    private static final int CHUNK_SIZE = 5;
+
     @Autowired
     private MongoTemplate mongoTemplate;
 
@@ -78,7 +80,8 @@ public class MergedDeprecatedVariantMongoReaderTest {
     @Before
     public void setUp() {
         ExecutionContext executionContext = new ExecutionContext();
-        reader = new MergedDeprecatedVariantMongoReader(ASSEMBLY, mongoClient, TEST_DB, mongoTemplate.getConverter());
+        reader = new MergedDeprecatedVariantMongoReader(ASSEMBLY, mongoClient, TEST_DB, mongoTemplate.getConverter(),
+                                                        CHUNK_SIZE);
         reader.open(executionContext);
     }
 

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReaderTest.java
@@ -82,6 +82,8 @@ public class MergedVariantMongoReaderTest {
 
     private static final String ID_2_MERGED_INTO = "rs869927931";
 
+    private static final int CHUNK_SIZE = 5;
+
     @Autowired
     private MongoClient mongoClient;
 
@@ -103,7 +105,7 @@ public class MergedVariantMongoReaderTest {
     @Before
     public void setUp() throws Exception {
         executionContext = new ExecutionContext();
-        reader = new MergedVariantMongoReader(ASSEMBLY, mongoClient, TEST_DB);
+        reader = new MergedVariantMongoReader(ASSEMBLY, mongoClient, TEST_DB, CHUNK_SIZE);
     }
 
     @Test


### PR DESCRIPTION
make the eva-accession-deprecate and eva-accession-release assume that a Clustered Variant should be declustered if and only if it is present in dbsnpClusteredVariantEntityDeclustered and its RS ID is not used by any dbsnpSubmittedVariantEntity.