### PR TITLE
EVA-1598 Filter variants for VCF release file of current variants

### DIFF
--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
@@ -86,7 +86,7 @@ public class AccessionedVariantMongoReader extends VariantMongoAggregationReader
         for (Document submittedVariant : submittedVariants) {
             long submittedVariantStart = submittedVariant.getLong(START_FIELD);
             String submittedVariantContig = submittedVariant.getString(CONTIG_FIELD);
-            if (!isSameLocation(contig, start, submittedVariantContig, submittedVariantStart)) {
+            if (!isSameLocation(contig, start, submittedVariantContig, submittedVariantStart, type)) {
                 continue;
             }
             String reference = submittedVariant.getString(REFERENCE_ALLELE_FIELD);
@@ -111,8 +111,9 @@ public class AccessionedVariantMongoReader extends VariantMongoAggregationReader
      * clustered variant is mapped against multiple locations. So we need to check that that clustered variant we are
      * processing only appears in the VCF release file with the alleles from submitted variants matching the location.
      */
-    private boolean isSameLocation(String contig, long start, String submittedVariantContig, long submittedVariantStart) {
-        return contig.equals(submittedVariantContig) && isSameStart(start, submittedVariantStart);
+    private boolean isSameLocation(String contig, long start, String submittedVariantContig, long submittedVariantStart,
+                                   String type) {
+        return contig.equals(submittedVariantContig) && isSameStart(start, submittedVariantStart, type);
     }
 
     /**
@@ -129,8 +130,12 @@ public class AccessionedVariantMongoReader extends VariantMongoAggregationReader
      * SS (assembly: GCA_000309985.1, accession: 490570267, chromosome: CM001642.1, start: 7356604, reference: ,
      *     alternate: AGAGCTATGATCTTCGGAAGGAGAAGGAGAAGGAAAAGATTCATGACGTCCAC)
      */
-    private boolean isSameStart(long clusteredVariantStart, long submittedVariantStart) {
+    private boolean isSameStart(long clusteredVariantStart, long submittedVariantStart, String type) {
          return clusteredVariantStart == submittedVariantStart
-                 || Math.abs(clusteredVariantStart - submittedVariantStart) == 1L;
+                 || (isIndel(type) && Math.abs(clusteredVariantStart - submittedVariantStart) == 1L);
+    }
+
+    private boolean isIndel(String type) {
+        return type.equals(VariantType.INS.toString()) || type.equals(VariantType.DEL.toString());
     }
 }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
@@ -84,7 +84,9 @@ public class AccessionedVariantMongoReader extends VariantMongoAggregationReader
         Collection<Document> submittedVariants = (Collection<Document>)clusteredVariant.get(SS_INFO_FIELD);
 
         for (Document submittedVariant : submittedVariants) {
-            if (!isSameLocation(contig, start, submittedVariant)) {
+            long submittedVariantStart = submittedVariant.getLong(START_FIELD);
+            String submittedVariantContig = submittedVariant.getString(CONTIG_FIELD);
+            if (!isSameLocation(contig, start, submittedVariantContig, submittedVariantStart)) {
                 continue;
             }
             String reference = submittedVariant.getString(REFERENCE_ALLELE_FIELD);
@@ -99,7 +101,7 @@ public class AccessionedVariantMongoReader extends VariantMongoAggregationReader
                                                                      submittedVariantValidated, allelesMatch,
                                                                      assemblyMatch, evidence);
 
-            addToVariants(variants, contig, start, rs, reference, alternate, sourceEntry);
+            addToVariants(variants, contig, submittedVariantStart, rs, reference, alternate, sourceEntry);
         }
         return new ArrayList<>(variants.values());
     }
@@ -109,9 +111,7 @@ public class AccessionedVariantMongoReader extends VariantMongoAggregationReader
      * clustered variant is mapped against multiple locations. So we need to check that that clustered variant we are
      * processing only appears in the VCF release file with the alleles from submitted variants matching the location.
      */
-    private boolean isSameLocation(String contig, long start, Document submittedVariant) {
-        long submittedVariantStart = submittedVariant.getLong(START_FIELD);
-        String submittedVariantContig = submittedVariant.getString(CONTIG_FIELD);
+    private boolean isSameLocation(String contig, long start, String submittedVariantContig, long submittedVariantStart) {
         return contig.equals(submittedVariantContig) && isSameStart(start, submittedVariantStart);
     }
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReader.java
@@ -83,6 +83,10 @@ public class AccessionedVariantMongoReader extends VariantMongoAggregationReader
         Collection<Document> submittedVariants = (Collection<Document>)clusteredVariant.get(SS_INFO_FIELD);
 
         for (Document submittedVariant : submittedVariants) {
+            if (!contig.equals(submittedVariant.getString(CONTIG_FIELD))
+                    || start != submittedVariant.getLong(START_FIELD)) {
+                continue;
+            }
             String reference = submittedVariant.getString(REFERENCE_ALLELE_FIELD);
             String alternate = submittedVariant.getString(ALTERNATE_ALLELE_FIELD);
             String study = submittedVariant.getString(STUDY_FIELD);

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/AccessionedVariantMongoReaderTest.java
@@ -346,18 +346,17 @@ public class AccessionedVariantMongoReaderTest {
         assertFlagEqualsInAllVariants(SUPPORTED_BY_EVIDENCE_KEY, false);
     }
 
+    /**
+     * Two clustered variants with the same accession but mapped against different locations. Each clustered variant
+     * should only appear with the alleles of the its corresponding submitted variants.
+     *
+     * This means variants will only be returned by the reader when the clustered and submitted variant have the same location
+     * (contig and start)
+     */
     @Test
-    public void includeOnlyVariantsWithTheSameChromosomeAndStartInRsAndSs() {
-        AccessionedVariantMongoReader reader2 = new AccessionedVariantMongoReader("GCA_000002775.1", mongoClient,
-                                                                                  TEST_DB,CHUNK_SIZE);
-
-        reader2.open(executionContext);
-        List<Variant> allVariants = new ArrayList<>();
-        List<Variant> variants;
-        while ((variants = reader2.read()) != null) {
-            allVariants.addAll(variants);
-        }
-        reader2.close();
+    public void includeOnlyVariantsWithTheSameChromosomeAndStartInRsAndSs() throws Exception {
+        reader = new AccessionedVariantMongoReader("GCA_000002775.1", mongoClient, TEST_DB,CHUNK_SIZE);
+        List<Variant> allVariants = readIntoList();
 
         assertEquals(3, allVariants.size());
 

--- a/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantEntity.json
@@ -130,6 +130,28 @@
       "createdDate" : ISODate(
       "2010-03-24T15:04:00.000Z"
       )
+    },
+    {
+      "_id" : "963B5901449DA80430C87E1D0EAB45A243AA8F29",
+      "asm" : "GCA_000002775.1",
+      "tax" : 3694,
+      "contig" : "CM000337.1",
+      "start" : NumberLong(19922),
+      "type" : "SNV",
+      "accession" : NumberLong(1153055382),
+      "version" : 1,
+      "createdDate" : ISODate("2017-09-20T08:25:00.000Z")
+    },
+    {
+      "_id" : "6400015A93030F0BF842E25106CB63580374A403",
+      "asm" : "GCA_000002775.1",
+      "tax" : 3694,
+      "contig" : "CM000351.1",
+      "start" : NumberLong(3474340),
+      "type" : "SNV",
+      "accession" : NumberLong(1153055382),
+      "version" : 1,
+      "createdDate" : ISODate("2017-09-20T08:25:00.000Z")
     }
   ]
 }

--- a/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -309,6 +309,54 @@
       "createdDate" : ISODate(
       "2016-04-26T11:55:00.000Z"
       )
+    },
+    {
+      "_id" : "3C881100879954FB682FC8976CB1FB462F7B10C4",
+      "seq" : "GCA_000002775.1",
+      "tax" : 3694,
+      "study" : "BESC_ASSOC_544",
+      "contig" : "CM000337.1",
+      "start" : NumberLong(19922),
+      "ref" : "G",
+      "alt" : "A",
+      "rs" : NumberLong(1153055382),
+      "evidence" : false,
+      "validated" : true,
+      "accession" : NumberLong(1122557780),
+      "version" : 1,
+      "createdDate" : ISODate("2014-07-29T22:13:00.000Z")
+    },
+    {
+      "_id" : "A92DDF05899B9B6F0FCDE66CC64E65378EE9EF05",
+      "seq" : "GCA_000002775.1",
+      "tax" : 3694,
+      "study" : "BESC_ASSOC_544",
+      "contig" : "CM000337.1",
+      "start" : NumberLong(19922),
+      "ref" : "G",
+      "alt" : "T",
+      "rs" : NumberLong(1153055382),
+      "evidence" : false,
+      "validated" : true,
+      "accession" : NumberLong(1125436664),
+      "version" : 1,
+      "createdDate" : ISODate("2014-07-30T01:41:00.000Z")
+    },
+    {
+      "_id" : "47B7C562F91D91DC8CFC4A2102DF7E7A9AB38315",
+      "seq" : "GCA_000002775.1",
+      "tax" : 3694,
+      "study" : "BESC_ASSOC_544",
+      "contig" : "CM000351.1",
+      "start" : NumberLong(3474340),
+      "ref" : "C",
+      "alt" : "T",
+      "rs" : NumberLong(1153055382),
+      "evidence" : false,
+      "validated" : true,
+      "accession" : NumberLong(1122557780),
+      "version" : 1,
+      "createdDate" : ISODate("2014-07-29T22:13:00.000Z")
     }
   ]
 }


### PR DESCRIPTION
Given that the VCF release file for **current variants** include the alleles and those are only present in the submitted variants a join between the two collections is needed but given that the same RS ID can be mapped against multiple locations (chromosome and/or start position) we will need to filter the results with only the ones that match the location.

There will be an exceptional case with the ambiguous INDELs because dbSNP and the EVA treat them in different ways: dbSNP remove the context nucleotide before an INDEL while the EVA removes the rightmost bases

During the dbSNP import we re-normalize the submitted variants (which can imply modifying the start position) but the clustered variants are not renormalized.

This situation will be handled in this release pipeline by considering the start position as the "same" if the clustered and submitted variants positions:
- Exactly match
- Have a difference of only 1