### PR TITLE
EVA-1536 - Support concatenated BZ2 files and check for empty batches before write

### DIFF
--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsWriterConfiguration.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/configuration/ImportDbsnpJsonVariantsWriterConfiguration.java
@@ -19,11 +19,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import uk.ac.ebi.eva.accession.core.configuration.MongoConfiguration;
+import uk.ac.ebi.eva.accession.core.io.DbsnpClusteredVariantWriter;
 import uk.ac.ebi.eva.accession.core.listeners.ImportCounts;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity;
 import uk.ac.ebi.eva.accession.dbsnp2.io.DbsnpJsonClusteredVariantsWriter;
@@ -37,12 +39,18 @@ public class ImportDbsnpJsonVariantsWriterConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(ImportDbsnpJsonVariantsWriterConfiguration.class);
 
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private ImportCounts importCounts;
+
     @Bean(name = DBSNP_JSON_VARIANT_WRITER)
     @StepScope
-    public ItemWriter<DbsnpClusteredVariantEntity> writer(InputParameters parameters,
-                                                          MongoTemplate mongoTemplate,
-                                                          ImportCounts importCounts) {
+    public ItemWriter<DbsnpClusteredVariantEntity> writer(InputParameters parameters) {
         logger.info("Injecting dbsnpClusteredVariantWriter with parameters: {}", parameters);
-        return new DbsnpJsonClusteredVariantsWriter(mongoTemplate, importCounts);
+        DbsnpClusteredVariantWriter dbsnpClusteredVariantWriter = new DbsnpClusteredVariantWriter(mongoTemplate,
+                                                                                                  importCounts);
+        return new DbsnpJsonClusteredVariantsWriter(dbsnpClusteredVariantWriter);
     }
 }

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/BzipLazyResource.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/BzipLazyResource.java
@@ -46,10 +46,10 @@ public class BzipLazyResource extends FileSystemResource {
     public InputStream getInputStream() throws IOException {
         BufferedInputStream bis = new BufferedInputStream(super.getInputStream());
         try {
-            return new CompressorStreamFactory().createCompressorInputStream(bis);
+            return new CompressorStreamFactory().createCompressorInputStream(CompressorStreamFactory.BZIP2, bis,
+                                                                             true);
         } catch (CompressorException compressorException) {
             throw new IOException("The input file is not compressed in bzip2 format");
         }
     }
 }
-

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/DbsnpJsonClusteredVariantsWriter.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/io/DbsnpJsonClusteredVariantsWriter.java
@@ -18,7 +18,6 @@ package uk.ac.ebi.eva.accession.dbsnp2.io;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.BulkOperationException;
 import uk.ac.ebi.eva.accession.core.io.DbsnpClusteredVariantWriter;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity;

--- a/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/io/DbsnpJsonClusteredVariantsWriterTest.java
+++ b/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/io/DbsnpJsonClusteredVariantsWriterTest.java
@@ -70,7 +70,7 @@ public class DbsnpJsonClusteredVariantsWriterTest {
     public void setUp() {
         importCounts = new ImportCounts();
         DbsnpClusteredVariantWriter dbsnpClusteredVariantWriter = new DbsnpClusteredVariantWriter(mongoTemplate,
-                                                                                             importCounts);
+                                                                                                  importCounts);
         variantEntity1 = buildClusteredVariantEntity(1L,
                                                      buildClusteredVariant("acsn1",
                                                                            "contig1",

--- a/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/io/DbsnpJsonClusteredVariantsWriterTest.java
+++ b/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/io/DbsnpJsonClusteredVariantsWriterTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.eva.accession.core.ClusteredVariant;
 import uk.ac.ebi.eva.accession.core.IClusteredVariant;
+import uk.ac.ebi.eva.accession.core.io.DbsnpClusteredVariantWriter;
 import uk.ac.ebi.eva.accession.core.listeners.ImportCounts;
 import uk.ac.ebi.eva.accession.core.persistence.DbsnpClusteredVariantEntity;
 import uk.ac.ebi.eva.accession.core.summary.ClusteredVariantSummaryFunction;
@@ -68,12 +69,14 @@ public class DbsnpJsonClusteredVariantsWriterTest {
     @Before
     public void setUp() {
         importCounts = new ImportCounts();
+        DbsnpClusteredVariantWriter dbsnpClusteredVariantWriter = new DbsnpClusteredVariantWriter(mongoTemplate,
+                                                                                             importCounts);
         variantEntity1 = buildClusteredVariantEntity(1L,
                                                      buildClusteredVariant("acsn1",
                                                                            "contig1",
                                                                            1L,
                                                                            VariantType.SNV));
-        dbsnpJsonClusteredVariantsWriter = new DbsnpJsonClusteredVariantsWriter(mongoTemplate, importCounts);
+        dbsnpJsonClusteredVariantsWriter = new DbsnpJsonClusteredVariantsWriter(dbsnpClusteredVariantWriter);
         mongoTemplate.dropCollection(DbsnpClusteredVariantEntity.class);
     }
 


### PR DESCRIPTION
While importing large BZ2 JSON files from ftp://ftp.ncbi.nih.gov/snp/latest_release/JSON/, I discovered that some of these were not being read entirely by the pipeline because the input stream did not permit concatenated BZ2 files. This PR fixes that issue by using [this specific constructor](https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/compressors/CompressorStreamFactory.html#createCompressorInputStream-java.lang.String-java.io.InputStream-boolean-) in Apache commons-compress library that allows for such files to be processed.