### PR TITLE
EVA-1666 Release the species other than EVA-1651

### DIFF
--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigMapping.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contig/ContigMapping.java
@@ -63,6 +63,8 @@ public class ContigMapping {
      * - UCSC and assignedMolecule columns may appear as "na" (not available).
      * - assignedMolecule values may not be unique across rows. Keep only those that have "assembled-molecule" in the
      * Sequence-Role column.
+     * - with our custom assembly reports, sometimes the Genbank column is also not unique. Keep all the duplicated
+     * entries but when asked for a genbank, return the mapping where it's an "assembled-molecule".
      */
     private void fillContigConventionMaps(ContigSynonyms contigSynonyms) {
         normalizeNames(contigSynonyms);
@@ -79,7 +81,11 @@ public class ContigMapping {
             assignedMoleculeToSynonyms.put(contigSynonyms.getAssignedMolecule(), contigSynonyms);
         }
         if (contigSynonyms.getGenBank() != null) {
-            genBankToSynonyms.put(contigSynonyms.getGenBank(), contigSynonyms);
+            if (ASSEMBLED_MOLECULE.equals(contigSynonyms.getSequenceRole())) {
+                genBankToSynonyms.put(contigSynonyms.getGenBank(), contigSynonyms);
+            } else {
+                genBankToSynonyms.putIfAbsent(contigSynonyms.getGenBank(), contigSynonyms);
+            }
         }
         if (contigSynonyms.getRefSeq() != null) {
             refSeqToSynonyms.put(contigSynonyms.getRefSeq(), contigSynonyms);

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/contig/ContigMappingTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/contig/ContigMappingTest.java
@@ -35,11 +35,19 @@ public class ContigMappingTest {
 
     private static final String SEQNAME_NON_ASSEMBLED = "MMCHR1_RANDOM_CTG1";
 
+    private static final String SEQNAME_OF_DUPLICATED_AND_ASSEMBLED_GENBANK = "alternate_chr6";
+
+    private static final String SEQNAME_OF_DUPLICATED_GENBANK = "7";
+
     private static final String ASSIGNED_MOLECULE_CONTIG = "1";
 
     private static final String GENBANK_CONTIG = "CM000994.2";
 
     private static final String GENBANK_WITHOUT_SYNONYM = "GL_without_synonym";
+
+    private static final String GENBANK_DUPLICATED_AND_ASSEMBLED = "CM000999.2";
+
+    private static final String GENBANK_DUPLICATED = "CM001000.2";
 
     private static final String REFSEQ_CONTIG = "NC_000067.6";
 
@@ -53,9 +61,13 @@ public class ContigMappingTest {
 
     private ContigMapping contigMapping;
 
-    private static final int TOTAL_ROWS = 24;
+    private static final int TOTAL_ROWS = 26;
 
-    private static final int NON_ASSEMBLED_MOLECULE_ROWS = 11;
+    private static final int NON_ASSEMBLED_MOLECULE_ROWS = 12;
+
+    private static final int DUPLICATED_ASSEMBLED_MOLECULE_ROWS = 1;
+
+    private static final int DUPLICATED_GENBANK = 2;
 
     private static final int MISSING_UCSC_ROWS = 1;
 
@@ -95,6 +107,17 @@ public class ContigMappingTest {
     }
 
     @Test
+    public void getSynonymsOfDuplicatedGenbank() {
+        ContigSynonyms contigSynonyms = contigMapping.getContigSynonyms(GENBANK_DUPLICATED_AND_ASSEMBLED);
+        assertNotNull(contigSynonyms);
+        assertEquals(SEQNAME_OF_DUPLICATED_AND_ASSEMBLED_GENBANK, contigSynonyms.getSequenceName());
+
+        contigSynonyms = contigMapping.getContigSynonyms(GENBANK_DUPLICATED);
+        assertNotNull(contigSynonyms);
+        assertEquals(SEQNAME_OF_DUPLICATED_GENBANK, contigSynonyms.getSequenceName());
+    }
+
+    @Test
     public void getAssignedMoleculeReturnsNullForNonAssembledMolecules() {
         assertNull(contigMapping.getContigSynonyms(SEQNAME_NON_ASSEMBLED).getAssignedMolecule());
     }
@@ -112,8 +135,9 @@ public class ContigMappingTest {
     @Test
     public void checkAllEntriesWereLoaded() {
         assertEquals(TOTAL_ROWS, contigMapping.sequenceNameToSynonyms.size());
-        assertEquals(TOTAL_ROWS - NON_ASSEMBLED_MOLECULE_ROWS, contigMapping.assignedMoleculeToSynonyms.size());
-        assertEquals(TOTAL_ROWS, contigMapping.genBankToSynonyms.size());
+        assertEquals(TOTAL_ROWS - NON_ASSEMBLED_MOLECULE_ROWS - DUPLICATED_ASSEMBLED_MOLECULE_ROWS,
+                     contigMapping.assignedMoleculeToSynonyms.size());
+        assertEquals(TOTAL_ROWS - DUPLICATED_GENBANK, contigMapping.genBankToSynonyms.size());
         assertEquals(TOTAL_ROWS, contigMapping.refSeqToSynonyms.size());
         assertEquals(TOTAL_ROWS - MISSING_UCSC_ROWS, contigMapping.ucscToSynonyms.size());
     }

--- a/eva-accession-core/src/test/resources/input-files/assembly-report/GCA_000001635.8_Mus_musculus-grcm38.p6_assembly_report.txt
+++ b/eva-accession-core/src/test/resources/input-files/assembly-report/GCA_000001635.8_Mus_musculus-grcm38.p6_assembly_report.txt
@@ -65,3 +65,5 @@ MMCHRX_RANDOM_CTG2	unlocalized-scaffold	X	Chromosome	GL456233.1	=	NT_165789.2	C5
 otherprefix_chr45	assembled-molecule	45	Chromosome	genbank_example_2	=	refseq_example_2	C57BL/6J	91744698	ucsc_example_2
 sequence_name_example_3	assembled-molecule	assigned_molecule_example_3	Chromosome	genbank_example_3	=	refseq_example_3	C57BL/6J	91744698	ucsc_example_3
 sequence_name_example_4	assembled-molecule	assigned_molecule_example_4	Chromosome	genbank_example_4	=	NW_006738765.1	C57BL/6J	91744698	ucsc_example_4
+alternate_chr6	assembled-molecule	7	Chromosome	CM000999.2	=	NW_alternate_chr6	C57BL/6J	91744698	ucsc_example_6
+alternate_chr7	unlocalized-scaffold	na	Chromosome	CM001000.2	=	NW_alternate_chr7	C57BL/6J	91744698	ucsc_example_7


### PR DESCRIPTION
parsing asm report, overwrite duplicate genbank only if it's assembled-molecule.

What this achieves is ignoring scaffolds when translating from
genbank to other name (e.g. from genbank to sequence name), while
still having the mappings from different names to the same genbank.