### PR TITLE
EVA-1665 VCF headers list the contigs in accession order

### DIFF
--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/ContigWriter.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/ContigWriter.java
@@ -69,6 +69,19 @@ public class ContigWriter implements ItemStreamWriter<String> {
     @Override
     public void close() throws ItemStreamException {
         printWriter.close();
+        sortContigFile();
+    }
+
+    private void sortContigFile() {
+        try {
+            int exitCode = Runtime.getRuntime().exec(new String[]{"sort", this.output.getAbsolutePath()}).waitFor();
+            if (exitCode != 0) {
+                throw new ItemStreamException(
+                        "Trying to sort the contig list, the 'sort' command returned exit code'" + exitCode + "'.");
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new ItemStreamException("Failed sorting contig list. ", e);
+        }
     }
 
     @Override
@@ -85,7 +98,7 @@ public class ContigWriter implements ItemStreamWriter<String> {
                 throw new IllegalArgumentException("Could not find the corresponding sequence name for contig " + contig);
             }
 
-            printWriter.println(contig + "," + sequenceName);
+            printWriter.println(sequenceName + "," + contig);
         }
     }
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriter.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriter.java
@@ -137,9 +137,9 @@ public class VariantContextWriter implements ItemStreamWriter<VariantContext> {
             BufferedReader bufferedReader = new BufferedReader(new FileReader(contigsFilePath));
             String contigLine;
             while ((contigLine = bufferedReader.readLine()) != null) {
-                String[] contigAndName = contigLine.split(",");
-                String contig = contigAndName[0];
-                String name = contigAndName[1];
+                String[] nameAndContig = contigLine.split(",");
+                String name = nameAndContig[0];
+                String contig = nameAndContig[1];
                 metaData.add(new VCFHeaderLine("contig", "<ID=" + name + ",accession=\"" + contig + "\">"));
             }
         } catch (IOException e) {

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/configuration/steps/ListActiveContigsStepConfigurationTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/configuration/steps/ListActiveContigsStepConfigurationTest.java
@@ -100,7 +100,7 @@ public class ListActiveContigsStepConfigurationTest {
     public void contigsWritten() throws Exception {
         assertStepExecutesAndCompletes();
 
-        assertEquals(new HashSet<>(Arrays.asList("CM001954.1,CAE13", "CM001941.2,CAE1")),
+        assertEquals(new HashSet<>(Arrays.asList("CAE13,CM001954.1", "CAE1,CM001941.2")),
                      setOfLines(getActiveContigsFilePath(inputParameters.getOutputFolder(),
                                                          inputParameters.getAssemblyAccession())));
     }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/configuration/steps/ListMergedContigsStepConfigurationTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/configuration/steps/ListMergedContigsStepConfigurationTest.java
@@ -101,7 +101,7 @@ public class ListMergedContigsStepConfigurationTest {
     public void contigsWritten() throws Exception {
         assertStepExecutesAndCompletes();
 
-        assertEquals(new HashSet<>(Arrays.asList("CM001954.1,CAE13", "CM001941.2,CAE1")),
+        assertEquals(new HashSet<>(Arrays.asList("CAE13,CM001954.1", "CAE1,CM001941.2")),
                      setOfLines(ContigWriter.getMergedContigsFilePath(inputParameters.getOutputFolder(),
                                                                       inputParameters.getAssemblyAccession())));
     }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/ContigWriterTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/ContigWriterTest.java
@@ -85,7 +85,7 @@ public class ContigWriterTest {
 
         assertEquals(contigs.size(), numberOfLines(output));
 
-        List<String> expectedLines = Arrays.asList("CM0001.1,Chr1", "CM0002.1,Chr2", "CM0003.1,Chr3");
+        List<String> expectedLines = Arrays.asList("Chr1,CM0001.1", "Chr2,CM0002.1", "Chr3,CM0003.1");
         assertContigFileContent(output, expectedLines);
     }
 
@@ -123,7 +123,7 @@ public class ContigWriterTest {
 
         assertEquals(contigs.size(), numberOfLines(output));
 
-        List<String> expectedLines = Arrays.asList("NC0001.1,Chr1", "NC0002.1,Chr2", "CM0003.1,Chr3");
+        List<String> expectedLines = Arrays.asList("Chr1,NC0001.1", "Chr2,NC0002.1", "Chr3,CM0003.1");
         assertContigFileContent(output, expectedLines);
     }
 

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriterTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/io/VariantContextWriterTest.java
@@ -187,7 +187,7 @@ public class VariantContextWriterTest {
     public void checkMetadataSection() throws Exception {
         File outputFolder = temporaryFolder.newFolder();
         FileWriter fileWriter = new FileWriter(ContigWriter.getActiveContigsFilePath(outputFolder, REFERENCE_ASSEMBLY));
-        String contig = "CM0001.1,Chr1";
+        String contig = "Chr1,CM0001.1";
         fileWriter.write(contig);
         fileWriter.close();
 


### PR DESCRIPTION
Of course this is platform dependent, but given that we have some
species with lots of contigs (e.g. almost 0.5M for rat or turkey),
we can either:

- keep the hacky implementation of this commit.
- evaluate memory performance of: loading the file into
a list, sort the list in memory, write the list. For at least a
couple million of 20 bytes strings.

If we go for the second option, the changes have to be done in the
same place as the current system sort.