### PR TITLE
EVA-1639 Check ss ids declustered operations before throwing exeption

### DIFF
--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReader.java
@@ -147,10 +147,12 @@ public class MergedVariantMongoReader extends VariantMongoAggregationReader {
 
         if (!hasSubmittedVariantsDeclustered && variants.isEmpty()) {
             throw new IllegalStateException ("There was a merge operation for rs" + rs + " but there is no update " +
-                                                     "operation for the SS IDs. This can be either an error or a " +
-                                                     "special scenario where all the corresponding SS IDs were " +
-                                                     "declustered so when the merge operation occurs, there are no " +
-                                                     "SS IDs to update.");
+                                                     "operation for the SS IDs. This happens because there were no " +
+                                                     "update (merge/decluster) operations for the corresponding SS IDs" +
+                                                     "Every RS ID in dbSNP comes with at least one associated SS ID. " +
+                                                     "If an RS ID is merged, its corresponding SS IDs must be " +
+                                                     "updated (with the new RS ID) unless they have been previously " +
+                                                     "declustered (rs = null).");
         }
 
         return new ArrayList<>(variants.values());

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReaderTest.java
@@ -260,4 +260,25 @@ public class MergedVariantMongoReaderTest {
         assertNotNull(allVariants.get("AAWR02045368.1_505_T_A"));
         assertNull(allVariants.get("AAWR02045368.1_505_A_T"));
     }
+
+    /**
+     * This test will use a different defaultReader for assembly GCA_000001635.5 to evaluate this specific scenario:
+     * - One merge operation for clustered variants (rs258660893 merged into 244942339)
+     * - One update operations for submitted variants but the reason is a DECLUSTER
+     *
+     * This happens because the decluster operations are created in the processor and the merge operations in the writer.
+     *
+     * So we will have some situations where there is a merge operation but the merged clustered variant does not have
+     * any submitted variants associated because they all have been declustered (rs = null). Hence no update operation
+     * to indicate the merge is created for submitted variants.
+     */
+    @Test
+    public void noExceptionIfSsWereDeclustered() throws Exception {
+        MergedVariantMongoReader reader = new MergedVariantMongoReader("GCA_000001635.5", mongoClient, TEST_DB,
+                                                                       CHUNK_SIZE);
+
+        Map<String, Variant> allVariants = readIntoMap(reader);
+
+        assertEquals(0, allVariants.size());
+    }
 }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/MergedVariantMongoReaderTest.java
@@ -28,6 +28,7 @@ import org.bson.Document;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -263,7 +264,7 @@ public class MergedVariantMongoReaderTest {
 
     /**
      * This test will use a different defaultReader for assembly GCA_000001635.5 to evaluate this specific scenario:
-     * - One merge operation for clustered variants (rs258660893 merged into 244942339)
+     * - One merge operation for clustered variants (rs258660893 merged into rs244942339)
      * - One update operations for submitted variants but the reason is a DECLUSTER
      *
      * This happens because the decluster operations are created in the processor and the merge operations in the writer.
@@ -276,9 +277,22 @@ public class MergedVariantMongoReaderTest {
     public void noExceptionIfSsWereDeclustered() throws Exception {
         MergedVariantMongoReader reader = new MergedVariantMongoReader("GCA_000001635.5", mongoClient, TEST_DB,
                                                                        CHUNK_SIZE);
-
         Map<String, Variant> allVariants = readIntoMap(reader);
-
         assertEquals(0, allVariants.size());
+    }
+
+    /**
+     * This test will use a different defaultReader for assembly GCA_000181335.3 to evaluate this specific scenario:
+     * - One merge operation for clustered variants (rs782965190 merged into rs43955718)
+     * - No submitted variants operations associated to rs782965190
+     *
+     * Given that the are not merge nor decluster operations for any submitted variant associated this should throw
+     * an exception
+     */
+    @Test(expected = IllegalStateException.class)
+    public void exceptionIfRsMergedHasNoSsMergeOperations() throws Exception {
+        MergedVariantMongoReader reader = new MergedVariantMongoReader("GCA_000181335.3", mongoClient, TEST_DB,
+                                                                       CHUNK_SIZE);
+        readIntoMap(reader);
     }
 }

--- a/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantOperationEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantOperationEntity.json
@@ -267,6 +267,27 @@
           "createdDate" : ISODate("2009-02-10T21:16:00.000Z")
         }
       ]
+    },
+    {
+      "_id" : ObjectId("5d4bd7e256ccf06f703798a9"),
+      "eventType" : "MERGED",
+      "accession" : NumberLong(258660893),
+      "mergeInto" : NumberLong(244942339),
+      "reason" : "Identical clustered variant received multiple RS identifiers",
+      "inactiveObjects" : [
+        {
+          "asm" : "GCA_000001635.5",
+          "tax" : 10090,
+          "contig" : "CM000996.2",
+          "start" : NumberLong(121461812),
+          "type" : "SEQUENCE_ALTERATION",
+          "validated" : false,
+          "hashedMessage" : "873E24F88F92E8BD25CFD4056F05A98942B37BF3",
+          "accession" : NumberLong(258660893),
+          "version" : 1,
+          "createdDate" : ISODate("2012-07-06T10:59:47.290+0000")
+        }
+      ]
     }
   ]
 }

--- a/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantOperationEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpClusteredVariantOperationEntity.json
@@ -288,6 +288,27 @@
           "createdDate" : ISODate("2012-07-06T10:59:47.290+0000")
         }
       ]
+    },
+    {
+      "_id" : ObjectId("5d1ce7fccb53114de4929225"),
+      "eventType" : "MERGED",
+      "accession" : NumberLong(782965190),
+      "mergeInto" : NumberLong(43955718),
+      "reason" : "Identical clustered variant received multiple RS identifiers",
+      "inactiveObjects" : [
+        {
+          "asm" : "GCA_000181335.3",
+          "tax" : 9685,
+          "contig" : "AANG03312718.1",
+          "start" : NumberLong(1977),
+          "type" : "SNV",
+          "validated" : false,
+          "hashedMessage" : "42105F18A98F5F8D312F281B294BCA1B0CF3C5C7",
+          "accession" : NumberLong(782965190),
+          "version" : 1,
+          "createdDate" : ISODate("2015-04-16T13:30:00.000Z")
+        }
+      ]
     }
   ]
 }

--- a/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantOperationEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantOperationEntity.json
@@ -286,6 +286,32 @@
           "createdDate" : ISODate("2008-09-25T16:29:00.000Z")
         }
       ]
+    },
+    {
+      "_id" : ObjectId("5d4bd7e256ccf06f703798cc"),
+      "eventType" : "UPDATED",
+      "accession" : NumberLong(181942290),
+      "reason" : "Declustered: None of the variant alleles match the reference allele.",
+      "inactiveObjects" : [
+        {
+          "seq" : "GCA_000001635.5",
+          "tax" : 10090,
+          "study" : "UNISTS_SUBMISSION_08-24-2009",
+          "contig" : "CM000996.2",
+          "start" : NumberLong(121461812),
+          "ref" : "TCTACACACACACACACACACACACACACACACACACACAGCACTAGAATTAGGCATGTAACATCACAGTCATCTTTTATGTGGTAGTGGTCTCATGCACAGAAACTTTA",
+          "alt" : "(D3MIT42)",
+          "rs" : NumberLong(258660893),
+          "evidence" : false,
+          "asmMatch" : true,
+          "allelesMatch" : true,
+          "validated" : false,
+          "hashedMessage" : "29E8AA6153CEB07AA14CFCFC56BDC144DFA1A476",
+          "accession" : NumberLong(181942290),
+          "version" : 1,
+          "createdDate" : ISODate("2009-12-15T15:28:00.000+0000")
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
An exception should not be thrown if a clustered variant was merged but there are not operation for the submitted variants because they were declustered before. 

This happens because the decluster operations are created before the merge operations.

So we will have some situations where there is a merge operation but the merged clustered variant does not have any submitted variants associated because they all have been declustered (rs = null). Hence no update operation to indicate the merge is created for submitted variants.