### PR TITLE
EVA-1654 Assess the impact of variants with start position greater than end of chromosome

### DIFF
--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/exceptions/IllegalStartPositionException.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/exceptions/IllegalStartPositionException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.ac.ebi.eva.accession.release.exceptions;
+package uk.ac.ebi.eva.accession.core.exceptions;
 
 public class IllegalStartPositionException extends IllegalArgumentException {
 

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/exceptions/PositionOutsideOfContigException.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/exceptions/PositionOutsideOfContigException.java
@@ -15,9 +15,9 @@
  */
 package uk.ac.ebi.eva.accession.core.exceptions;
 
-public class IllegalStartPositionException extends IllegalArgumentException {
+public class PositionOutsideOfContigException extends IllegalArgumentException {
 
-    public IllegalStartPositionException(String message) {
+    public PositionOutsideOfContigException(String message) {
         super(message);
     }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/io/FastaSequenceReader.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/io/FastaSequenceReader.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
 import uk.ac.ebi.eva.commons.core.utils.FileUtils;
 
 import java.io.IOException;
@@ -138,7 +139,7 @@ public class FastaSequenceReader {
         } else {
             int sequenceLengthInFastaFile = sequenceDictionary.getSequence(contig).getSequenceLength();
             if (end > sequenceLengthInFastaFile) {
-                throw new IllegalArgumentException(
+                throw new IllegalStartPositionException(
                         "Variant coordinate " + end + " greater than end of chromosome " + contig + ": " +
                                 sequenceLengthInFastaFile);
             }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/io/FastaSequenceReader.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/io/FastaSequenceReader.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
+import uk.ac.ebi.eva.accession.core.exceptions.PositionOutsideOfContigException;
 import uk.ac.ebi.eva.commons.core.utils.FileUtils;
 
 import java.io.IOException;
@@ -139,7 +139,7 @@ public class FastaSequenceReader {
         } else {
             int sequenceLengthInFastaFile = sequenceDictionary.getSequence(contig).getSequenceLength();
             if (end > sequenceLengthInFastaFile) {
-                throw new IllegalStartPositionException(
+                throw new PositionOutsideOfContigException(
                         "Variant coordinate " + end + " greater than end of chromosome " + contig + ": " +
                                 sequenceLengthInFastaFile);
             }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/policies/IllegalStartSkipPolicy.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/policies/IllegalStartSkipPolicy.java
@@ -18,12 +18,12 @@ package uk.ac.ebi.eva.accession.release.policies;
 import org.springframework.batch.core.step.skip.SkipLimitExceededException;
 import org.springframework.batch.core.step.skip.SkipPolicy;
 
-import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
+import uk.ac.ebi.eva.accession.core.exceptions.PositionOutsideOfContigException;
 
 public class IllegalStartSkipPolicy implements SkipPolicy {
 
     @Override
     public boolean shouldSkip(Throwable exception, int skipCount) throws SkipLimitExceededException {
-        return exception instanceof IllegalStartPositionException;
+        return exception instanceof PositionOutsideOfContigException;
     }
 }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/policies/IllegalStartSkipPolicy.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/policies/IllegalStartSkipPolicy.java
@@ -18,7 +18,7 @@ package uk.ac.ebi.eva.accession.release.policies;
 import org.springframework.batch.core.step.skip.SkipLimitExceededException;
 import org.springframework.batch.core.step.skip.SkipPolicy;
 
-import uk.ac.ebi.eva.accession.release.exceptions.IllegalStartPositionException;
+import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
 
 public class IllegalStartSkipPolicy implements SkipPolicy {
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessor.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessor.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 
 import uk.ac.ebi.eva.accession.core.io.FastaSynonymSequenceReader;
-import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
+import uk.ac.ebi.eva.accession.core.exceptions.PositionOutsideOfContigException;
 import uk.ac.ebi.eva.commons.core.models.IVariant;
 import uk.ac.ebi.eva.commons.core.models.VariantType;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
@@ -50,7 +50,7 @@ public class ContextNucleotideAdditionProcessor implements ItemProcessor<Variant
             } else {
                 throw new IllegalArgumentException("Contig '" + contig + "' does not appear in the FASTA file ");
             }
-        } catch (IllegalStartPositionException e) {
+        } catch (PositionOutsideOfContigException e) {
             logger.warn(e.getMessage() + ". " + variant.toString());
             throw e;
         }

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessor.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessor.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 
 import uk.ac.ebi.eva.accession.core.io.FastaSynonymSequenceReader;
-import uk.ac.ebi.eva.accession.release.exceptions.IllegalStartPositionException;
+import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
 import uk.ac.ebi.eva.commons.core.models.IVariant;
 import uk.ac.ebi.eva.commons.core.models.VariantType;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
@@ -50,9 +50,9 @@ public class ContextNucleotideAdditionProcessor implements ItemProcessor<Variant
             } else {
                 throw new IllegalArgumentException("Contig '" + contig + "' does not appear in the FASTA file ");
             }
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalStartPositionException e) {
             logger.warn(e.getMessage() + ". " + variant.toString());
-            throw new IllegalStartPositionException(e.getMessage());
+            throw e;
         }
     }
 

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/policies/IllegalStartSkipPolicyTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/policies/IllegalStartSkipPolicyTest.java
@@ -18,7 +18,7 @@ package uk.ac.ebi.eva.accession.release.policies;
 import org.junit.Before;
 import org.junit.Test;
 
-import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
+import uk.ac.ebi.eva.accession.core.exceptions.PositionOutsideOfContigException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -34,7 +34,7 @@ public class IllegalStartSkipPolicyTest {
 
     @Test
     public void shouldSkipException() {
-        Throwable illegalStartPositionException = new IllegalStartPositionException("exception");
+        Throwable illegalStartPositionException = new PositionOutsideOfContigException("exception");
         assertTrue(illegalStartSkipPolicy.shouldSkip(illegalStartPositionException, 0));
     }
 

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/policies/IllegalStartSkipPolicyTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/policies/IllegalStartSkipPolicyTest.java
@@ -18,7 +18,7 @@ package uk.ac.ebi.eva.accession.release.policies;
 import org.junit.Before;
 import org.junit.Test;
 
-import uk.ac.ebi.eva.accession.release.exceptions.IllegalStartPositionException;
+import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessorTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessorTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
 import uk.ac.ebi.eva.accession.core.io.FastaSynonymSequenceReader;
-import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
+import uk.ac.ebi.eva.accession.core.exceptions.PositionOutsideOfContigException;
 import uk.ac.ebi.eva.commons.core.models.IVariant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
@@ -178,7 +178,7 @@ public class ContextNucleotideAdditionProcessorTest {
         assertEquals("<100_BP_insertion>", processedVariant.getAlternate());
     }
 
-    @Test(expected = IllegalStartPositionException.class)
+    @Test(expected = PositionOutsideOfContigException.class)
     public void testStartPositionGreaterThanChromosomeEnd() throws Exception {
         Variant variant1 = new Variant(CONTIG, START_OUTSIDE_CHOMOSOME, START_OUTSIDE_CHOMOSOME, "", "A");
         String rs1000 = "rs1000";
@@ -202,7 +202,7 @@ public class ContextNucleotideAdditionProcessorTest {
         Variant variant1 = new Variant(MISSING_IN_FASTA, 10, 10, "", "A");
         try {
             contextNucleotideAdditionProcessor.process(variant1);
-        } catch (IllegalStartPositionException wrongException) {
+        } catch (PositionOutsideOfContigException wrongException) {
             fail("The exception (" + wrongException.getClass().getSimpleName()
                  + ") is wrong because the variant doesn't have a position outside of chromosome. The correct "
                  + "exception should be that the contig is not present in the fasta");

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessorTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessorTest.java
@@ -30,13 +30,21 @@ import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class ContextNucleotideAdditionProcessorTest {
 
     private static final String CONTIG = "22";
+
+    private static final String SCAFFOLD = "scaffold";
+
+    private static final String SCAFFOLD_GENBANK_IN_FASTA = "AADN04000814.1";
+
+    private static final String MISSING_IN_FASTA = "chrMissing";
 
     private static final int START_OUTSIDE_CHOMOSOME = 5000000;
 
@@ -47,10 +55,12 @@ public class ContextNucleotideAdditionProcessorTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         Path fastaPath = Paths.get("../eva-accession-core/src/test/resources/input-files/fasta/Gallus_gallus-5.0.test.fa");
-        ContigMapping contigMapping = new ContigMapping(Collections.singletonList(
-                new ContigSynonyms(CONTIG, "", "", "", "", "", true)));
+        ContigMapping contigMapping = new ContigMapping(
+                Arrays.asList(new ContigSynonyms(CONTIG, "", "", "", "", "", true),
+                              new ContigSynonyms(SCAFFOLD, "", "", SCAFFOLD_GENBANK_IN_FASTA, "", "", true),
+                              new ContigSynonyms(MISSING_IN_FASTA, "", "", "", "", "", true)));
         fastaSynonymSequenceReader = new FastaSynonymSequenceReader(contigMapping, fastaPath);
-        contextNucleotideAdditionProcessor = new ContextNucleotideAdditionProcessor (fastaSynonymSequenceReader);
+        contextNucleotideAdditionProcessor = new ContextNucleotideAdditionProcessor(fastaSynonymSequenceReader);
     }
 
     @AfterClass
@@ -175,5 +185,27 @@ public class ContextNucleotideAdditionProcessorTest {
         variant1.setMainId(rs1000);
         variant1.setIds(Collections.singleton(rs1000));
         contextNucleotideAdditionProcessor.process(variant1);
+    }
+
+    @Test
+    public void addContextBaseUsingSynonymContig() throws Exception {
+        Variant variant = new Variant(SCAFFOLD, 7, 8, "", "A");
+        IVariant processedVariant = contextNucleotideAdditionProcessor.process(variant);
+        assertEquals(6, processedVariant.getStart());
+        assertEquals(7, processedVariant.getEnd());
+        assertEquals("T", processedVariant.getReference());
+        assertEquals("TA", processedVariant.getAlternate());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void contigNotFound() throws Exception {
+        Variant variant1 = new Variant(MISSING_IN_FASTA, 10, 10, "", "A");
+        try {
+            contextNucleotideAdditionProcessor.process(variant1);
+        } catch (IllegalStartPositionException wrongException) {
+            fail("The exception (" + wrongException.getClass().getSimpleName()
+                 + ") is wrong because the variant doesn't have a position outside of chromosome. The correct "
+                 + "exception should be that the contig is not present in the fasta");
+        }
     }
 }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessorTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/steps/processors/ContextNucleotideAdditionProcessorTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import uk.ac.ebi.eva.accession.core.contig.ContigMapping;
 import uk.ac.ebi.eva.accession.core.contig.ContigSynonyms;
 import uk.ac.ebi.eva.accession.core.io.FastaSynonymSequenceReader;
-import uk.ac.ebi.eva.accession.release.exceptions.IllegalStartPositionException;
+import uk.ac.ebi.eva.accession.core.exceptions.IllegalStartPositionException;
 import uk.ac.ebi.eva.commons.core.models.IVariant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 


### PR DESCRIPTION
This PR fixes a bug where variants in chromosomes that don't appear in the provided fasta, are reported as variants that are located past the end of its chromosome. 