### PR TITLE
EVA-1552 Use original chromosomes in accessioning VCF report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # eva-accession
 EVA non-human variant accessioning service
+
+To compile the project you only need to run `mvn clean install`.
+
+You can use maven profiles (e.g. `mvn clean install -Pproduction`) to fill some required parameters and include them in the compiled jars/wars.
+
+For a quick compilation without tests, you can run `mvn clean install -DskipTests`.
+
+Look at the READMEs of each module for more details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eva-accession
+# eva-accession [![Build Status](https://travis-ci.com/EBIvariation/eva-accession.svg?branch=master)](https://travis-ci.com/EBIvariation/eva-accession)
 EVA non-human variant accessioning service.
 
 The EVA is responsible for issuing RS IDs and SS IDs for variants in non-human species. The official announcement is available at https://www.ebi.ac.uk/about/news/press-releases/eva-issues-long-term-ids-non-human-variants.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # eva-accession
-EVA non-human variant accessioning service
+EVA non-human variant accessioning service.
 
-To compile the project you only need to run `mvn clean install`.
+The EVA is responsible for issuing RS IDs and SS IDs for variants in non-human species. The official announcement is available at https://www.ebi.ac.uk/about/news/press-releases/eva-issues-long-term-ids-non-human-variants.
+
+# Build
+To compile the whole project you only need to run `mvn clean install`.
 
 You can use maven profiles (e.g. `mvn clean install -Pproduction`) to fill some required parameters and include them in the compiled jars/wars.
 

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigMapping.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigMapping.java
@@ -130,11 +130,11 @@ public class ContigMapping {
     }
 
     /**
-     * Replacement to genbanks is only possible if:
+     * Replacement with a GenBank sequence accession is only possible if:
      * - Contig has synonyms
-     * - Genbank and Refseq are identical or are not identical but there is no RefSeq accession. This means that no
+     * - GenBank and RefSeq are identical or are not identical but there is no RefSeq accession. This means that no
      *   replacement will be done with a line like "chr1 ... genbank1 <> refseq1 ...", not even chr -> genbank
-     * - Contig has Genbank synonym
+     * - Contig has a GenBank synonym
      */
     public boolean isGenbankReplacementPossible(String contig, ContigSynonyms contigSynonyms, StringBuilder reason) {
         if (contigSynonyms == null) {
@@ -143,9 +143,9 @@ public class ContigMapping {
         }
 
         if(!contigSynonyms.isIdenticalGenBankAndRefSeq() && hasText(contigSynonyms.getRefSeq())) {
-            reason.append("Genbank and refseq not identical in the assembly report for contig '" + contig
-                          + "' and refseq is not empty. No conversion performed, even unrelated to refseq (e.g. "
-                          + "chromosome to genbank");
+            reason.append("GenBank and RefSeq not identical in the assembly report for contig '" + contig
+                          + "' and RefSeq is not empty. No conversion performed, even unrelated to RefSeq (e.g. "
+                          + "chromosome to GenBank");
             return false;
         }
 

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigNaming.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigNaming.java
@@ -15,6 +15,9 @@
  */
 package uk.ac.ebi.eva.accession.core.contig;
 
+/**
+ * This enum can be used to specify one of the synonyms from NCBI's assembly reports.
+ */
 public enum ContigNaming {
     SEQUENCE_NAME,  // this is the same as chromosome names
     ASSIGNED_MOLECULE,

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigNaming.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigNaming.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.core.contig;
+
+public enum ContigNaming {
+    SEQUENCE_NAME,
+    ASSIGNED_MOLECULE,
+    INSDC,
+    REFSEQ,
+    UCSC
+}

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigNaming.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigNaming.java
@@ -16,9 +16,9 @@
 package uk.ac.ebi.eva.accession.core.contig;
 
 public enum ContigNaming {
-    SEQUENCE_NAME,
+    SEQUENCE_NAME,  // this is the same as chromosome names
     ASSIGNED_MOLECULE,
-    INSDC,
+    INSDC,  // this is the same as GenBank
     REFSEQ,
     UCSC
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigSynonyms.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigSynonyms.java
@@ -58,7 +58,7 @@ public class ContigSynonyms {
                 return getUcsc();
             default:
                 throw new RuntimeException(
-                        "Incomplete switch on enum " + ContigNaming.class.getSimpleName() + ". It doesn't handle "
+                        "Enum type " + ContigNaming.class.getSimpleName() + " doesn't accept value "
                         + contigNaming);
         }
     }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigSynonyms.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigSynonyms.java
@@ -44,6 +44,25 @@ public class ContigSynonyms {
         this.identicalGenBankAndRefSeq = identicalGenBankAndRefSeq;
     }
 
+    public String get(ContigNaming contigNaming) {
+        switch (contigNaming) {
+            case SEQUENCE_NAME:
+                return getSequenceName();
+            case ASSIGNED_MOLECULE:
+                return getAssignedMolecule();
+            case INSDC:
+                return getGenBank();
+            case REFSEQ:
+                return getRefSeq();
+            case UCSC:
+                return getUcsc();
+            default:
+                throw new RuntimeException(
+                        "Incomplete switch on enum " + ContigNaming.class.getSimpleName() + ". It doesn't handle "
+                        + contigNaming);
+        }
+    }
+
     public String getSequenceName() {
         return sequenceName;
     }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/exceptions/NonIdenticalChromosomeAccessionsException.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/exceptions/NonIdenticalChromosomeAccessionsException.java
@@ -15,6 +15,8 @@
  */
 package uk.ac.ebi.eva.accession.dbsnp.exceptions;
 
+import static org.springframework.util.StringUtils.hasText;
+
 /**
  * This exception signals a possible issue with the chromosome accession equivalences in a species.
  *
@@ -29,6 +31,9 @@ package uk.ac.ebi.eva.accession.dbsnp.exceptions;
  * We don't expect this to happen, but (at the time of writing)
  * {@link uk.ac.ebi.eva.accession.dbsnp.processors.ContigReplacerProcessor} will replace the chromosome with the
  * GenBank accession if the 'forceImport' is set.
+ *
+ * Note that this doesn't apply if refseq is not available ("CM123.1 <> na") because then it's clear that the chromosome
+ * is identical to the genbank contig, and the replacement "chromosome to genbank" can be safely done.
  */
 public class NonIdenticalChromosomeAccessionsException extends RuntimeException {
 
@@ -52,5 +57,12 @@ public class NonIdenticalChromosomeAccessionsException extends RuntimeException 
                + "' and INSDC accessions are not identical. This could mean that dbSNP (RefSeq) "
                + "chromosomes are not the same as EVA (INSDC, GenBank) chromosomes, at least for this "
                + "species.";
+    }
+
+    /**
+     * This check was extracted to give visibility to this class' documentation
+     */
+    public static boolean isExceptionApplicable(boolean genbankAndRefseqIdentical, String refSeq) {
+        return !genbankAndRefseqIdentical && hasText(refSeq);
     }
 }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/exceptions/NonIdenticalChromosomeAccessionsException.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/exceptions/NonIdenticalChromosomeAccessionsException.java
@@ -32,8 +32,8 @@ import static org.springframework.util.StringUtils.hasText;
  * {@link uk.ac.ebi.eva.accession.dbsnp.processors.ContigReplacerProcessor} will replace the chromosome with the
  * GenBank accession if the 'forceImport' is set.
  *
- * Note that this doesn't apply if refseq is not available ("CM123.1 <> na") because then it's clear that the chromosome
- * is identical to the genbank contig, and the replacement "chromosome to genbank" can be safely done.
+ * Note that this doesn't apply if RefSeq is not available ("CM123.1 <> na") because then it's clear that the chromosome
+ * is identical to the GenBank contig, and the replacement "chromosome to GenBank" can be safely done.
  */
 public class NonIdenticalChromosomeAccessionsException extends RuntimeException {
 

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/ContigSynonymValidationProcessor.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/processors/ContigSynonymValidationProcessor.java
@@ -74,7 +74,8 @@ public class ContigSynonymValidationProcessor implements ItemProcessor<Coordinat
             return false;
         }
 
-        if (!chromosomeSynonyms.isIdenticalGenBankAndRefSeq()) {
+        if (NonIdenticalChromosomeAccessionsException.isExceptionApplicable(
+                chromosomeSynonyms.isIdenticalGenBankAndRefSeq(), chromosomeSynonyms.getRefSeq())) {
             throw new NonIdenticalChromosomeAccessionsException(chromosome,
                                                                 chromosomeSynonyms.getGenBank(),
                                                                 chromosomeSynonyms.getRefSeq());

--- a/eva-accession-pipeline/README.md
+++ b/eva-accession-pipeline/README.md
@@ -4,16 +4,16 @@ This module can be used to assign SubSNP (SS) accessions to a set of variants fr
 
 The program will reserve the accessions in a database (`spring.datasource` parameters), store the accessioned variants in another database (`spring.data.mongodb` parameters), and write a VCF report with the accessioned variants.
 
-## Compiling
+## Build
 
 As the README in the root of the project explains, a basic `mvn clean install` should work.
 
-## Running
+## Run
 
 You will need to provide several parameters to run this pipeline. The easiest way to specify them is filling an `application.properties` and provide it as a CLI parameter:
 
 ```
-java -jar eva-accession-pipeline-0.3.0-SNAPSHOT-c87679a.jar --spring.config.name=application.properties
+java -jar eva-accession-pipeline-x.y.z.jar --spring.config.name=application.properties
 ```
 Note: If a file named `application.properties` is present, Spring will use it automatically even without specifying it in the `spring.config.name` parameter.
 
@@ -70,7 +70,7 @@ Available values (from ContigNaming):
 - `SEQUENCE_NAME`: Use chromosome or scaffold names.
 - `ASSIGNED_MOLECULE`: Usually similar to SEQUENCE_NAME but without prefixes.
 - `INSDC`: Use GenBank contig accessions.
-- `REFSEQ`
-- `UCSC`
+- `REFSEQ`: Use RefSeq contig accessions.
+- `UCSC`: Use chromosome names defined by UCSC, usually of the form `chr<name>`.
 
 If not provided, the default value is `SEQUENCE_NAME`.

--- a/eva-accession-pipeline/README.md
+++ b/eva-accession-pipeline/README.md
@@ -1,0 +1,72 @@
+# EVA accession pipeline
+
+This module can be used to assign SubSNP (SS) accessions to a set of variants in a VCF file.
+
+## Compiling
+
+The README in the root of the project contains basic instructions.
+
+## Running
+
+You will need to provide several parameters to run this pipeline. The easiest way is to fill an `application.properties` and provide it as a CLI parameter:
+
+```
+java -jar eva-accession-pipeline-0.3.0-SNAPSHOT-c87679a.jar --spring.config.name=application.properties`
+```
+Note: If a file named `application.properties` is present, Spring will use it automatically even without specifying it in the `spring.config.name` parameter.
+
+### Parameters
+
+Empty template of an `application.properties`:
+
+```
+spring.batch.job.names=CREATE_SUBSNP_ACCESSION_JOB
+
+accessioning.instanceId=
+accessioning.submitted.categoryId=ss
+
+accessioning.monotonic.ss.blockSize=100000
+accessioning.monotonic.ss.blockStartValue=5000000000
+accessioning.monotonic.ss.nextBlockInterval=1000000000
+
+parameters.assemblyAccession=
+parameters.taxonomyAccession=
+parameters.projectAccession=
+
+parameters.vcf=
+parameters.vcfAggregation=
+parameters.fasta=
+parameters.assemblyReportUrl=
+parameters.outputVcf=
+
+parameters.chunkSize=
+parameters.forceRestart=
+parameters.contigNaming=SEQUENCE_NAME
+
+spring.data.mongodb.database=
+mongodb.read-preference=|eva.mongo.read-preference|
+
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=
+spring.datasource.username=
+spring.datasource.password=
+spring.datasource.tomcat.max-active=3
+
+# Only to set up the database!
+# spring.jpa.generate-ddl=true
+
+spring.main.web-environment=false
+```
+
+### `parameters.contigNaming`
+
+This parameter allows selecting which contig/chromosome naming should be used in the accessioned report (the file `parameters.outputVcf`). The mapping is achieved using NCBI's assembly reports.
+
+Available values (from ContigNaming):
+- `SEQUENCE_NAME`: Use chromosome or scaffold names.
+- `ASSIGNED_MOLECULE`: Usually similar to SEQUENCE_NAME but without prefixes.
+- `INSDC`: Use GenBank contig accessions.
+- `REFSEQ`
+- `UCSC`
+
+If not provided, the default value is `SEQUENCE_NAME`.

--- a/eva-accession-pipeline/README.md
+++ b/eva-accession-pipeline/README.md
@@ -1,17 +1,19 @@
 # EVA accession pipeline
 
-This module can be used to assign SubSNP (SS) accessions to a set of variants in a VCF file.
+This module can be used to assign SubSNP (SS) accessions to a set of variants from a VCF file.
+
+The program will reserve the accessions in a database (`spring.datasource` parameters), store the accessioned variants in another database (`spring.data.mongodb` parameters), and write a VCF report with the accessioned variants.
 
 ## Compiling
 
-The README in the root of the project contains basic instructions.
+As the README in the root of the project explains, a basic `mvn clean install` should work.
 
 ## Running
 
-You will need to provide several parameters to run this pipeline. The easiest way is to fill an `application.properties` and provide it as a CLI parameter:
+You will need to provide several parameters to run this pipeline. The easiest way to specify them is filling an `application.properties` and provide it as a CLI parameter:
 
 ```
-java -jar eva-accession-pipeline-0.3.0-SNAPSHOT-c87679a.jar --spring.config.name=application.properties`
+java -jar eva-accession-pipeline-0.3.0-SNAPSHOT-c87679a.jar --spring.config.name=application.properties
 ```
 Note: If a file named `application.properties` is present, Spring will use it automatically even without specifying it in the `spring.config.name` parameter.
 
@@ -24,7 +26,6 @@ spring.batch.job.names=CREATE_SUBSNP_ACCESSION_JOB
 
 accessioning.instanceId=
 accessioning.submitted.categoryId=ss
-
 accessioning.monotonic.ss.blockSize=100000
 accessioning.monotonic.ss.blockStartValue=5000000000
 accessioning.monotonic.ss.nextBlockInterval=1000000000
@@ -32,19 +33,22 @@ accessioning.monotonic.ss.nextBlockInterval=1000000000
 parameters.assemblyAccession=
 parameters.taxonomyAccession=
 parameters.projectAccession=
-
 parameters.vcf=
 parameters.vcfAggregation=
 parameters.fasta=
 parameters.assemblyReportUrl=
 parameters.outputVcf=
-
 parameters.chunkSize=
 parameters.forceRestart=
 parameters.contigNaming=SEQUENCE_NAME
 
 spring.data.mongodb.database=
-mongodb.read-preference=|eva.mongo.read-preference|
+spring.data.mongodb.host=
+spring.data.mongodb.port=
+spring.data.mongodb.username=
+spring.data.mongodb.password=
+spring.data.mongodb.authentication-database=
+mongodb.read-preference=
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/AccessionWriterConfiguration.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/AccessionWriterConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Import;
 import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.configuration.SubmittedVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
+import uk.ac.ebi.eva.accession.core.io.FastaSynonymSequenceReader;
 import uk.ac.ebi.eva.accession.pipeline.io.AccessionReportWriter;
 import uk.ac.ebi.eva.accession.pipeline.io.AccessionWriter;
 import uk.ac.ebi.eva.accession.core.io.FastaSequenceReader;
@@ -51,7 +52,9 @@ public class AccessionWriterConfiguration {
     AccessionReportWriter accessionReportWriter(InputParameters inputParameters, ContigMapping contigMapping)
             throws IOException {
         return new AccessionReportWriter(new File(inputParameters.getOutputVcf()),
-                                         new FastaSequenceReader(Paths.get(inputParameters.getFasta())), contigMapping,
+                                         new FastaSynonymSequenceReader(contigMapping,
+                                                                        Paths.get(inputParameters.getFasta())),
+                                         contigMapping,
                                          inputParameters.getContigNaming());
     }
 

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/AccessionWriterConfiguration.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/AccessionWriterConfiguration.java
@@ -51,7 +51,8 @@ public class AccessionWriterConfiguration {
     AccessionReportWriter accessionReportWriter(InputParameters inputParameters, ContigMapping contigMapping)
             throws IOException {
         return new AccessionReportWriter(new File(inputParameters.getOutputVcf()),
-                                         new FastaSequenceReader(Paths.get(inputParameters.getFasta())), contigMapping);
+                                         new FastaSequenceReader(Paths.get(inputParameters.getFasta())), contigMapping,
+                                         inputParameters.getContigNaming());
     }
 
 }

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/AccessionWriterConfiguration.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/AccessionWriterConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Import;
 
 import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.configuration.SubmittedVariantAccessioningConfiguration;
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.pipeline.io.AccessionReportWriter;
 import uk.ac.ebi.eva.accession.pipeline.io.AccessionWriter;
 import uk.ac.ebi.eva.accession.core.io.FastaSequenceReader;
@@ -47,9 +48,10 @@ public class AccessionWriterConfiguration {
     }
 
     @Bean
-    AccessionReportWriter accessionReportWriter(InputParameters inputParameters) throws IOException {
+    AccessionReportWriter accessionReportWriter(InputParameters inputParameters, ContigMapping contigMapping)
+            throws IOException {
         return new AccessionReportWriter(new File(inputParameters.getOutputVcf()),
-                                         new FastaSequenceReader(Paths.get(inputParameters.getFasta())));
+                                         new FastaSequenceReader(Paths.get(inputParameters.getFasta())), contigMapping);
     }
 
 }

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/VariantProcessorConfiguration.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/VariantProcessorConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Configuration;
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.pipeline.parameters.InputParameters;
-import uk.ac.ebi.eva.accession.pipeline.steps.processors.ContigReplacerProcessor;
+import uk.ac.ebi.eva.accession.pipeline.steps.processors.ContigToGenbankReplacerProcessor;
 import uk.ac.ebi.eva.accession.pipeline.steps.processors.ExcludeStructuralVariantsProcessor;
 import uk.ac.ebi.eva.accession.pipeline.steps.processors.VariantProcessor;
 import uk.ac.ebi.eva.commons.core.models.IVariant;
@@ -48,11 +48,12 @@ public class VariantProcessorConfiguration {
     @StepScope
     public ItemProcessor<IVariant, ISubmittedVariant> compositeVariantProcessor(
             InputParameters inputParameters, VariantProcessor variantProcessor,
-            ContigReplacerProcessor contigReplacerProcessor,
+            ContigToGenbankReplacerProcessor contigToGenbankReplacerProcessor,
             ExcludeStructuralVariantsProcessor excludeStructuralVariantsProcessor) {
         logger.info("Injecting dbsnpVariantProcessor with parameters: {}", inputParameters);
         CompositeItemProcessor<IVariant, ISubmittedVariant> compositeProcessor = new CompositeItemProcessor<>();
-        compositeProcessor.setDelegates(Arrays.asList(excludeStructuralVariantsProcessor, contigReplacerProcessor,
+        compositeProcessor.setDelegates(Arrays.asList(excludeStructuralVariantsProcessor,
+                                                      contigToGenbankReplacerProcessor,
                                                       variantProcessor));
         return compositeProcessor;
     }
@@ -72,8 +73,8 @@ public class VariantProcessorConfiguration {
     }
 
     @Bean
-    ContigReplacerProcessor contigReplacerProcessor(ContigMapping contigMapping) {
-        return new ContigReplacerProcessor(contigMapping);
+    ContigToGenbankReplacerProcessor contigReplacerProcessor(ContigMapping contigMapping) {
+        return new ContigToGenbankReplacerProcessor(contigMapping);
     }
 
     @Bean

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/jobs/steps/CheckSubsnpAccessionsStepConfiguration.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/jobs/steps/CheckSubsnpAccessionsStepConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.pipeline.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.pipeline.steps.tasklets.reportCheck.CoordinatesVcfLineMapper;
 import uk.ac.ebi.eva.accession.pipeline.steps.tasklets.reportCheck.ReportCheckTasklet;
@@ -48,6 +49,9 @@ public class CheckSubsnpAccessionsStepConfiguration {
     private InputParameters inputParameters;
 
     @Autowired
+    private ContigMapping contigMapping;
+
+    @Autowired
     @Qualifier(VARIANT_READER)
     private ItemStreamReader<Variant> inputReader;
 
@@ -61,7 +65,7 @@ public class CheckSubsnpAccessionsStepConfiguration {
     @Bean(CHECK_SUBSNP_ACCESSION_STEP)
     public Step checkSubsnpAccessionStep(StepBuilderFactory stepBuilderFactory) throws IOException {
         ReportCheckTasklet tasklet = new ReportCheckTasklet(inputReader, reportReader(),
-                                                            inputParameters.getChunkSize() * 2);
+                                                            inputParameters.getChunkSize() * 2, contigMapping);
         TaskletStep step = stepBuilderFactory.get(CHECK_SUBSNP_ACCESSION_STEP)
                                              .tasklet(tasklet)
                                              .build();

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriter.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriter.java
@@ -160,7 +160,7 @@ public class AccessionReportWriter {
                 return createVariantWithContextBase(normalizedVariant);
             } else {
                 throw new IllegalArgumentException("Contig '" + normalizedVariant.getContig()
-                                                   + "' does not appear in the fasta file ");
+                                                   + "' does not appear in the FASTA file ");
             }
         } else {
             return normalizedVariant;
@@ -205,7 +205,7 @@ public class AccessionReportWriter {
 
     /**
      * Note that we can't use {@link ContigToGenbankReplacerProcessor} here because we allow other replacements than
-     * genbank, while that class is used to replace to genbank only (for writing in mongo and for comparing input and
+     * GenBank, while that class is used to replace to GenBank only (for writing in Mongo and for comparing input and
      * report VCFs).
      */
     private String getEquivalentContig(ISubmittedVariant normalizedVariant, ContigNaming contigNaming) {

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriter.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriter.java
@@ -148,8 +148,8 @@ public class AccessionReportWriter {
             List<? extends AccessionWrapper<ISubmittedVariant, String, Long>> accessions) {
         List<AccessionWrapper<ISubmittedVariant, String, Long>> denormalizedAccessions = new ArrayList<>();
         for (AccessionWrapper<ISubmittedVariant, String, Long> accession : accessions) {
-            denormalizedAccessions.add(new AccessionWrapper(accession.getAccession(), accession.getHash(),
-                                                            denormalizeVariant(accession.getData())));
+            denormalizedAccessions.add(new AccessionWrapper<>(accession.getAccession(), accession.getHash(),
+                                                              denormalizeVariant(accession.getData())));
         }
         return denormalizedAccessions;
     }
@@ -222,8 +222,8 @@ public class AccessionReportWriter {
             return oldContig;
         }
 
-        String replacedContig = contigSynonyms.get(contigNaming);
-        if (replacedContig == null) {
+        String contigReplacement = contigSynonyms.get(contigNaming);
+        if (contigReplacement == null) {
             if (!loggedUnreplaceableContigs.contains(oldContig)) {
                 loggedUnreplaceableContigs.add(oldContig);
                 logger.warn("Will not replace contig '" + oldContig
@@ -233,23 +233,24 @@ public class AccessionReportWriter {
             return oldContig;
         }
 
-        boolean genbankAndRefseq = oldContig.equals(contigSynonyms.getGenBank())
-                                   && replacedContig.equals(contigSynonyms.getRefSeq());
+        boolean genbankReplacedWithRefseq = oldContig.equals(contigSynonyms.getGenBank())
+                                            && contigReplacement.equals(contigSynonyms.getRefSeq());
 
-        boolean refseqAndGenbank = oldContig.equals(contigSynonyms.getRefSeq())
-                                   && replacedContig.equals(contigSynonyms.getGenBank());
+        boolean refseqReplacedWithGenbank = oldContig.equals(contigSynonyms.getRefSeq())
+                                            && contigReplacement.equals(contigSynonyms.getGenBank());
 
-        if (!contigSynonyms.isIdenticalGenBankAndRefSeq() && (genbankAndRefseq || refseqAndGenbank)) {
+        if (!contigSynonyms.isIdenticalGenBankAndRefSeq() && (genbankReplacedWithRefseq || refseqReplacedWithGenbank)) {
             if (!loggedUnreplaceableContigs.contains(oldContig)) {
                 loggedUnreplaceableContigs.add(oldContig);
-                logger.warn("Will not replace contig '" + oldContig + "' with " + contigNaming + " '" + replacedContig
-                            + "' (in the current variant or any subsequent one) as requested because those contigs "
-                            + "are not identical according to the assembly report provided.");
+                logger.warn(
+                        "Will not replace contig '" + oldContig + "' with " + contigNaming + " '" + contigReplacement
+                        + "' (in the current variant or any subsequent one) as requested because those contigs "
+                        + "are not identical according to the assembly report provided.");
             }
             return oldContig;
         }
 
-        return replacedContig;
+        return contigReplacement;
     }
 
 }

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriter.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriter.java
@@ -24,6 +24,7 @@ import uk.ac.ebi.ampt2d.commons.accession.core.models.AccessionWrapper;
 
 import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariant;
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.core.io.FastaSequenceReader;
 import uk.ac.ebi.eva.accession.pipeline.steps.tasklets.reportCheck.AccessionWrapperComparator;
 
@@ -54,7 +55,7 @@ public class AccessionReportWriter {
 
     private String accessionPrefix;
 
-    public AccessionReportWriter(File output, FastaSequenceReader fastaSequenceReader) throws IOException {
+    public AccessionReportWriter(File output, FastaSequenceReader fastaSequenceReader, ContigMapping contigMapping) throws IOException {
         this.fastaSequenceReader = fastaSequenceReader;
         this.output = output;
         this.accessionPrefix = ACCESSION_PREFIX;

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/parameters/InputParameters.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/parameters/InputParameters.java
@@ -18,6 +18,7 @@ package uk.ac.ebi.eva.accession.pipeline.parameters;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 
+import uk.ac.ebi.eva.accession.core.contig.ContigNaming;
 import uk.ac.ebi.eva.commons.core.models.Aggregation;
 
 public class InputParameters {
@@ -43,6 +44,23 @@ public class InputParameters {
     private int chunkSize;
 
     private boolean forceRestart;
+
+    private ContigNaming contigNaming;
+
+    public JobParameters toJobParameters() {
+        return new JobParametersBuilder()
+                .addString("vcf", vcf)
+                .addString("vcfAggregation", vcfAggregation.toString())
+                .addString("aggregatedMappingFile", aggregatedMappingFile)
+                .addString("fasta", fasta)
+                .addString("outputVcf", outputVcf)
+                .addLong("taxonomyAccession", (long)taxonomyAccession)
+                .addString("assemblyAccession", assemblyAccession)
+                .addString("projectAccession", projectAccession)
+                .addLong("chunkSize", (long)chunkSize)
+                .addString("contigNaming", contigNaming.toString())
+                .toJobParameters();
+    }
 
     public String getVcf() {
         return vcf;
@@ -124,25 +142,19 @@ public class InputParameters {
         this.chunkSize = chunkSize;
     }
 
-    public JobParameters toJobParameters() {
-        return new JobParametersBuilder()
-                .addString("vcf", vcf)
-                .addString("vcfAggregation", vcfAggregation.toString())
-                .addString("aggregatedMappingFile", aggregatedMappingFile)
-                .addString("fasta", fasta)
-                .addString("outputVcf", outputVcf)
-                .addLong("taxonomyAccession", (long)taxonomyAccession)
-                .addString("assemblyAccession", assemblyAccession)
-                .addString("projectAccession", projectAccession)
-                .addLong("chunkSize", (long)chunkSize)
-                .toJobParameters();
-    }
-
     public boolean isForceRestart() {
         return forceRestart;
     }
 
     public void setForceRestart(boolean forceRestart) {
         this.forceRestart = forceRestart;
+    }
+
+    public ContigNaming getContigNaming() {
+        return contigNaming;
+    }
+
+    public void setContigNaming(ContigNaming contigNaming) {
+        this.contigNaming = contigNaming;
     }
 }

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigReplacerProcessor.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigReplacerProcessor.java
@@ -69,7 +69,7 @@ public class ContigReplacerProcessor implements ItemProcessor<IVariant, IVariant
      * - Genbank and Refseq are identical or are not identical but there is no RefSeq accession
      * - Contig has Genbank synonym
      */
-    private boolean isReplacementPossible(IVariant variant, ContigSynonyms contigSynonyms, StringBuilder message) {
+    public static boolean isReplacementPossible(IVariant variant, ContigSynonyms contigSynonyms, StringBuilder message) {
         if (contigSynonyms == null) {
             message.append("Contig '" + variant.getChromosome() + "' was not found in the assembly report!");
         } else if(!contigSynonyms.isIdenticalGenBankAndRefSeq() && contigSynonyms.getRefSeq() != null) {

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigToGenbankReplacerProcessor.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigToGenbankReplacerProcessor.java
@@ -72,14 +72,21 @@ public class ContigToGenbankReplacerProcessor implements ItemProcessor<IVariant,
     public static boolean isReplacementPossible(IVariant variant, ContigSynonyms contigSynonyms, StringBuilder message) {
         if (contigSynonyms == null) {
             message.append("Contig '" + variant.getChromosome() + "' was not found in the assembly report!");
-        } else if(!contigSynonyms.isIdenticalGenBankAndRefSeq() && contigSynonyms.getRefSeq() != null) {
+            return false;
+        }
+
+        if(!contigSynonyms.isIdenticalGenBankAndRefSeq() && contigSynonyms.getRefSeq() != null) {
             message.append("Genbank and refseq not identical in the assembly report for contig '"
                                    + variant.getChromosome() + "'. No conversion performed");
-        } else if(contigSynonyms.getGenBank() == null) {
+            return false;
+        }
+
+        if(contigSynonyms.getGenBank() == null) {
             message.append("No Genbank equivalent found for contig '" + variant.getChromosome()
                                    + "' in the assembly report");
+            return false;
         }
-        return message.toString().isEmpty();
+        return true;
     }
 
     private IVariant replaceContigWithGenbankAccession(IVariant variant, ContigSynonyms contigSynonyms) {

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigToGenbankReplacerProcessor.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigToGenbankReplacerProcessor.java
@@ -33,15 +33,15 @@ import java.util.stream.Collectors;
  * Converts the contig to its GenBank synonym when possible. If the synonym can't be determined it keeps the contig as
  * is
  */
-public class ContigReplacerProcessor implements ItemProcessor<IVariant, IVariant> {
+public class ContigToGenbankReplacerProcessor implements ItemProcessor<IVariant, IVariant> {
 
-    private static final Logger logger = LoggerFactory.getLogger(ContigReplacerProcessor.class);
+    private static final Logger logger = LoggerFactory.getLogger(ContigToGenbankReplacerProcessor.class);
 
     private ContigMapping contigMapping;
 
     private Set<String> processedContigs;
 
-    public ContigReplacerProcessor(ContigMapping contigMapping) {
+    public ContigToGenbankReplacerProcessor(ContigMapping contigMapping) {
         this.contigMapping = contigMapping;
         this.processedContigs = new HashSet<>();
     }

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigToGenbankReplacerProcessor.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigToGenbankReplacerProcessor.java
@@ -52,7 +52,7 @@ public class ContigToGenbankReplacerProcessor implements ItemProcessor<IVariant,
         ContigSynonyms contigSynonyms = contigMapping.getContigSynonyms(contigName);
 
         StringBuilder message = new StringBuilder();
-        if (isReplacementPossible(variant, contigSynonyms, message)) {
+        if (contigMapping.isGenbankReplacementPossible(contigName, contigSynonyms, message)) {
             return replaceContigWithGenbankAccession(variant, contigSynonyms);
         } else {
             if (!processedContigs.contains(contigName)) {
@@ -61,32 +61,6 @@ public class ContigToGenbankReplacerProcessor implements ItemProcessor<IVariant,
             }
             return variant;
         }
-    }
-
-    /**
-     * Replacement only possible if:
-     * - Contig has synonyms
-     * - Genbank and Refseq are identical or are not identical but there is no RefSeq accession
-     * - Contig has Genbank synonym
-     */
-    public static boolean isReplacementPossible(IVariant variant, ContigSynonyms contigSynonyms, StringBuilder message) {
-        if (contigSynonyms == null) {
-            message.append("Contig '" + variant.getChromosome() + "' was not found in the assembly report!");
-            return false;
-        }
-
-        if(!contigSynonyms.isIdenticalGenBankAndRefSeq() && contigSynonyms.getRefSeq() != null) {
-            message.append("Genbank and refseq not identical in the assembly report for contig '"
-                                   + variant.getChromosome() + "'. No conversion performed");
-            return false;
-        }
-
-        if(contigSynonyms.getGenBank() == null) {
-            message.append("No Genbank equivalent found for contig '" + variant.getChromosome()
-                                   + "' in the assembly report");
-            return false;
-        }
-        return true;
     }
 
     private IVariant replaceContigWithGenbankAccession(IVariant variant, ContigSynonyms contigSynonyms) {

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/tasklets/reportCheck/ReportCheckTasklet.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/tasklets/reportCheck/ReportCheckTasklet.java
@@ -152,7 +152,7 @@ public class ReportCheckTasklet implements Tasklet {
 
     private String getEquivalentGenbankContig(Variant variant) {
         ContigSynonyms contigSynonyms = contigMapping.getContigSynonyms(variant.getChromosome());
-        if (ContigToGenbankReplacerProcessor.isReplacementPossible(variant, contigSynonyms, new StringBuilder())) {
+        if (contigMapping.isGenbankReplacementPossible(variant.getChromosome(), contigSynonyms, new StringBuilder())) {
             return contigSynonyms.getGenBank();
         } else {
             return variant.getChromosome();

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/tasklets/reportCheck/ReportCheckTasklet.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/tasklets/reportCheck/ReportCheckTasklet.java
@@ -26,6 +26,7 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.repeat.RepeatStatus;
 
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.pipeline.policies.InvalidVariantSkipPolicy;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
@@ -68,11 +69,14 @@ public class ReportCheckTasklet implements Tasklet {
 
     private SkipPolicy skipPolicy;
 
+    private ContigMapping contigMapping;
+
     public ReportCheckTasklet(ItemStreamReader<Variant> inputReader, ItemStreamReader<Variant> reportReader,
-                              long initialBufferSize) {
+                              long initialBufferSize, ContigMapping contigMapping) {
         this.inputBufferHelper = new BufferHelper(inputReader);
         this.reportBufferHelper = new BufferHelper(reportReader);
         this.initialBufferSize = initialBufferSize;
+        this.contigMapping = contigMapping;
         this.maxBufferSize = 0;
         this.iterations = 0;
         this.skipPolicy = new InvalidVariantSkipPolicy();

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/tasklets/reportCheck/ReportCheckTasklet.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/steps/tasklets/reportCheck/ReportCheckTasklet.java
@@ -29,7 +29,7 @@ import org.springframework.batch.repeat.RepeatStatus;
 import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
 import uk.ac.ebi.eva.accession.pipeline.policies.InvalidVariantSkipPolicy;
-import uk.ac.ebi.eva.accession.pipeline.steps.processors.ContigReplacerProcessor;
+import uk.ac.ebi.eva.accession.pipeline.steps.processors.ContigToGenbankReplacerProcessor;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
 import java.util.HashSet;
@@ -143,15 +143,16 @@ public class ReportCheckTasklet implements Tasklet {
             }
         }
         if (variant != null) {
-            String contig = replaceContig(variant);
-            variant = new Variant(contig, variant.getStart(), variant.getEnd(), variant.getReference(), variant.getAlternate());
+            String contig = getEquivalentGenbankContig(variant);
+            variant = new Variant(contig, variant.getStart(), variant.getEnd(), variant.getReference(),
+                                  variant.getAlternate());
         }
         return variant;
     }
 
-    private String replaceContig(Variant variant) {
+    private String getEquivalentGenbankContig(Variant variant) {
         ContigSynonyms contigSynonyms = contigMapping.getContigSynonyms(variant.getChromosome());
-        if (ContigReplacerProcessor.isReplacementPossible(variant, contigSynonyms, new StringBuilder())) {
+        if (ContigToGenbankReplacerProcessor.isReplacementPossible(variant, contigSynonyms, new StringBuilder())) {
             return contigSynonyms.getGenBank();
         } else {
             return variant.getChromosome();

--- a/eva-accession-pipeline/src/main/resources/application.properties
+++ b/eva-accession-pipeline/src/main/resources/application.properties
@@ -2,7 +2,6 @@ spring.batch.job.names=
 
 accessioning.instanceId=
 accessioning.submitted.categoryId=ss
-
 accessioning.monotonic.ss.blockSize=100000
 accessioning.monotonic.ss.blockStartValue=5000000000
 accessioning.monotonic.ss.nextBlockInterval=1000000000
@@ -10,18 +9,21 @@ accessioning.monotonic.ss.nextBlockInterval=1000000000
 parameters.assemblyAccession=
 parameters.taxonomyAccession=
 parameters.projectAccession=
-
 parameters.vcf=
 parameters.vcfAggregation=
 parameters.fasta=
 parameters.assemblyReportUrl=
 parameters.outputVcf=
-
 parameters.chunkSize=
 parameters.forceRestart=
 parameters.contigNaming=SEQUENCE_NAME
 
 spring.data.mongodb.database=
+spring.data.mongodb.host=
+spring.data.mongodb.port=
+spring.data.mongodb.username=
+spring.data.mongodb.password=
+spring.data.mongodb.authentication-database=
 mongodb.read-preference=|eva.mongo.read-preference|
 
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/eva-accession-pipeline/src/main/resources/application.properties
+++ b/eva-accession-pipeline/src/main/resources/application.properties
@@ -17,6 +17,7 @@ parameters.fasta=
 
 parameters.chunkSize=
 parameters.forceRestart=
+parameters.contigNaming=SEQUENCE_NAME
 
 spring.data.mongodb.database=
 mongodb.read-preference=|eva.mongo.read-preference|

--- a/eva-accession-pipeline/src/main/resources/application.properties
+++ b/eva-accession-pipeline/src/main/resources/application.properties
@@ -14,6 +14,8 @@ parameters.projectAccession=
 parameters.vcf=
 parameters.vcfAggregation=
 parameters.fasta=
+parameters.assemblyReportUrl=
+parameters.outputVcf=
 
 parameters.chunkSize=
 parameters.forceRestart=

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
@@ -87,7 +87,17 @@ public class AccessionReportWriterTest {
 
     private static final String REFSEQ_2 = "refseq_2";
 
+    private static final String SEQUENCE_NAME_3 = "ctg3";
+
     private static final String GENBANK_3 = "genbank_3";
+
+    private static final String REFSEQ_3 = "refseq_3";
+
+    private static final String SEQUENCE_NAME_4 = "ctg4";
+
+    private static final String GENBANK_4 = "genbank_4";
+
+    private static final String REFSEQ_4 = "refseq_4";
 
     private AccessionReportWriter accessionReportWriter;
 
@@ -110,7 +120,8 @@ public class AccessionReportWriterTest {
         contigMapping = new ContigMapping(Arrays.asList(
                 new ContigSynonyms(CHROMOSOME_1, "assembled-molecule", "1", CONTIG_1, "refseq_1", "chr1", true),
                 new ContigSynonyms("chr2", "assembled-molecule", "2", GENBANK_2, REFSEQ_2, "chr2", false),
-                new ContigSynonyms("ctg3", "unlocalized-scaffold", "1", GENBANK_3, "refseq_3", "chr3_random", true)));
+                new ContigSynonyms(SEQUENCE_NAME_3, "unlocalized-scaffold", "1", GENBANK_3, REFSEQ_3, "chr3_random", true),
+                new ContigSynonyms(SEQUENCE_NAME_4, "unlocalized-scaffold", "4", GENBANK_4, REFSEQ_4, "chr4_random", true)));
         accessionReportWriter = new AccessionReportWriter(output, fastaSequenceReader, contigMapping,
                                                           ContigNaming.SEQUENCE_NAME);
         executionContext = new ExecutionContext();
@@ -271,7 +282,7 @@ public class AccessionReportWriterTest {
     private void assertContigReplacement(String originalContig, ContigNaming requestedReplacement,
                                          String replacementContig) throws IOException {
         SubmittedVariant variant = new SubmittedVariant("accession", TAXONOMY, "project", originalContig,
-                                                        START_1, REFERENCE, ALTERNATE, CLUSTERED_VARIANT,
+                                                        START_1, "", ALTERNATE, CLUSTERED_VARIANT,
                                                         SUPPORTED_BY_EVIDENCE, MATCHES_ASSEMBLY, ALLELES_MATCH,
                                                         VALIDATED, null);
 
@@ -304,6 +315,15 @@ public class AccessionReportWriterTest {
     @Test
     public void writeContigWithoutIdenticalReplacement() throws IOException {
         assertContigReplacement(REFSEQ_2, ContigNaming.INSDC, REFSEQ_2);
+    }
+
+    /**
+     * Note how in the fasta there's no entry for GENBANK_4 nor SEQUENCE_NAME_4, only for REFSEQ_4
+     * @throws IOException
+     */
+    @Test
+    public void writeContigWithSynonymFasta() throws IOException {
+        assertContigReplacement(GENBANK_4, ContigNaming.SEQUENCE_NAME, SEQUENCE_NAME_4);
     }
 
 }

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
@@ -120,8 +120,10 @@ public class AccessionReportWriterTest {
         contigMapping = new ContigMapping(Arrays.asList(
                 new ContigSynonyms(CHROMOSOME_1, "assembled-molecule", "1", CONTIG_1, "refseq_1", "chr1", true),
                 new ContigSynonyms("chr2", "assembled-molecule", "2", GENBANK_2, REFSEQ_2, "chr2", false),
-                new ContigSynonyms(SEQUENCE_NAME_3, "unlocalized-scaffold", "1", GENBANK_3, REFSEQ_3, "chr3_random", true),
-                new ContigSynonyms(SEQUENCE_NAME_4, "unlocalized-scaffold", "4", GENBANK_4, REFSEQ_4, "chr4_random", true)));
+                new ContigSynonyms(SEQUENCE_NAME_3, "unlocalized-scaffold", "1", GENBANK_3, REFSEQ_3, "chr3_random",
+                                   true),
+                new ContigSynonyms(SEQUENCE_NAME_4, "unlocalized-scaffold", "4", GENBANK_4, REFSEQ_4, "chr4_random",
+                                   true)));
         fastaSequenceReader = new FastaSynonymSequenceReader(contigMapping, fastaPath);
         accessionReportWriter = new AccessionReportWriter(output, fastaSequenceReader, contigMapping,
                                                           ContigNaming.SEQUENCE_NAME);
@@ -320,7 +322,6 @@ public class AccessionReportWriterTest {
 
     /**
      * Note how in the fasta there's no entry for GENBANK_4 nor SEQUENCE_NAME_4, only for REFSEQ_4
-     * @throws IOException
      */
     @Test
     public void writeContigWithSynonymFasta() throws IOException {

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
@@ -28,6 +28,7 @@ import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.core.contig.ContigNaming;
 import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
 import uk.ac.ebi.eva.accession.core.io.FastaSequenceReader;
+import uk.ac.ebi.eva.accession.core.io.FastaSynonymSequenceReader;
 import uk.ac.ebi.eva.accession.pipeline.steps.tasklets.reportCheck.AccessionWrapperComparator;
 import uk.ac.ebi.eva.commons.core.utils.FileUtils;
 
@@ -116,12 +117,12 @@ public class AccessionReportWriterTest {
     public void setUp() throws Exception {
         output = temporaryFolderRule.newFile();
         Path fastaPath = Paths.get(AccessionReportWriterTest.class.getResource("/input-files/fasta/mock.fa").toURI());
-        fastaSequenceReader = new FastaSequenceReader(fastaPath);
         contigMapping = new ContigMapping(Arrays.asList(
                 new ContigSynonyms(CHROMOSOME_1, "assembled-molecule", "1", CONTIG_1, "refseq_1", "chr1", true),
                 new ContigSynonyms("chr2", "assembled-molecule", "2", GENBANK_2, REFSEQ_2, "chr2", false),
                 new ContigSynonyms(SEQUENCE_NAME_3, "unlocalized-scaffold", "1", GENBANK_3, REFSEQ_3, "chr3_random", true),
                 new ContigSynonyms(SEQUENCE_NAME_4, "unlocalized-scaffold", "4", GENBANK_4, REFSEQ_4, "chr4_random", true)));
+        fastaSequenceReader = new FastaSynonymSequenceReader(contigMapping, fastaPath);
         accessionReportWriter = new AccessionReportWriter(output, fastaSequenceReader, contigMapping,
                                                           ContigNaming.SEQUENCE_NAME);
         executionContext = new ExecutionContext();
@@ -300,7 +301,7 @@ public class AccessionReportWriterTest {
         assertEquals(replacementContig, getFirstVariantLine(output).split("\t")[CHROMOSOME_COLUMN_VCF]);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void writeContigWithoutEquivalent() throws IOException {
         String contigMissingInAssemblyReport = "contig_missing_in_assembly_report";
         assertContigReplacement(contigMissingInAssemblyReport, ContigNaming.SEQUENCE_NAME,

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
@@ -321,8 +321,8 @@ public class AccessionReportWriterTest {
     }
 
     /**
-     * This test checks that the context base is added from the fasta, and it doesn't matter which contig naming the
-     * fasta uses: it's independent of the accessioned contig naming (genbank) and the VCF report contig naming.
+     * This test checks that the context base is added from the FASTA, and it doesn't matter which contig naming the
+     * FASTA uses: it's independent of the accessioned contig naming (GenBank) and the VCF report contig naming.
      *
      * Note how in the fasta there's no entry for GENBANK_4 nor SEQUENCE_NAME_4, only for REFSEQ_4
      */

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
@@ -311,7 +311,7 @@ public class AccessionReportWriterTest {
     }
 
     @Test
-    public void writeContigIgnoringNonAssembledMolecule() throws IOException {
+    public void writeContigWithNoAvailableAssignedMolecule() throws IOException {
         assertContigReplacement(GENBANK_3, ContigNaming.ASSIGNED_MOLECULE, GENBANK_3);
     }
 
@@ -321,6 +321,9 @@ public class AccessionReportWriterTest {
     }
 
     /**
+     * This test checks that the context base is added from the fasta, and it doesn't matter which contig naming the
+     * fasta uses: it's independent of the accessioned contig naming (genbank) and the VCF report contig naming.
+     *
      * Note how in the fasta there's no entry for GENBANK_4 nor SEQUENCE_NAME_4, only for REFSEQ_4
      */
     @Test

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionReportWriterTest.java
@@ -87,6 +87,8 @@ public class AccessionReportWriterTest {
 
     private static final String REFSEQ_2 = "refseq_2";
 
+    private static final String GENBANK_3 = "genbank_3";
+
     private AccessionReportWriter accessionReportWriter;
 
     private File output;
@@ -108,9 +110,7 @@ public class AccessionReportWriterTest {
         contigMapping = new ContigMapping(Arrays.asList(
                 new ContigSynonyms(CHROMOSOME_1, "assembled-molecule", "1", CONTIG_1, "refseq_1", "chr1", true),
                 new ContigSynonyms("chr2", "assembled-molecule", "2", GENBANK_2, REFSEQ_2, "chr2", false),
-                new ContigSynonyms("ctg3", "unlocalized-scaffold", "1", "genbank_3", "refseq_3", "chr3_random", true),
-                new ContigSynonyms("ctg4", "unlocalized-scaffold", "2", "genbank_4", "refseq_4", "chr4_random",
-                                   false)));
+                new ContigSynonyms("ctg3", "unlocalized-scaffold", "1", GENBANK_3, "refseq_3", "chr3_random", true)));
         accessionReportWriter = new AccessionReportWriter(output, fastaSequenceReader, contigMapping,
                                                           ContigNaming.SEQUENCE_NAME);
         executionContext = new ExecutionContext();
@@ -294,6 +294,11 @@ public class AccessionReportWriterTest {
         String contigMissingInAssemblyReport = "contig_missing_in_assembly_report";
         assertContigReplacement(contigMissingInAssemblyReport, ContigNaming.SEQUENCE_NAME,
                                 contigMissingInAssemblyReport);
+    }
+
+    @Test
+    public void writeContigIgnoringNonAssembledMolecule() throws IOException {
+        assertContigReplacement(GENBANK_3, ContigNaming.ASSIGNED_MOLECULE, GENBANK_3);
     }
 
     @Test

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
@@ -36,6 +36,7 @@ import uk.ac.ebi.eva.accession.core.SubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.configuration.SubmittedVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
+import uk.ac.ebi.eva.accession.core.contig.ContigNaming;
 import uk.ac.ebi.eva.accession.core.io.FastaSequenceReader;
 import uk.ac.ebi.eva.accession.pipeline.test.MongoTestConfiguration;
 
@@ -116,7 +117,8 @@ public class AccessionWriterTest {
         Path fastaPath = Paths.get(AccessionReportWriterTest.class.getResource("/input-files/fasta/mock.fa").toURI());
         AccessionReportWriter accessionReportWriter = new AccessionReportWriter(output,
                                                                                 new FastaSequenceReader(fastaPath),
-                                                                                contigMapping);
+                                                                                contigMapping,
+                                                                                ContigNaming.SEQUENCE_NAME);
         accessionWriter = new AccessionWriter(service, accessionReportWriter);
         accessionReportWriter.open(new ExecutionContext());
     }

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
@@ -35,6 +35,7 @@ import uk.ac.ebi.eva.accession.core.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariant;
 import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.configuration.SubmittedVariantAccessioningConfiguration;
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.core.io.FastaSequenceReader;
 import uk.ac.ebi.eva.accession.pipeline.test.MongoTestConfiguration;
 
@@ -96,6 +97,9 @@ public class AccessionWriterTest {
     @Autowired
     private SubmittedVariantAccessioningService service;
 
+    @Autowired
+    private ContigMapping contigMapping;
+
     @Rule
     public TemporaryFolder temporaryFolderRule = new TemporaryFolder();
 
@@ -111,7 +115,8 @@ public class AccessionWriterTest {
         output = temporaryFolderRule.newFile();
         Path fastaPath = Paths.get(AccessionReportWriterTest.class.getResource("/input-files/fasta/mock.fa").toURI());
         AccessionReportWriter accessionReportWriter = new AccessionReportWriter(output,
-                                                                                new FastaSequenceReader(fastaPath));
+                                                                                new FastaSequenceReader(fastaPath),
+                                                                                contigMapping);
         accessionWriter = new AccessionWriter(service, accessionReportWriter);
         accessionReportWriter.open(new ExecutionContext());
     }

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/io/AccessionWriterTest.java
@@ -37,6 +37,7 @@ import uk.ac.ebi.eva.accession.core.SubmittedVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.configuration.SubmittedVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.core.contig.ContigNaming;
+import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
 import uk.ac.ebi.eva.accession.core.io.FastaSequenceReader;
 import uk.ac.ebi.eva.accession.pipeline.test.MongoTestConfiguration;
 
@@ -69,9 +70,13 @@ public class AccessionWriterTest {
 
     private static final long EXPECTED_ACCESSION = 5000000000L;
 
-    private static final String CONTIG_1 = "contig_1";
+    private static final String CONTIG_1 = "genbank_1";
 
-    private static final String CONTIG_2 = "contig_2";
+    private static final String CHROMOSOME_1 = "chr1";
+
+    private static final String CONTIG_2 = "genbank_2";
+
+    private static final String CHROMOSOME_2 = "chr2";
 
     private static final int START_1 = 2;
 
@@ -98,7 +103,6 @@ public class AccessionWriterTest {
     @Autowired
     private SubmittedVariantAccessioningService service;
 
-    @Autowired
     private ContigMapping contigMapping;
 
     @Rule
@@ -113,6 +117,9 @@ public class AccessionWriterTest {
 
     @Before
     public void setUp() throws Exception {
+        contigMapping = new ContigMapping(Arrays.asList(
+                new ContigSynonyms(CHROMOSOME_1, "assembled-molecule", "1", CONTIG_1, "refseq_1", "chr1", true),
+                new ContigSynonyms(CHROMOSOME_2, "assembled-molecule", "2", CONTIG_2, "refseq_2", "chr2", true)));
         output = temporaryFolderRule.newFile();
         Path fastaPath = Paths.get(AccessionReportWriterTest.class.getResource("/input-files/fasta/mock.fa").toURI());
         AccessionReportWriter accessionReportWriter = new AccessionReportWriter(output,
@@ -185,9 +192,9 @@ public class AccessionWriterTest {
                 service.get(Arrays.asList(firstVariant, secondVariant));
         assertEquals(2, accessions.size());
 
-        int firstVariantLineNumber = getVariantLineNumberByPosition(output, CONTIG_1 + "\t" + START_1);
+        int firstVariantLineNumber = getVariantLineNumberByPosition(output, CHROMOSOME_1 + "\t" + START_1);
         //secondVariant position is 1 because it is an insertion and the context base is added
-        int secondVariantLineNumber = getVariantLineNumberByPosition(output, CONTIG_1 + "\t" + (START_1 - 1));
+        int secondVariantLineNumber = getVariantLineNumberByPosition(output, CHROMOSOME_1 + "\t" + (START_1 - 1));
         assertTrue(firstVariantLineNumber > secondVariantLineNumber);
     }
 
@@ -306,12 +313,12 @@ public class AccessionWriterTest {
         while ((line = fileInputStream.readLine()) != null && line.startsWith("#")) {
         }
 
-        assertThat(line, Matchers.startsWith(CONTIG_1 + "\t" + START_1));
+        assertThat(line, Matchers.startsWith(CHROMOSOME_1 + "\t" + START_1));
         line = fileInputStream.readLine();
-        assertThat(line, Matchers.startsWith(CONTIG_1 + "\t" + START_2));
+        assertThat(line, Matchers.startsWith(CHROMOSOME_1 + "\t" + START_2));
         line = fileInputStream.readLine();
-        assertThat(line, Matchers.startsWith(CONTIG_2 + "\t" + START_1));
+        assertThat(line, Matchers.startsWith(CHROMOSOME_2 + "\t" + START_1));
         line = fileInputStream.readLine();
-        assertThat(line, Matchers.startsWith(CONTIG_2 + "\t" + START_2));
+        assertThat(line, Matchers.startsWith(CHROMOSOME_2 + "\t" + START_2));
     }
 }

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigToGenbankReplacerProcessorTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/steps/processors/ContigToGenbankReplacerProcessorTest.java
@@ -23,17 +23,17 @@ import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
 import static org.junit.Assert.assertEquals;
 
-public class ContigReplacerProcessorTest {
+public class ContigToGenbankReplacerProcessorTest {
 
-    private ContigReplacerProcessor processor;
+    private ContigToGenbankReplacerProcessor processor;
 
     @Before
     public void setUp() throws Exception {
-        String fileString = ContigReplacerProcessorTest.class.getResource(
+        String fileString = ContigToGenbankReplacerProcessorTest.class.getResource(
                 "/input-files/assembly-report/assembly_report.txt").toString();
         ContigMapping contigMapping = new ContigMapping(fileString);
 
-        processor = new ContigReplacerProcessor(contigMapping);
+        processor = new ContigToGenbankReplacerProcessor(contigMapping);
     }
 
     @Test

--- a/eva-accession-pipeline/src/test/resources/accession-pipeline-interval-test.properties
+++ b/eva-accession-pipeline/src/test/resources/accession-pipeline-interval-test.properties
@@ -15,6 +15,7 @@ parameters.vcfAggregation=NONE
 parameters.fasta=src/test/resources/input-files/fasta/Homo_sapiens.GRCh37.75.chr20.head_1200.fa
 parameters.outputVcf=/tmp/accession-output.vcf
 parameters.assemblyReportUrl=file:src/test/resources/input-files/assembly-report/assembly_report.txt
+parameters.contigNaming=SEQUENCE_NAME
 
 spring.jpa.show-sql=true
 

--- a/eva-accession-pipeline/src/test/resources/accession-pipeline-recover-test.properties
+++ b/eva-accession-pipeline/src/test/resources/accession-pipeline-recover-test.properties
@@ -23,6 +23,7 @@ parameters.vcfAggregation=NONE
 parameters.fasta=src/test/resources/input-files/fasta/Homo_sapiens.GRCh37.75.chr20.head_1200.fa
 parameters.outputVcf=/tmp/accession-output.vcf
 parameters.assemblyReportUrl=file:src/test/resources/input-files/assembly-report/assembly_report.txt
+parameters.contigNaming=SEQUENCE_NAME
 
 spring.jpa.show-sql=true
 

--- a/eva-accession-pipeline/src/test/resources/accession-pipeline-test.properties
+++ b/eva-accession-pipeline/src/test/resources/accession-pipeline-test.properties
@@ -15,6 +15,7 @@ parameters.vcfAggregation=NONE
 parameters.fasta=src/test/resources/input-files/fasta/Homo_sapiens.GRCh37.75.chr20.head_1200.fa
 parameters.outputVcf=/tmp/accession-output.vcf
 parameters.assemblyReportUrl=file:src/test/resources/input-files/assembly-report/assembly_report.txt
+parameters.contigNaming=SEQUENCE_NAME
 
 spring.jpa.show-sql=true
 

--- a/eva-accession-pipeline/src/test/resources/input-files/assembly-report/assembly_report.txt
+++ b/eva-accession-pipeline/src/test/resources/input-files/assembly-report/assembly_report.txt
@@ -7,3 +7,4 @@ chr4	assembled-molecule	4	Chromosome	na	=	NW_003763687.1	Primary Assembly	111302
 chr5	assembled-molecule	5	Chromosome	na	<>	NW_003763688.1	Primary Assembly	111302124	chr5
 chr6	assembled-molecule	6	Chromosome	CM000096.4	<>	na	Primary Assembly	111302125	chr6
 chr7	assembled-molecule	7	Chromosome	na	<>	na	Primary Assembly	111302126	chr7
+20	assembled-molecule	20	Chromosome	20	=	20	Primary	Assembly	111302126	20

--- a/eva-accession-pipeline/src/test/resources/input-files/assembly-report/mock_report.txt
+++ b/eva-accession-pipeline/src/test/resources/input-files/assembly-report/mock_report.txt
@@ -1,6 +1,0 @@
-# mocking of an assembly report
-# Sequence-Name	Sequence-Role	Assigned-Molecule	Assigned-Molecule-Location/Type	GenBank-Accn	Relationship	RefSeq-Accn	Assembly-Unit	Sequence-Length	UCSC-style-name
-chr1	assembled-molecule	1	Chromosome	genbank_1	=	refseq_1	Primary Assembly	196202544	chr1
-chr2	assembled-molecule	2	Chromosome	genbank_2	<>	refseq_2	Primary Assembly	149560735	chr2
-ctg3	unlocalized-scaffold	1	Chromosome	genbank_3	=	refseq_3	C57BL/6J	169725	chr1_GL456210_random
-ctg4	unlocalized-scaffold	2	Chromosome	genbank_4	<>	refseq_4	C57BL/6J	169725	chr1_GL456210_random

--- a/eva-accession-pipeline/src/test/resources/input-files/assembly-report/mock_report.txt
+++ b/eva-accession-pipeline/src/test/resources/input-files/assembly-report/mock_report.txt
@@ -1,0 +1,6 @@
+# mocking of an assembly report
+# Sequence-Name	Sequence-Role	Assigned-Molecule	Assigned-Molecule-Location/Type	GenBank-Accn	Relationship	RefSeq-Accn	Assembly-Unit	Sequence-Length	UCSC-style-name
+chr1	assembled-molecule	1	Chromosome	genbank_1	=	refseq_1	Primary Assembly	196202544	chr1
+chr2	assembled-molecule	2	Chromosome	genbank_2	<>	refseq_2	Primary Assembly	149560735	chr2
+ctg3	unlocalized-scaffold	1	Chromosome	genbank_3	=	refseq_3	C57BL/6J	169725	chr1_GL456210_random
+ctg4	unlocalized-scaffold	2	Chromosome	genbank_4	<>	refseq_4	C57BL/6J	169725	chr1_GL456210_random

--- a/eva-accession-pipeline/src/test/resources/input-files/fasta/mock.fa
+++ b/eva-accession-pipeline/src/test/resources/input-files/fasta/mock.fa
@@ -1,4 +1,4 @@
->contig_1
+>genbank_1
 GTCAGTCAGTCA
->contig_2
+>genbank_2
 GTCAGTCAGTCA

--- a/eva-accession-pipeline/src/test/resources/input-files/fasta/mock.fa
+++ b/eva-accession-pipeline/src/test/resources/input-files/fasta/mock.fa
@@ -1,4 +1,10 @@
 >genbank_1
 GTCAGTCAGTCA
->genbank_2
+>refseq_2
+GTCAGTCAGTCA
+>genbank_3
+GTCAGTCAGTCA
+>refseq_4
+GTCAGTCAGTCA
+>contig_missing_in_assembly_report
 GTCAGTCAGTCA


### PR DESCRIPTION
Using the original chromosomes is actually harder than I expected because we accession using the replaced contigs, and to match them with the original contigs we would need to pass both copies of each variant along the spring batch step. Currently, once we reach the writer to accession the variants, we only have the replaced contig.

Instead, this PR introduces a parameter `parameters.contigNaming` to write the report. It has these possible values:
```
public enum ContigNaming {
    SEQUENCE_NAME,  // this is the same as chromosome names
    ASSIGNED_MOLECULE,
    INSDC,  // this is the same as GenBank
    REFSEQ,
    UCSC
}
```
and default value SEQUENCE_NAME.

The report check tasklet also replaces contigs from both the input and report VCFs into genbank (when possible) to be able to match the variants.