### PR TITLE
Add ref seq input parameter, ignore variant on assembly accession mismatch 

### DIFF
--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsWriterConfiguration.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsWriterConfiguration.java
@@ -21,7 +21,9 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.accession.core.listeners.ImportCounts;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity;
 import uk.ac.ebi.eva.accession.dbsnp2.io.DbsnpJsonClusteredVariantsWriter;
@@ -30,6 +32,7 @@ import uk.ac.ebi.eva.accession.dbsnp2.parameters.InputParameters;
 import static uk.ac.ebi.eva.accession.dbsnp2.configuration.BeanNames.DBSNP_JSON_VARIANT_WRITER;
 
 @Configuration
+@Import({MongoConfiguration.class})
 public class ImportDbsnpJsonVariantsWriterConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(ImportDbsnpJsonVariantsWriterConfiguration.class);

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/JsonNodeToClusteredVariantProcessorConfiguration.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/JsonNodeToClusteredVariantProcessorConfiguration.java
@@ -57,8 +57,8 @@ public class JsonNodeToClusteredVariantProcessorConfiguration {
     }
 
     @Bean
-    JsonNodeToClusteredVariantProcessor jsonNodeToClusteredVariantProcessor() {
-        return new JsonNodeToClusteredVariantProcessor();
+    JsonNodeToClusteredVariantProcessor jsonNodeToClusteredVariantProcessor(InputParameters parameters) {
+        return new JsonNodeToClusteredVariantProcessor(parameters.getRefseqAssembly());
     }
 
     @Bean

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/JsonNodeToClusteredVariantProcessorConfiguration.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/JsonNodeToClusteredVariantProcessorConfiguration.java
@@ -58,7 +58,7 @@ public class JsonNodeToClusteredVariantProcessorConfiguration {
 
     @Bean
     JsonNodeToClusteredVariantProcessor jsonNodeToClusteredVariantProcessor(InputParameters parameters) {
-        return new JsonNodeToClusteredVariantProcessor(parameters.getRefseqAssembly());
+        return new JsonNodeToClusteredVariantProcessor(parameters.getRefseqAssembly(), parameters.getGenbankAssembly());
     }
 
     @Bean

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessor.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessor.java
@@ -78,7 +78,7 @@ public class JsonNodeToClusteredVariantProcessor implements ItemProcessor<JsonNo
             String assemblyAccession = assemblyInfo.get(0).path("assembly_accession").asText();
             // Ignore variant if it's assembly accession doesn't match the one supplied in input parameters
             if(!StringUtils.equals(refseqAssembly, assemblyAccession)) {
-                logger.error("Variant with RSID {} has a different assembly accession {}"
+                logger.error("Variant with RS ID {} has a different assembly accession {}"
                         + "than the Reference Sequence accession {} supplied in input parameters",
                     jsonRootNode.path("refsnp_id").asText(),
                     assemblyAccession,

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessor.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessor.java
@@ -78,7 +78,7 @@ public class JsonNodeToClusteredVariantProcessor implements ItemProcessor<JsonNo
                 continue;
             }
             String assemblyAccession = assemblyInfo.get(0).path("assembly_accession").asText();
-            // Ignore variant if it's assembly accession doesn't match the one supplied in input parameters
+            // Ignore variant if its assembly accession doesn't match the one supplied in input parameters
             if(!refseqAssembly.equals(assemblyAccession)) {
                 logger.error("Variant with RS ID {} has a different assembly accession {}"
                         + "than the RefSeq accession {} supplied in input parameters",

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessor.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessor.java
@@ -81,7 +81,7 @@ public class JsonNodeToClusteredVariantProcessor implements ItemProcessor<JsonNo
             // Ignore variant if it's assembly accession doesn't match the one supplied in input parameters
             if(!refseqAssembly.equals(assemblyAccession)) {
                 logger.error("Variant with RS ID {} has a different assembly accession {}"
-                        + "than the Reference Sequence accession {} supplied in input parameters",
+                        + "than the RefSeq accession {} supplied in input parameters",
                     jsonRootNode.path("refsnp_id").asText(),
                     assemblyAccession,
                     refseqAssembly);

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessor.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessor.java
@@ -41,9 +41,11 @@ public class JsonNodeToClusteredVariantProcessor implements ItemProcessor<JsonNo
     private Function<IClusteredVariant, String> hashingFunction =
         new ClusteredVariantSummaryFunction().andThen(new SHA1HashingFunction());
     private String refseqAssembly;
+    private String genbankAssembly;
 
-    public JsonNodeToClusteredVariantProcessor(String refseqAssembly) {
+    public JsonNodeToClusteredVariantProcessor(String refseqAssembly, String genbankAssembly) {
         this.refseqAssembly = refseqAssembly;
+        this.genbankAssembly = genbankAssembly;
     }
 
     /**
@@ -77,7 +79,7 @@ public class JsonNodeToClusteredVariantProcessor implements ItemProcessor<JsonNo
             }
             String assemblyAccession = assemblyInfo.get(0).path("assembly_accession").asText();
             // Ignore variant if it's assembly accession doesn't match the one supplied in input parameters
-            if(!StringUtils.equals(refseqAssembly, assemblyAccession)) {
+            if(!refseqAssembly.equals(assemblyAccession)) {
                 logger.error("Variant with RS ID {} has a different assembly accession {}"
                         + "than the Reference Sequence accession {} supplied in input parameters",
                     jsonRootNode.path("refsnp_id").asText(),
@@ -90,7 +92,7 @@ public class JsonNodeToClusteredVariantProcessor implements ItemProcessor<JsonNo
             // DbSNP JSON in 0 base, EVA in 1 base
             // @see <a href=https://api.ncbi.nlm.nih.gov/variation/v0/>DbSNP JSON 2.0 schema specification</a>
             long start = spdi.path("position").asLong() + 1;
-            return new ClusteredVariant(assemblyAccession, taxonomyAccession, contig, start,
+            return new ClusteredVariant(genbankAssembly, taxonomyAccession, contig, start,
                                         type, Boolean.FALSE, createdDate);
         }
         // Absence of primary top level placement (PLTP) data

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/parameters/InputParameters.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/parameters/InputParameters.java
@@ -21,21 +21,18 @@ import org.springframework.batch.core.JobParametersBuilder;
 public class InputParameters {
 
     private String input;
-
-    private String assembly;
-
+    private String genbankAssembly;
+    private String refseqAssembly;
     private String assemblyReportUrl;
-
     private int chunkSize;
-
     private boolean forceRestart;
-
     private boolean forceImport;
 
     public JobParameters toJobParameters() {
         return new JobParametersBuilder()
             .addString("input", input)
-            .addString("assembly", assembly)
+            .addString("genbankAssembly", genbankAssembly)
+            .addString("refseqAssembly", refseqAssembly)
             .addLong("chunkSize", (long) chunkSize, false)
             .toJobParameters();
     }
@@ -48,12 +45,20 @@ public class InputParameters {
         this.input = input;
     }
 
-    public String getAssembly() {
-        return assembly;
+    public String getGenbankAssembly() {
+        return genbankAssembly;
     }
 
-    public void setAssembly(String assembly) {
-        this.assembly = assembly;
+    public void setGenbankAssembly(String genbankAssembly) {
+        this.genbankAssembly = genbankAssembly;
+    }
+
+    public String getRefseqAssembly() {
+        return refseqAssembly;
+    }
+
+    public void setRefseqAssembly(String refseqAssembly) {
+        this.refseqAssembly = refseqAssembly;
     }
 
     public String getAssemblyReportUrl() {

--- a/eva-accession-import-dbsnp2/src/main/resources/application.properties
+++ b/eva-accession-import-dbsnp2/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.batch.job.names=IMPORT_DBSNP_JSON_VARIANTS_JOB
 
 # DbSNP JSON input source
 parameters.input=
-# Genbank accession
+# Genbank accession - Please ensure that this is the equivalent accession to the RefSeq accession below as the equivalence is NOT verified by the program
 parameters.genbankAssembly=
 # Reference sequence accession
 parameters.refseqAssembly=

--- a/eva-accession-import-dbsnp2/src/main/resources/application.properties
+++ b/eva-accession-import-dbsnp2/src/main/resources/application.properties
@@ -2,8 +2,10 @@ spring.batch.job.names=IMPORT_DBSNP_JSON_VARIANTS_JOB
 
 # DbSNP JSON input source
 parameters.input=
+# Genbank accession
+parameters.genbankAssembly=
 # Reference sequence accession
-parameters.assembly=
+parameters.refseqAssembly=
 parameters.assemblyReportUrl=
 
 parameters.chunkSize=

--- a/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsJobConfigurationTest.java
+++ b/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsJobConfigurationTest.java
@@ -45,7 +45,6 @@ public class ImportDbsnpJsonVariantsJobConfigurationTest {
 
     @Autowired
     private InputParameters inputParameters;
-
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
 

--- a/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsStepConfigurationTest.java
+++ b/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsStepConfigurationTest.java
@@ -44,21 +44,17 @@ public class ImportDbsnpJsonVariantsStepConfigurationTest {
 
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
-
-    @Autowired
-    private InputParameters inputParameters;
-
     @Autowired
     private MongoTemplate mongoTemplate;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mongoTemplate.dropCollection(DbsnpClusteredVariantEntity.class);
     }
 
     @Test
     @DirtiesContext
-    public void executeStep() throws IOException {
+    public void executeStep() {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(IMPORT_DBSNP_JSON_VARIANTS_STEP);
         assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 

--- a/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessorTest.java
+++ b/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessorTest.java
@@ -32,12 +32,14 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity;
+import uk.ac.ebi.eva.accession.dbsnp2.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.dbsnp2.test.BatchTestConfiguration;
 import uk.ac.ebi.eva.commons.core.models.VariantType;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -54,9 +56,9 @@ public class JsonNodeToClusteredVariantProcessorTest {
     @Autowired
     @Qualifier(DBSNP_JSON_VARIANT_READER)
     private FlatFileItemReader<JsonNode> reader;
-
+    @Autowired
+    private InputParameters inputParameters;
     private JsonNodeToClusteredVariantProcessor processor;
-
     private List<JsonNode> variants = new ArrayList<>();
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -70,7 +72,7 @@ public class JsonNodeToClusteredVariantProcessorTest {
         while ((variant = reader.read()) != null) {
             variants.add(variant);
         }
-        processor = new JsonNodeToClusteredVariantProcessor();
+        processor = new JsonNodeToClusteredVariantProcessor(inputParameters.getRefseqAssembly());
     }
 
     @Test
@@ -138,6 +140,7 @@ public class JsonNodeToClusteredVariantProcessorTest {
     public List<DbsnpClusteredVariantEntity> getFilteredDbsnpClusteredVariantEntities(VariantType type) {
         return variants.stream()
             .map(variant -> processor.process(variant))
+            .filter(Objects::nonNull)
             .filter(dbsnpClusteredVariantEntity -> dbsnpClusteredVariantEntity.getType().equals(type))
             .collect(Collectors.toList());
     }

--- a/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessorTest.java
+++ b/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/io/JsonNodeToClusteredVariantProcessorTest.java
@@ -72,7 +72,8 @@ public class JsonNodeToClusteredVariantProcessorTest {
         while ((variant = reader.read()) != null) {
             variants.add(variant);
         }
-        processor = new JsonNodeToClusteredVariantProcessor(inputParameters.getRefseqAssembly());
+        processor = new JsonNodeToClusteredVariantProcessor(inputParameters.getRefseqAssembly(),
+                                                            inputParameters.getGenbankAssembly());
     }
 
     @Test
@@ -119,7 +120,7 @@ public class JsonNodeToClusteredVariantProcessorTest {
             .collect(Collectors.toList());
         assertEquals(1, variant3906List.size());
         DbsnpClusteredVariantEntity variant3906 = variant3906List.get(0);
-        assertEquals("GCF_000001405.38", variant3906.getAssemblyAccession());
+        assertEquals("GCA_000001405.27", variant3906.getAssemblyAccession());
         assertEquals(9606L, variant3906.getTaxonomyAccession());
         assertEquals("NC_000024.10", variant3906.getContig());
         assertEquals(19562813L, variant3906.getStart());

--- a/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/test/BatchTestConfiguration.java
+++ b/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/test/BatchTestConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.accession.dbsnp2.configuration.ChunkSizeCompletionPolicyConfiguration;
 import uk.ac.ebi.eva.accession.dbsnp2.configuration.ImportDbsnpJsonFlowConfiguration;
 import uk.ac.ebi.eva.accession.dbsnp2.configuration.ImportDbsnpJsonVariantsJobConfiguration;
@@ -41,6 +42,7 @@ import uk.ac.ebi.eva.commons.batch.job.JobExecutionApplicationListener;
 @EnableAutoConfiguration
 @EnableBatchProcessing
 @Import({ListenersConfiguration.class,
+        MongoConfiguration.class,
         ImportDbsnpJsonVariantsJobConfiguration.class,
         ImportDbsnpJsonVariantsStepConfiguration.class,
         ImportDbsnpJsonVariantsReaderConfiguration.class,

--- a/eva-accession-import-dbsnp2/src/test/resources/application.properties
+++ b/eva-accession-import-dbsnp2/src/test/resources/application.properties
@@ -3,7 +3,7 @@ spring.batch.job.names=IMPORT_DBSNP_JSON_VARIANTS_JOB
 # dbSNP JSON input source
 parameters.input=src/test/resources/input-files/test-dbsnp.json.bz2
 # Genbank accession
-parameters.genbankAssembly=CRCh38.p12
+parameters.genbankAssembly=GCA_000001405.27
 # Reference sequence accession
 parameters.refseqAssembly=GCF_000001405.38
 parameters.assemblyReportUrl=file:src/test/resources/input-files/GCF_000001405.38_GRCh38.p12_assembly_report.txt

--- a/eva-accession-import-dbsnp2/src/test/resources/application.properties
+++ b/eva-accession-import-dbsnp2/src/test/resources/application.properties
@@ -2,8 +2,10 @@ spring.batch.job.names=IMPORT_DBSNP_JSON_VARIANTS_JOB
 
 # dbSNP JSON input source
 parameters.input=src/test/resources/input-files/test-dbsnp.json.bz2
-# reference sequence accession
-parameters.assembly=GRCh38.p13
+# Genbank accession
+parameters.genbankAssembly=CRCh38.p12
+# Reference sequence accession
+parameters.refseqAssembly=GCF_000001405.38
 parameters.assemblyReportUrl=file:src/test/resources/input-files/GCF_000001405.38_GRCh38.p12_assembly_report.txt
 
 parameters.chunkSize=100

--- a/eva-accession-import-dbsnp2/src/test/resources/application.properties
+++ b/eva-accession-import-dbsnp2/src/test/resources/application.properties
@@ -4,7 +4,7 @@ spring.batch.job.names=IMPORT_DBSNP_JSON_VARIANTS_JOB
 parameters.input=src/test/resources/input-files/test-dbsnp.json.bz2
 # Genbank accession
 parameters.genbankAssembly=GCA_000001405.27
-# Reference sequence accession
+# RefSeq accession
 parameters.refseqAssembly=GCF_000001405.38
 parameters.assemblyReportUrl=file:src/test/resources/input-files/GCF_000001405.38_GRCh38.p12_assembly_report.txt
 


### PR DESCRIPTION
## Updates

- Add `@MongoConfiguration` from `eva-accession-core` to remove "_class" field from the persistence document
- Add new `refseqAssembly` and `genbankAssembly` as input parameters
- Add business logic to ignore variant if it's `assembly-accession` doesn't match `refseq-assembly`
- For processor test case, small change to ignore null variants
- Remove unused attributes/exceptions

## Testing

- Mongo document: 

```
{
  "_id": "7F4FBBB9CBBD9AEA24DCF86C023D620D6C8554A7",
  "asm": "acsn1",
  "tax": 9606,
  "contig": "contig1",
  "start": NumberLong(1),
  "type": "SNV",
  "accession": NumberLong(1),
  "version": 1,
  "createdDate": ISODate("2019-08-14T03:44:12.008Z")
}
```
- For testing purpose I modified Refseq accession to test the mismatch case. Result: No documents persist (as expected)