### PR TITLE
EVA-1643 Switch sequence accessions and names 

### DIFF
--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/processors/ReleaseProcessorConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/processors/ReleaseProcessorConfiguration.java
@@ -42,12 +42,13 @@ import static uk.ac.ebi.eva.accession.release.configuration.BeanNames.RELEASE_PR
 public class ReleaseProcessorConfiguration {
 
     @Bean(RELEASE_PROCESSOR)
-    public ItemProcessor<Variant, VariantContext> releaseProcessor(FastaSynonymSequenceReader fastaReader) {
+    public ItemProcessor<Variant, VariantContext> releaseProcessor(FastaSynonymSequenceReader fastaReader,
+                                                                   ContigMapping contigMapping) {
         CompositeItemProcessor<Variant, VariantContext> compositeItemProcessor = new CompositeItemProcessor<>();
         compositeItemProcessor.setDelegates(Arrays.asList(new NamedVariantProcessor(),
                                                           new ExcludeInvalidVariantsProcessor(),
                                                           new ContextNucleotideAdditionProcessor(fastaReader),
-                                                          new VariantToVariantContextProcessor()));
+                                                          new VariantToVariantContextProcessor(contigMapping)));
         return compositeItemProcessor;
     }
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/writers/ContigWriterConfiguration.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/configuration/writers/ContigWriterConfiguration.java
@@ -15,9 +15,11 @@
  */
 package uk.ac.ebi.eva.accession.release.configuration.writers;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.release.io.ContigWriter;
 import uk.ac.ebi.eva.accession.release.parameters.InputParameters;
 
@@ -31,15 +33,20 @@ import static uk.ac.ebi.eva.accession.release.io.ContigWriter.getMergedContigsFi
 @Configuration
 public class ContigWriterConfiguration {
 
+    @Autowired
+    private ContigMapping contigMapping;
+
     @Bean(ACTIVE_CONTIG_WRITER)
     public ContigWriter activeContigWriter(InputParameters inputParameters) {
         return new ContigWriter(new File(getActiveContigsFilePath(inputParameters.getOutputFolder(),
-                                                                  inputParameters.getAssemblyAccession())));
+                                                                  inputParameters.getAssemblyAccession())),
+                                contigMapping);
     }
 
     @Bean(MERGED_CONTIG_WRITER)
     public ContigWriter mergedContigWriter(InputParameters inputParameters) {
         return new ContigWriter(new File(getMergedContigsFilePath(inputParameters.getOutputFolder(),
-                                                                  inputParameters.getAssemblyAccession())));
+                                                                  inputParameters.getAssemblyAccession())),
+                                contigMapping);
     }
 }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/ContigWriter.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/ContigWriter.java
@@ -74,12 +74,13 @@ public class ContigWriter implements ItemStreamWriter<String> {
     @Override
     public void write(List<? extends String> contigs) {
         for (String contig : contigs) {
-            ContigSynonyms contigSynonyms = contigMapping.getContigSynonyms(contig);
-            String sequenceName = contigMapping.getContigSynonym(contig, contigSynonyms, ContigNaming.SEQUENCE_NAME);
-
             if (contig == null || contig.isEmpty()) {
                 throw new IllegalArgumentException("The contig cannot be null or empty");
             }
+
+            ContigSynonyms contigSynonyms = contigMapping.getContigSynonyms(contig);
+            String sequenceName = contigMapping.getContigSynonym(contig, contigSynonyms, ContigNaming.SEQUENCE_NAME);
+
             if (sequenceName == null || sequenceName.isEmpty()) {
                 throw new IllegalArgumentException("Could not find the corresponding sequence name for contig " + contig);
             }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/ContigWriter.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/ContigWriter.java
@@ -19,6 +19,10 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamWriter;
 
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
+import uk.ac.ebi.eva.accession.core.contig.ContigNaming;
+import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -39,10 +43,13 @@ public class ContigWriter implements ItemStreamWriter<String> {
 
     private final File output;
 
+    private ContigMapping contigMapping;
+
     private PrintWriter printWriter;
 
-    public ContigWriter(File output) {
+    public ContigWriter(File output, ContigMapping contigMapping) {
         this.output = output;
+        this.contigMapping = contigMapping;
     }
 
     @Override
@@ -67,7 +74,9 @@ public class ContigWriter implements ItemStreamWriter<String> {
     @Override
     public void write(List<? extends String> contigs) {
         for (String contig : contigs) {
-            printWriter.println(contig);
+            ContigSynonyms contigSynonyms = contigMapping.getContigSynonyms(contig);
+            printWriter.println(contig + "," + contigMapping.getContigSynonym(contig, contigSynonyms,
+                                                                              ContigNaming.SEQUENCE_NAME));
         }
     }
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/ContigWriter.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/ContigWriter.java
@@ -75,8 +75,16 @@ public class ContigWriter implements ItemStreamWriter<String> {
     public void write(List<? extends String> contigs) {
         for (String contig : contigs) {
             ContigSynonyms contigSynonyms = contigMapping.getContigSynonyms(contig);
-            printWriter.println(contig + "," + contigMapping.getContigSynonym(contig, contigSynonyms,
-                                                                              ContigNaming.SEQUENCE_NAME));
+            String sequenceName = contigMapping.getContigSynonym(contig, contigSynonyms, ContigNaming.SEQUENCE_NAME);
+
+            if (contig == null || contig.isEmpty()) {
+                throw new IllegalArgumentException("The contig cannot be null or empty");
+            }
+            if (sequenceName == null || sequenceName.isEmpty()) {
+                throw new IllegalArgumentException("Could not find the corresponding sequence name for contig " + contig);
+            }
+
+            printWriter.println(contig + "," + sequenceName);
         }
     }
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriter.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriter.java
@@ -122,9 +122,12 @@ public class VariantContextWriter implements ItemStreamWriter<VariantContext> {
     private void addContigs(Set<VCFHeaderLine> metaData) {
         try {
             BufferedReader bufferedReader = new BufferedReader(new FileReader(contigsFilePath));
-            String contig;
-            while ((contig = bufferedReader.readLine()) != null) {
-                metaData.add(new VCFHeaderLine("contig", "<ID=" + contig + ">"));
+            String contigLine;
+            while ((contigLine = bufferedReader.readLine()) != null) {
+                String[] contigAndName = contigLine.split(",");
+                String contig = contigAndName[0];
+                String name = contigAndName[1];
+                metaData.add(new VCFHeaderLine("contig", "<ID=" + name + ",Name=\"" + contig + "\">"));
             }
         } catch (IOException e) {
             logger.warn("Contigs file not found, VCF header will not have any contigs in the metadata section");

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriter.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriter.java
@@ -127,7 +127,7 @@ public class VariantContextWriter implements ItemStreamWriter<VariantContext> {
                 String[] contigAndName = contigLine.split(",");
                 String contig = contigAndName[0];
                 String name = contigAndName[1];
-                metaData.add(new VCFHeaderLine("contig", "<ID=" + name + ",Name=\"" + contig + "\">"));
+                metaData.add(new VCFHeaderLine("contig", "<ID=" + name + ",accession=\"" + contig + "\">"));
             }
         } catch (IOException e) {
             logger.warn("Contigs file not found, VCF header will not have any contigs in the metadata section");

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/VariantToVariantContextProcessor.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/VariantToVariantContextProcessor.java
@@ -20,6 +20,9 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.springframework.batch.item.ItemProcessor;
 
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
+import uk.ac.ebi.eva.accession.core.contig.ContigNaming;
+import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
 import uk.ac.ebi.eva.commons.core.models.IVariant;
 import uk.ac.ebi.eva.commons.core.models.IVariantSourceEntry;
 
@@ -47,9 +50,12 @@ import static uk.ac.ebi.eva.accession.release.io.MergedVariantMongoReader.MERGED
  */
 public class VariantToVariantContextProcessor implements ItemProcessor<IVariant, VariantContext> {
 
+    private final ContigMapping contigMapping;
+
     private final VariantContextBuilder variantContextBuilder;
 
-    public VariantToVariantContextProcessor() {
+    public VariantToVariantContextProcessor(ContigMapping contigMapping) {
+        this.contigMapping = contigMapping;
         this.variantContextBuilder = new VariantContextBuilder();
     }
 
@@ -61,8 +67,11 @@ public class VariantToVariantContextProcessor implements ItemProcessor<IVariant,
         }
         String[] allelesArray = getAllelesArray(variant);
 
+        String contig = variant.getChromosome();
+        String sequenceName = getSequenceName(contig);
+
         VariantContext variantContext = variantContextBuilder
-                .chr(variant.getChromosome())
+                .chr(sequenceName)
                 .start(variant.getStart())
                 .stop(getVariantContextStop(variant))
                 .id(variant.getMainId())
@@ -73,6 +82,11 @@ public class VariantToVariantContextProcessor implements ItemProcessor<IVariant,
                 .make();
 
         return variantContext;
+    }
+
+    private String getSequenceName(String contig) {
+        ContigSynonyms contigSynonyms = contigMapping.getContigSynonyms(contig);
+        return contigMapping.getContigSynonym(contig, contigSynonyms, ContigNaming.SEQUENCE_NAME);
     }
 
     private Map<String, String> getAttributes(IVariant variant) {

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/VariantToVariantContextProcessor.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/VariantToVariantContextProcessor.java
@@ -66,9 +66,7 @@ public class VariantToVariantContextProcessor implements ItemProcessor<IVariant,
                     "VCF specification and HTSJDK forbid empty alleles. Illegal variant: " + variant);
         }
         String[] allelesArray = getAllelesArray(variant);
-
-        String contig = variant.getChromosome();
-        String sequenceName = getSequenceName(contig);
+        String sequenceName = getSequenceName(variant.getChromosome());
 
         VariantContext variantContext = variantContextBuilder
                 .chr(sequenceName)

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/configuration/steps/ListActiveContigsStepConfigurationTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/configuration/steps/ListActiveContigsStepConfigurationTest.java
@@ -100,7 +100,7 @@ public class ListActiveContigsStepConfigurationTest {
     public void contigsWritten() throws Exception {
         assertStepExecutesAndCompletes();
 
-        assertEquals(new HashSet<>(Arrays.asList("CM001954.1", "CM001941.2")),
+        assertEquals(new HashSet<>(Arrays.asList("CM001954.1,CAE13", "CM001941.2,CAE1")),
                      setOfLines(getActiveContigsFilePath(inputParameters.getOutputFolder(),
                                                          inputParameters.getAssemblyAccession())));
     }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/configuration/steps/ListMergedContigsStepConfigurationTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/configuration/steps/ListMergedContigsStepConfigurationTest.java
@@ -101,7 +101,7 @@ public class ListMergedContigsStepConfigurationTest {
     public void contigsWritten() throws Exception {
         assertStepExecutesAndCompletes();
 
-        assertEquals(new HashSet<>(Arrays.asList("CM001954.1", "CM001941.2")),
+        assertEquals(new HashSet<>(Arrays.asList("CM001954.1,CAE13", "CM001941.2,CAE1")),
                      setOfLines(ContigWriter.getMergedContigsFilePath(inputParameters.getOutputFolder(),
                                                                       inputParameters.getAssemblyAccession())));
     }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/ContigWriterTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/ContigWriterTest.java
@@ -29,6 +29,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class ContigWriterTest {
@@ -44,23 +45,32 @@ public class ContigWriterTest {
     public void setUp() throws Exception {
         output = temporaryFolderRule.newFile();
         ContigMapping contigMapping = new ContigMapping(Arrays.asList(
-                new ContigSynonyms("Chr1", "A", "A", "CM0001.1", "A", "A", true),
-                new ContigSynonyms("Chr2", "A", "A", "CM0002.1", "A", "A", true),
-                new ContigSynonyms("Chr3", "A", "A", "CM0003.1", "A", "A", true)));
+                new ContigSynonyms("Chr1", "assembled-molecule", "1", "CM0001.1", "NC0001.1", "ucsc1", true),
+                new ContigSynonyms("Chr2", "assembled-molecule", "2", "CM0002.1", "NC0001.1", "ucsc1", false),
+                new ContigSynonyms("Chr3", "assembled-molecule", "3", "CM0003.1", "na", "ucsc1", false)));
         contigWriter = new ContigWriter(output, contigMapping);
     }
 
     @Test
     public void write() throws Exception {
         contigWriter.open(null);
-        contigWriter.write(Arrays.asList("CM0001.1", "CM0002.2", "CM0003.3"));
+        contigWriter.write(Arrays.asList("CM0001.1", "CM0002.1", "CM0003.1"));
         contigWriter.close();
 
         assertEquals(3, numberOfLines(output));
+        assertContigFileContent(output);
     }
 
     private long numberOfLines(File file) throws IOException {
         BufferedReader br = new BufferedReader(new FileReader(file));
         return br.lines().count();
+    }
+
+    private void assertContigFileContent(File file) throws IOException {
+        BufferedReader br = new BufferedReader(new FileReader(file));
+        String line;
+        while ((line = br.readLine()) != null) {
+            assertTrue(line.equals("CM0001.1,Chr1") || line.equals("CM0002.1,Chr2") || line.equals("CM0003.1,Chr3"));
+        }
     }
 }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/ContigWriterTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/ContigWriterTest.java
@@ -20,6 +20,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
+import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -40,13 +43,17 @@ public class ContigWriterTest {
     @Before
     public void setUp() throws Exception {
         output = temporaryFolderRule.newFile();
-        contigWriter = new ContigWriter(output);
+        ContigMapping contigMapping = new ContigMapping(Arrays.asList(
+                new ContigSynonyms("Chr1", "A", "A", "CM0001.1", "A", "A", true),
+                new ContigSynonyms("Chr2", "A", "A", "CM0002.1", "A", "A", true),
+                new ContigSynonyms("Chr3", "A", "A", "CM0003.1", "A", "A", true)));
+        contigWriter = new ContigWriter(output, contigMapping);
     }
 
     @Test
     public void write() throws Exception {
         contigWriter.open(null);
-        contigWriter.write(Arrays.asList("CM0001.1", "CM0001.2", "CM0001.3"));
+        contigWriter.write(Arrays.asList("CM0001.1", "CM0002.2", "CM0003.3"));
         contigWriter.close();
 
         assertEquals(3, numberOfLines(output));

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/ContigWriterTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/ContigWriterTest.java
@@ -128,21 +128,34 @@ public class ContigWriterTest {
     }
 
     /**
-     * This will happen a contig is null or empty
+     * This will happen a contig is null
      */
     @Test(expected = IllegalArgumentException.class)
     public void throwExceptionIfNullContig() {
         ContigMapping contigMapping = new ContigMapping(Arrays.asList(
                 new ContigSynonyms(SEQUENCE_NAME_1, "assembled-molecule", "1", GENBANK_ACCESSION_1, REFSEQ_ACCESSION_1,
-                                   "ucsc1", true),
-                new ContigSynonyms(SEQUENCE_NAME_2, "assembled-molecule", "2", GENBANK_ACCESSION_2, REFSEQ_ACCESSION_2,
-                                   "ucsc2", false),
-                new ContigSynonyms(SEQUENCE_NAME_3, "assembled-molecule", "3", GENBANK_ACCESSION_3, "na", "ucsc3",
-                                   false)));
+                                   "ucsc1", true)));
         ContigWriter contigWriter = new ContigWriter(output, contigMapping);
 
         contigWriter.open(null);
-        contigWriter.write(Arrays.asList(GENBANK_ACCESSION_1, null));
+        String nullGenbankAccession = null;
+        contigWriter.write(Arrays.asList(GENBANK_ACCESSION_1, nullGenbankAccession));
+        contigWriter.close();
+    }
+
+    /**
+     * This will happen a contig is empty
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void throwExceptionIfEmptyContig() {
+        ContigMapping contigMapping = new ContigMapping(Arrays.asList(
+                new ContigSynonyms(SEQUENCE_NAME_1, "assembled-molecule", "1", GENBANK_ACCESSION_1, REFSEQ_ACCESSION_1,
+                                   "ucsc1", true)));
+        ContigWriter contigWriter = new ContigWriter(output, contigMapping);
+
+        contigWriter.open(null);
+        String emptyGenbankAccession = "";
+        contigWriter.write(Arrays.asList(GENBANK_ACCESSION_1, emptyGenbankAccession));
         contigWriter.close();
     }
 
@@ -167,7 +180,7 @@ public class ContigWriterTest {
      * This will happen if there is any contig in mongo that is not in the assembly report
      */
     @Test(expected = IllegalArgumentException.class)
-    public void throwExceptionIfEmptyContig() {
+    public void throwExceptionIfContigNotInAssemblyReport() {
         ContigMapping contigMapping = new ContigMapping(Arrays.asList(
                 new ContigSynonyms(SEQUENCE_NAME_1, "assembled-molecule", "1", GENBANK_ACCESSION_1, REFSEQ_ACCESSION_1,
                                    "ucsc1", true)));

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriterTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriterTest.java
@@ -175,7 +175,7 @@ public class VariantContextWriterTest {
     public void checkMetadataSection() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
         FileWriter fileWriter = new FileWriter(ContigWriter.getActiveContigsFilePath(outputFolder, REFERENCE_ASSEMBLY));
-        String contig = "CM0001.1";
+        String contig = "CM0001.1,Chr1";
         fileWriter.write(contig);
         fileWriter.close();
 
@@ -183,7 +183,7 @@ public class VariantContextWriterTest {
 
         List<String> metadataLines = grepFile(output, "^##.*");
         assertEquals(10, metadataLines.size());
-        List<String> contigLines = grepFile(output, "##contig=<ID=CM0001.1>");
+        List<String> contigLines = grepFile(output, "##contig=<ID=Chr1,Name=\"CM0001.1\">");
         assertEquals(1, contigLines.size());
         List<String> headerLines = grepFile(output, "^#CHROM.*");
         assertEquals(1, headerLines.size());

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriterTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriterTest.java
@@ -195,7 +195,7 @@ public class VariantContextWriterTest {
 
         List<String> metadataLines = grepFile(output, "^##.*");
         assertEquals(10, metadataLines.size());
-        List<String> contigLines = grepFile(output, "##contig=<ID=Chr1,Name=\"CM0001.1\">");
+        List<String> contigLines = grepFile(output, "##contig=<ID=Chr1,accession=\"CM0001.1\">");
         assertEquals(1, contigLines.size());
         List<String> headerLines = grepFile(output, "^#CHROM.*");
         assertEquals(1, headerLines.size());

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriterTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriterTest.java
@@ -20,6 +20,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
+import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
 import uk.ac.ebi.eva.accession.release.parameters.ReportPathResolver;
 import uk.ac.ebi.eva.accession.release.steps.processors.VariantToVariantContextProcessor;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
@@ -53,7 +55,9 @@ public class VariantContextWriterTest {
 
     private static final String ID = "rs123";
 
-    private static final String CHR_1 = "1";
+    private static final String SEQUENCE_NAME_1 = "Chr1";
+
+    private static final String GENBANK_ACCESSION_1 = "CM0001.1";
 
     private static final String FILE_ID = "fileId";
 
@@ -100,18 +104,19 @@ public class VariantContextWriterTest {
     @Test
     public void basicWrite() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
+        File output = assertWriteVcf(outputFolder,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
     }
 
-    private Variant buildVariant(String chr, int start, String reference, String alternate,
-                                 String sequenceOntologyTerm, String... studies) {
+    private Variant buildVariant(String chr, int start, String reference, String alternate,String sequenceOntologyTerm,
+                                 String... studies) {
         return buildVariant(chr, start, reference, alternate, sequenceOntologyTerm, false, false, true, true, true,
                             studies);
     }
 
-    private Variant buildVariant(String chr, int start, String reference, String alternate,
-                                 String sequenceOntologyTerm, boolean validated, boolean submittedVariantValidated,
-                                 boolean allelesMatch, boolean assemblyMatch, boolean evidence, String... studies) {
+    private Variant buildVariant(String chr, int start, String reference, String alternate, String sequenceOntologyTerm,
+                                 boolean validated, boolean submittedVariantValidated, boolean allelesMatch,
+                                 boolean assemblyMatch, boolean evidence, String... studies) {
         Variant variant = new Variant(chr, start, start + alternate.length(), reference, alternate);
         variant.setMainId(ID);
         for (String study : studies) {
@@ -128,14 +133,19 @@ public class VariantContextWriterTest {
         return variant;
     }
 
-    public File assertWriteVcf(File outputFolder, Variant... variants) throws Exception {
+    private File assertWriteVcf(File outputFolder, Variant... variants) throws Exception {
         Path reportPath = ReportPathResolver.getCurrentIdsReportPath(outputFolder.getAbsolutePath(), REFERENCE_ASSEMBLY);
         String activeContigsFilePath = ContigWriter.getActiveContigsFilePath(reportPath.toFile().getParent(),
                                                                              REFERENCE_ASSEMBLY);
         VariantContextWriter writer = new VariantContextWriter(reportPath, REFERENCE_ASSEMBLY, activeContigsFilePath);
         writer.open(null);
 
-        VariantToVariantContextProcessor variantToVariantContextProcessor = new VariantToVariantContextProcessor();
+        ContigMapping contigMapping = new ContigMapping(Collections.singletonList(
+                new ContigSynonyms(SEQUENCE_NAME_1, "A", "A", GENBANK_ACCESSION_1, "A", "A", true)));
+
+        VariantToVariantContextProcessor variantToVariantContextProcessor =
+                new VariantToVariantContextProcessor(contigMapping);
+
         List<VariantContext> variantContexts =
                 Stream.of(variants).map(variantToVariantContextProcessor::process).collect(Collectors.toList());
         writer.write(variantContexts);
@@ -151,7 +161,8 @@ public class VariantContextWriterTest {
     @Test
     public void checkReference() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
+        File output = assertWriteVcf(outputFolder,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
 
         List<String> referenceLines = grepFile(output, "^##reference.*");
         assertEquals(1, referenceLines.size());
@@ -179,7 +190,8 @@ public class VariantContextWriterTest {
         fileWriter.write(contig);
         fileWriter.close();
 
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
+        File output = assertWriteVcf(outputFolder,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
 
         List<String> metadataLines = grepFile(output, "^##.*");
         assertEquals(10, metadataLines.size());
@@ -192,7 +204,8 @@ public class VariantContextWriterTest {
     @Test
     public void checkAccession() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
+        File output = assertWriteVcf(outputFolder,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
 
         List<String> dataLines = grepFileContains(output, ID);
         assertEquals(1, dataLines.size());
@@ -201,7 +214,8 @@ public class VariantContextWriterTest {
     @Test
     public void checkColumns() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
+        File output = assertWriteVcf(outputFolder,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
 
         List<String> dataLines = grepFileContains(output, ID);
         assertEquals(1, dataLines.size());
@@ -211,7 +225,9 @@ public class VariantContextWriterTest {
     @Test
     public void checkStudies() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1, STUDY_2));
+        File output = assertWriteVcf(outputFolder,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1,
+                                                  STUDY_2));
 
         List<String> metadataLines = grepFileContains(output, STUDY_1);
         assertEquals(1, metadataLines.size());
@@ -233,9 +249,12 @@ public class VariantContextWriterTest {
 
     private void checkSequenceOntology(String sequenceOntology, String reference, String alternate) throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, reference, alternate, sequenceOntology, STUDY_1, STUDY_2));
+        File output = assertWriteVcf(outputFolder,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, reference, alternate, sequenceOntology,
+                                                  STUDY_1, STUDY_2));
 
-        String dataWithVariantClassRegex = createRegexSurroundedByTabOrSemicolonInDataLine(VARIANT_CLASS_KEY + "=SO:[0-9]+");
+        String dataWithVariantClassRegex = createRegexSurroundedByTabOrSemicolonInDataLine(
+                VARIANT_CLASS_KEY + "=SO:[0-9]+");
         List<String> dataLines = grepFile(output, dataWithVariantClassRegex);
         assertEquals(1, dataLines.size());
 
@@ -290,9 +309,12 @@ public class VariantContextWriterTest {
         String alternate3 = "G";
 
         File output = assertWriteVcf(outputFolder,
-                       buildVariant(CHR_1, position1, "C", alternate1, SNP_SEQUENCE_ONTOLOGY, STUDY_1),
-                       buildVariant(CHR_1, position2, "C", alternate2, SNP_SEQUENCE_ONTOLOGY, STUDY_1),
-                       buildVariant(CHR_1, position3, "C", alternate3, SNP_SEQUENCE_ONTOLOGY, STUDY_1));
+                                     buildVariant(GENBANK_ACCESSION_1, position1, "C", alternate1,
+                                                  SNP_SEQUENCE_ONTOLOGY, STUDY_1),
+                                     buildVariant(GENBANK_ACCESSION_1, position2, "C", alternate2,
+                                                  SNP_SEQUENCE_ONTOLOGY, STUDY_1),
+                                     buildVariant(GENBANK_ACCESSION_1, position3, "C", alternate3,
+                                                  SNP_SEQUENCE_ONTOLOGY, STUDY_1));
 
         List<String> dataLines = grepFileContains(output, ID);
         assertEquals(3, dataLines.size());
@@ -309,7 +331,9 @@ public class VariantContextWriterTest {
     @Test
     public void checkStandardNucleotides() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, "C", "NACTG", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
+        File output = assertWriteVcf(outputFolder,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "NACTG", SNP_SEQUENCE_ONTOLOGY,
+                                                  STUDY_1));
 
         List<String> dataLines = grepFileContains(output, ID);
         assertEquals(1, dataLines.size());
@@ -318,20 +342,22 @@ public class VariantContextWriterTest {
     @Test(expected = IllegalArgumentException.class)
     public void throwIfNonStandardNucleotides() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, "C", "U", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
+        File output = assertWriteVcf(outputFolder,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "U", SNP_SEQUENCE_ONTOLOGY, STUDY_1));
     }
 
     @Test
     public void checkFlagsAreNotPresentWhenDefaultValues() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
         File output = assertWriteVcf(outputFolder,
-                       buildVariant(CHR_1, 1000, "C", "G", SNP_SEQUENCE_ONTOLOGY, false, false, true, true, true,
-                                    STUDY_1));
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "G", SNP_SEQUENCE_ONTOLOGY, false,
+                                                  false, true, true, true,
+                                                  STUDY_1));
 
         String dataLinesWithFlagsRegex = DATA_LINES_REGEX + "(" + CLUSTERED_VARIANT_VALIDATED_KEY
-                                         + "|" + ALLELES_MATCH_KEY
-                                         + "|" + ASSEMBLY_MATCH_KEY
-                                         + "|" + SUPPORTED_BY_EVIDENCE_KEY + ").*";
+                + "|" + ALLELES_MATCH_KEY
+                + "|" + ASSEMBLY_MATCH_KEY
+                + "|" + SUPPORTED_BY_EVIDENCE_KEY + ").*";
         List<String> dataLines = grepFile(output, dataLinesWithFlagsRegex);
 
         assertEquals(0, dataLines.size());
@@ -345,8 +371,9 @@ public class VariantContextWriterTest {
     private void assertFlagIsPresent(String flagRegex) throws Exception {
         File outputFolder = temporaryFolder.newFolder();
         File output = assertWriteVcf(outputFolder,
-                       buildVariant(CHR_1, 1000, "C", "G", SNP_SEQUENCE_ONTOLOGY, true, true, false, false, false,
-                                    STUDY_1));
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "C", "G", SNP_SEQUENCE_ONTOLOGY, true,
+                                                  true, false, false, false,
+                                                  STUDY_1));
 
         String dataLinesWithValidatedRegex = createRegexSurroundedByTabOrSemicolonInDataLine(flagRegex);
         List<String> dataLines;
@@ -358,13 +385,14 @@ public class VariantContextWriterTest {
     public void checkHowShouldTabsBeWrittenInJavaRegex() {
         assertTrue("\t".matches("\t")); // java string containing literal tab
         assertTrue("\t".matches("\\t"));    // java string containing a backwards slash and a 't', interpreted as
-                                            // a tab by the regex classes, @see Pattern
+        // a tab by the regex classes, @see Pattern
     }
 
     @Test
     public void checkNonDefaultSubmittedVariantValidatedFlag() throws Exception {
         assertFlagIsPresent(SUBMITTED_VARIANT_VALIDATED_KEY + "=[0-9]");
     }
+
     @Test
     public void checkNonDefaultAllelesMatchFlag() throws Exception {
         assertFlagIsPresent(ALLELES_MATCH_KEY);
@@ -387,7 +415,7 @@ public class VariantContextWriterTest {
 
     private void assertSeveralFlagValues(String flagKey, boolean firstValue, boolean secondValue,
                                          int expectedLinesWithTheFlag) throws Exception {
-        Variant variant = new Variant(CHR_1, 1000, 1000, "C", "G");
+        Variant variant = new Variant(GENBANK_ACCESSION_1, 1000, 1000, "C", "G");
         variant.setMainId(ID);
 
         VariantSourceEntry sourceEntry1 = new VariantSourceEntry(STUDY_1, FILE_ID);
@@ -406,10 +434,12 @@ public class VariantContextWriterTest {
         dataLines = grepFile(output, dataLinesWithValidatedRegex);
         assertEquals(expectedLinesWithTheFlag, dataLines.size());
     }
+
     @Test
     public void checkSeveralValidatedFlags() throws Exception {
         assertSeveralFlagValues(CLUSTERED_VARIANT_VALIDATED_KEY, true, false, 1);
     }
+
     @Test
     public void checkSeveralAllelesMatchFlags() throws Exception {
         assertSeveralFlagValues(ALLELES_MATCH_KEY, true, false, 1);
@@ -427,7 +457,7 @@ public class VariantContextWriterTest {
 
     private void assertNamedVariant(String reference, String alternate) throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, reference, alternate,
+        File output = assertWriteVcf(outputFolder, buildVariant(GENBANK_ACCESSION_1, 1000, reference, alternate,
                                                                 SEQUENCE_ALTERATION_SEQUENCE_ONTOLOGY, STUDY_1));
 
         List<String> dataLines = grepFile(output, DATA_LINES_REGEX);
@@ -445,7 +475,7 @@ public class VariantContextWriterTest {
     @Test(expected = IllegalArgumentException.class)
     public void throwIfNamedReference() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
-        File output = assertWriteVcf(outputFolder, buildVariant(CHR_1, 1000, "<1190_BP_DEL>", "A",
+        File output = assertWriteVcf(outputFolder, buildVariant(GENBANK_ACCESSION_1, 1000, "<1190_BP_DEL>", "A",
                                                                 SEQUENCE_ALTERATION_SEQUENCE_ONTOLOGY, STUDY_1));
     }
 
@@ -453,9 +483,11 @@ public class VariantContextWriterTest {
     public void writeStudyWithInvalidCharacters() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
         File output = assertWriteVcf(outputFolder,
-                                     buildVariant(CHR_1, 1000, "A", "T", SEQUENCE_ALTERATION_SEQUENCE_ONTOLOGY,
+                                     buildVariant(GENBANK_ACCESSION_1, 1000, "A", "T",
+                                                  SEQUENCE_ALTERATION_SEQUENCE_ONTOLOGY,
                                                   "study_id=weird, yes; but not impossible in dbSNP"),
-                                     buildVariant(CHR_1, 2000, "A", "T", SEQUENCE_ALTERATION_SEQUENCE_ONTOLOGY,
+                                     buildVariant(GENBANK_ACCESSION_1, 2000, "A", "T",
+                                                  SEQUENCE_ALTERATION_SEQUENCE_ONTOLOGY,
                                                   "one =study= ",
                                                   ";; extra study ;;"));
 

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/VariantToVariantContextProcessorTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/VariantToVariantContextProcessorTest.java
@@ -19,10 +19,13 @@ package uk.ac.ebi.eva.accession.release.steps.processors;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.assertj.core.util.Sets;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
+import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
 
@@ -41,7 +44,9 @@ public class VariantToVariantContextProcessorTest {
 
     private static final String INSERTION_SEQUENCE_ONTOLOGY = "SO:0000667";
 
-    private static final String CHR_1 = "1";
+    private static final String SEQUENCE_NAME_1 = "Chr1";
+
+    private static final String GENBANK_ACCESSION_1 = "CM0001.1";
 
     private static final String ID = "rs123";
 
@@ -53,17 +58,23 @@ public class VariantToVariantContextProcessorTest {
 
     private static final String STUDY_ID_KEY = "SID";
 
+    private VariantToVariantContextProcessor variantConverter;
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    @Before
+    public void setUp() throws Exception {
+        ContigMapping contigMapping = new ContigMapping(Collections.singletonList(
+                new ContigSynonyms(SEQUENCE_NAME_1, "A", "A", GENBANK_ACCESSION_1, "A", "A", true)));
+        variantConverter = new VariantToVariantContextProcessor(contigMapping);
+    }
+
     @Test
     public void singleStudySNV() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1000, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
         VariantContext variantContext = variantConverter.process(variant);
-
-        assertVariantContext(variantContext, CHR_1, 1000, 1000, ID, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1000, 1000, ID, "C", "A", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
     }
 
     private Variant buildVariant(String chr1, int start, String reference, String alternate,
@@ -104,113 +115,92 @@ public class VariantToVariantContextProcessorTest {
 
     @Test
     public void throwsIfAllelesAreEmpty() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1100, "", "G", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
-
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1100, "", "G", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
         expectedException.expect(IllegalArgumentException.class);
         variantConverter.process(variant);
     }
+
     @Test
     public void singleStudySingleNucleotideInsertion() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1100, "T", "TG", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1100, "T", "TG", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
         VariantContext variantContext = variantConverter.process(variant);
-
-        assertVariantContext(variantContext, CHR_1, 1100, 1100, ID, "T", "TG", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1100, 1100, ID, "T", "TG", SNP_SEQUENCE_ONTOLOGY,
+                             STUDY_1);
     }
 
     @Test
     public void singleStudySeveralNucleotidesInsertion() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1100, "T", "TGA", INSERTION_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1100, "T", "TGA", INSERTION_SEQUENCE_ONTOLOGY, STUDY_1);
         VariantContext variantContext = variantConverter.process(variant);
-
-        assertVariantContext(variantContext, CHR_1, 1100, 1100, ID, "T", "TGA", INSERTION_SEQUENCE_ONTOLOGY, STUDY_1);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1100, 1100, ID, "T", "TGA", INSERTION_SEQUENCE_ONTOLOGY,
+                             STUDY_1);
     }
 
     @Test
     public void singleStudySingleNucleotideDeletion() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1100, "TA", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1100, "TA", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
         VariantContext variantContext = variantConverter.process(variant);
-
-        assertVariantContext(variantContext, CHR_1, 1100, 1101, ID, "TA", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1100, 1101, ID, "TA", "T", DELETION_SEQUENCE_ONTOLOGY,
+                             STUDY_1);
     }
 
     @Test
     public void singleStudySeveralNucleotidesDeletion() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1100, "TAG", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1100, "TAG", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
         VariantContext variantContext = variantConverter.process(variant);
-
-        assertVariantContext(variantContext, CHR_1, 1100, 1102, ID, "TAG", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1100, 1102, ID, "TAG", "T", DELETION_SEQUENCE_ONTOLOGY,
+                             STUDY_1);
     }
 
     @Test
     public void singleStudyMultiAllelicVariant() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1100, "C", "A,T", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
-
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1100, "C", "A,T", SNP_SEQUENCE_ONTOLOGY, STUDY_1);
         expectedException.expect(IllegalArgumentException.class);
         variantConverter.process(variant);
     }
 
     @Test
     public void singleNucleotideInsertionInPosition1() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1, "A", "TA", INSERTION_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1, "A", "TA", INSERTION_SEQUENCE_ONTOLOGY, STUDY_1);
         VariantContext variantContext = variantConverter.process(variant);
-
-        assertVariantContext(variantContext, CHR_1, 1, 1, ID, "A", "TA", INSERTION_SEQUENCE_ONTOLOGY, STUDY_1);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1, 1, ID, "A", "TA", INSERTION_SEQUENCE_ONTOLOGY,
+                             STUDY_1);
     }
 
     @Test
     public void singleNucleotideDeletionInPosition1() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1, "AT", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1, "AT", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
         VariantContext variantContext = variantConverter.process(variant);
-
-        assertVariantContext(variantContext, CHR_1, 1, 2, ID, "AT", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1, 2, ID, "AT", "T", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
     }
 
 
     @Test
     public void severalNucleotidesInsertionInPosition1() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1, "A", "GGTA", INSERTION_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1, "A", "GGTA", INSERTION_SEQUENCE_ONTOLOGY, STUDY_1);
         VariantContext variantContext = variantConverter.process(variant);
-
-        assertVariantContext(variantContext, CHR_1, 1, 1, ID, "A", "GGTA", INSERTION_SEQUENCE_ONTOLOGY, STUDY_1);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1, 1, ID, "A", "GGTA", INSERTION_SEQUENCE_ONTOLOGY,
+                             STUDY_1);
     }
 
     @Test
     public void severalNucleotidesDeletionInPosition1() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1, "ATTG", "G", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
-
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1, "ATTG", "G", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
         VariantContext variantContext = variantConverter.process(variant);
-
-        assertVariantContext(variantContext, CHR_1, 1, 4, ID, "ATTG", "G", DELETION_SEQUENCE_ONTOLOGY, STUDY_1);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1, 4, ID, "ATTG", "G", DELETION_SEQUENCE_ONTOLOGY,
+                             STUDY_1);
     }
 
     @Test
     public void twoStudiesSingleVariant() throws Exception {
-        Variant variant = buildVariant(CHR_1, 1000, "T", "G", SNP_SEQUENCE_ONTOLOGY, STUDY_1, STUDY_2);
+        Variant variant = buildVariant(GENBANK_ACCESSION_1, 1000, "T", "G", SNP_SEQUENCE_ONTOLOGY, STUDY_1, STUDY_2);
 
         // process variant
-        VariantToVariantContextProcessor variantConverter = new VariantToVariantContextProcessor();
         VariantContext variantContext = variantConverter.process(variant);
 
         // check processed variant
-        assertVariantContext(variantContext, CHR_1, 1000, 1000, ID, "T", "G", SNP_SEQUENCE_ONTOLOGY, STUDY_1, STUDY_2);
+        assertVariantContext(variantContext, SEQUENCE_NAME_1, 1000, 1000, ID, "T", "G", SNP_SEQUENCE_ONTOLOGY, STUDY_1,
+                             STUDY_2);
     }
 
 }


### PR DESCRIPTION
Sequence names are included in the contig file in order to write both the contig and the sequence name in the VCF headers of the RS Release.

Format should be:
```
##contig=<ID=chr01,Name="CM000001.3">
```

The `#CROM` Column of the VCF file now uses the sequence name
```
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
chr01   112     rs850979046     A       G       .       .       LOE;SID=BROAD_VGB_CANINE_PON_SNP_DISCOVERY;SS_VALIDATED=0;VC=SO:0001483
chr01   132     rs851217143     C       A       .       .       LOE;SID=BROAD_VGB_CANINE_PON_SNP_DISCOVERY;SS_VALIDATED=0;VC=SO:0001483
chr01   147     rs853028708     G       A       .       .       LOE;SID=BROAD_VGB_CANINE_PON_SNP_DISCOVERY;SS_VALIDATED=0;VC=SO:0001483
```