### PR TITLE
EVA-1824 Mongo reader and Job for each data source

### DIFF
--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringMongoReader.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringMongoReader.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.io;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoClient;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClusteringMongoReader implements ItemStreamReader<SubmittedVariantEntity> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClusteringMongoReader.class);
+
+    private static final String ASSEMBLY_FIELD = "seq";
+
+    private static final String CLUSTERED_VARIANT_ACCESSION_FIELD = "rs";
+
+    private static final String SUBMITTED_VARIANT_ENTITY = "submittedVariantEntity";
+
+    private MongoClient mongoClient;
+
+    private String database;
+
+    private String assembly;
+
+    private MongoCursor<Document> cursor;
+
+    private MongoConverter converter;
+
+    private MongoTemplate mongoTemplate;
+
+    private int chunkSize;
+
+    public ClusteringMongoReader(MongoClient mongoClient, String database, MongoTemplate mongoTemplate,
+                                 String assembly, int chunkSize) {
+        this.mongoClient = mongoClient;
+        this.database = database;
+        this.mongoTemplate = mongoTemplate;
+        this.assembly = assembly;
+        this.chunkSize = chunkSize;
+    }
+
+    @Override
+    public SubmittedVariantEntity read() {
+        return cursor.hasNext() ? getSubmittedVariantEntity(cursor.next()) : null;
+    }
+
+    private SubmittedVariantEntity getSubmittedVariantEntity(Document notClusteredSubmittedVariants) {
+        return converter.read(SubmittedVariantEntity.class, new BasicDBObject(notClusteredSubmittedVariants));
+    }
+
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        MongoDatabase db = mongoClient.getDatabase(database);
+        MongoCollection<Document> collection = db.getCollection(SUBMITTED_VARIANT_ENTITY);
+        AggregateIterable<Document> notClusteredSubmittedVariants = collection.aggregate(buildAggregation())
+                .allowDiskUse(true)
+                .useCursor(true)
+                .batchSize(chunkSize);
+        cursor = notClusteredSubmittedVariants.iterator();
+        converter = mongoTemplate.getConverter();
+    }
+
+    private List<Bson> buildAggregation() {
+        List<Bson> aggregation = new ArrayList<>();
+        aggregation.add(Aggregates.match(Filters.in(ASSEMBLY_FIELD, assembly)));
+        aggregation.add(Aggregates.match(Filters.eq(CLUSTERED_VARIANT_ACCESSION_FIELD, null)));
+        logger.info("Issuing aggregation: {}", aggregation);
+        return aggregation;
+    }
+
+    @Override
+    public void update(ExecutionContext executionContext) throws ItemStreamException {
+
+    }
+
+    @Override
+    public void close() throws ItemStreamException {
+        cursor.close();
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/BeanNames.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/BeanNames.java
@@ -19,13 +19,19 @@ public class BeanNames {
 
     public static final String VCF_READER = "VCF_READER";
 
+    public static final String MONGO_READER = "MONGO_READER";
+
     public static final String VARIANT_TO_SUBMITTED_VARIANT_ENTITY_PROCESSOR =
             "VARIANT_TO_SUBMITTED_VARIANT_ENTITY_PROCESSOR";
 
     public static final String CLUSTERING_WRITER = "CLUSTERING_WRITER";
 
-    public static final String CLUSTERING_STEP = "CLUSTERING_STEP";
+    public static final String CLUSTERING_FROM_VCF_STEP = "CLUSTERING_FROM_VCF_STEP";
 
-    public static final String CLUSTERING_JOB = "CLUSTERING_JOB";
+    public static final String CLUSTERING_FROM_MONGO_STEP = "CLUSTERING_FROM_MONGO_STEP";
+
+    public static final String CLUSTERING_FROM_VCF_JOB = "CLUSTERING_FROM_VCF_JOB";
+
+    public static final String CLUSTERING_FROM_MONGO_JOB = "CLUSTERING_FROM_MONGO_JOB";
 
 }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/ClusteringMongoReaderConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/ClusteringMongoReaderConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.configuration.batch.io;
+
+import com.mongodb.MongoClient;
+import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringMongoReader;
+import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
+import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
+
+@Configuration
+@Import({MongoConfiguration.class})
+public class ClusteringMongoReaderConfiguration {
+
+    @Bean
+    ClusteringMongoReader clusteringMongoReader(MongoClient mongoClient, MongoProperties mongoProperties,
+                                                MongoTemplate mongoTemplate, InputParameters parameters) {
+        if (parameters.getAssemblyAccession() == null || parameters.getAssemblyAccession().isEmpty()) {
+            throw new IllegalArgumentException("Please provide an assembly");
+        }
+        return new ClusteringMongoReader(mongoClient, mongoProperties.getDatabase(), mongoTemplate,
+                parameters.getAssemblyAccession(), parameters.getChunkSize());
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/ClusteringMongoReaderConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/ClusteringMongoReaderConfiguration.java
@@ -16,21 +16,26 @@
 package uk.ac.ebi.eva.accession.clustering.configuration.batch.io;
 
 import com.mongodb.MongoClient;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.boot.autoconfigure.mongo.MongoProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringMongoReader;
+import uk.ac.ebi.eva.accession.clustering.configuration.InputParametersConfiguration;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
 
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.MONGO_READER;
+
 @Configuration
-@Import({MongoConfiguration.class})
+@Import({MongoConfiguration.class, InputParametersConfiguration.class})
 public class ClusteringMongoReaderConfiguration {
 
-    @Bean
-    ClusteringMongoReader clusteringMongoReader(MongoClient mongoClient, MongoProperties mongoProperties,
+    @Bean(MONGO_READER)
+    @StepScope
+    public ClusteringMongoReader clusteringMongoReader(MongoClient mongoClient, MongoProperties mongoProperties,
                                                 MongoTemplate mongoTemplate, InputParameters parameters) {
         if (parameters.getAssemblyAccession() == null || parameters.getAssemblyAccession().isEmpty()) {
             throw new IllegalArgumentException("Please provide an assembly");

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/ClusteringWriterConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/ClusteringWriterConfiguration.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.ebi.eva.accession.clustering.configuration.batch.io;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -24,7 +23,6 @@ import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.ClusteredVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
-import uk.ac.ebi.eva.accession.core.service.ClusteredVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.service.nonhuman.eva.ClusteredVariantMonotonicAccessioningService;
 
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_WRITER;
@@ -33,15 +31,10 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTER
 @Import({ClusteredVariantAccessioningConfiguration.class, MongoConfiguration.class})
 public class ClusteringWriterConfiguration {
 
-    @Autowired
-    InputParameters inputParameters;
-
-    @Autowired
-    ClusteredVariantMonotonicAccessioningService clusteredVariantAccessioningService;
-
     @Bean(CLUSTERING_WRITER)
-    public ClusteringWriter submittedVariantWriter(MongoTemplate mongoTemplate) {
+    public ClusteringWriter clusteringWriter(MongoTemplate mongoTemplate, InputParameters inputParameters,
+                                             ClusteredVariantMonotonicAccessioningService accessioningService) {
         return new ClusteringWriter(inputParameters.getAssemblyAccession(), mongoTemplate,
-                                    clusteredVariantAccessioningService);
+                                    accessioningService);
     }
 }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromMongoJobConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromMongoJobConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_FROM_MONGO_JOB;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_FROM_MONGO_STEP;
+
+@Configuration
+@EnableBatchProcessing
+public class ClusteringFromMongoJobConfiguration {
+
+    private Step clusteringFromMongoStep;
+
+    public ClusteringFromMongoJobConfiguration(@Qualifier(CLUSTERING_FROM_MONGO_STEP)Step clusteringFromMongoStep) {
+        this.clusteringFromMongoStep = clusteringFromMongoStep;
+    }
+
+    @Bean(CLUSTERING_FROM_MONGO_JOB)
+    public Job ClusteringFromMongoJob(JobBuilderFactory jobBuilderFactory) {
+        return jobBuilderFactory.get(CLUSTERING_FROM_MONGO_JOB)
+                .incrementer(new RunIdIncrementer())
+                .start(clusteringFromMongoStep)
+                .build();
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromMongoJobConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromMongoJobConfiguration.java
@@ -20,7 +20,6 @@ import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,14 +31,9 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTER
 @EnableBatchProcessing
 public class ClusteringFromMongoJobConfiguration {
 
-    private Step clusteringFromMongoStep;
-
-    public ClusteringFromMongoJobConfiguration(@Qualifier(CLUSTERING_FROM_MONGO_STEP)Step clusteringFromMongoStep) {
-        this.clusteringFromMongoStep = clusteringFromMongoStep;
-    }
-
     @Bean(CLUSTERING_FROM_MONGO_JOB)
-    public Job ClusteringFromMongoJob(JobBuilderFactory jobBuilderFactory) {
+    public Job clusteringFromMongoJob(@Qualifier(CLUSTERING_FROM_MONGO_STEP) Step clusteringFromMongoStep,
+                                      JobBuilderFactory jobBuilderFactory) {
         return jobBuilderFactory.get(CLUSTERING_FROM_MONGO_JOB)
                 .incrementer(new RunIdIncrementer())
                 .start(clusteringFromMongoStep)

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromVcfJobConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromVcfJobConfiguration.java
@@ -20,7 +20,6 @@ import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,14 +31,9 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTER
 @EnableBatchProcessing
 public class ClusteringFromVcfJobConfiguration {
 
-    private Step clusteringStep;
-
-    public ClusteringFromVcfJobConfiguration( @Qualifier(CLUSTERING_FROM_VCF_STEP)Step clusteringStep) {
-        this.clusteringStep = clusteringStep;
-    }
-
     @Bean(CLUSTERING_FROM_VCF_JOB)
-    public Job ClusteringFromVcfJob(JobBuilderFactory jobBuilderFactory) {
+    public Job ClusteringFromVcfJob(@Qualifier(CLUSTERING_FROM_VCF_STEP) Step clusteringStep,
+                                    JobBuilderFactory jobBuilderFactory) {
         return jobBuilderFactory.get(CLUSTERING_FROM_VCF_JOB)
                 .incrementer(new RunIdIncrementer())
                 .start(clusteringStep)

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromVcfJobConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromVcfJobConfiguration.java
@@ -25,20 +25,22 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_JOB;
-import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_STEP;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_FROM_VCF_JOB;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_FROM_VCF_STEP;
 
 @Configuration
 @EnableBatchProcessing
-public class ClusteringVariantJobConfiguration {
+public class ClusteringFromVcfJobConfiguration {
 
-    @Autowired
-    @Qualifier(CLUSTERING_STEP)
-    public Step clusteringStep;
+    private Step clusteringStep;
 
-    @Bean(CLUSTERING_JOB)
-    public Job ClusteringVariantJobConfiguration(JobBuilderFactory jobBuilderFactory) {
-        return jobBuilderFactory.get(CLUSTERING_JOB)
+    public ClusteringFromVcfJobConfiguration( @Qualifier(CLUSTERING_FROM_VCF_STEP)Step clusteringStep) {
+        this.clusteringStep = clusteringStep;
+    }
+
+    @Bean(CLUSTERING_FROM_VCF_JOB)
+    public Job ClusteringFromVcfJob(JobBuilderFactory jobBuilderFactory) {
+        return jobBuilderFactory.get(CLUSTERING_FROM_VCF_JOB)
                 .incrementer(new RunIdIncrementer())
                 .start(clusteringStep)
                 .build();

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/processors/ClusteringVariantProcessorConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/processors/ClusteringVariantProcessorConfiguration.java
@@ -15,10 +15,8 @@
  */
 package uk.ac.ebi.eva.accession.clustering.configuration.batch.processors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
 import uk.ac.ebi.eva.accession.clustering.batch.processors.VariantToSubmittedVariantEntityProcessor;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 
@@ -27,11 +25,8 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.VARIANT
 @Configuration
 public class ClusteringVariantProcessorConfiguration {
 
-    @Autowired
-    InputParameters inputParameters;
-
     @Bean(VARIANT_TO_SUBMITTED_VARIANT_ENTITY_PROCESSOR)
-    public VariantToSubmittedVariantEntityProcessor variantToSubmittedVariantProcessor() {
+    public VariantToSubmittedVariantEntityProcessor variantToSubmittedVariantProcessor(InputParameters inputParameters) {
         return new VariantToSubmittedVariantEntityProcessor(inputParameters.getAssemblyAccession());
     }
 }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringFromMongoStepConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringFromMongoStepConfiguration.java
@@ -23,7 +23,6 @@ import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,20 +36,12 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.MONGO_R
 @EnableBatchProcessing
 public class ClusteringFromMongoStepConfiguration {
 
-    private ItemStreamReader<SubmittedVariantEntity> mongoReader;
-
-    private ItemWriter<SubmittedVariantEntity> submittedVariantWriter;
-
-    public ClusteringFromMongoStepConfiguration(
-            @Qualifier(MONGO_READER)ItemStreamReader<SubmittedVariantEntity> mongoReader,
-            @Qualifier(CLUSTERING_WRITER)ItemWriter<SubmittedVariantEntity> submittedVariantWriter) {
-        this.mongoReader = mongoReader;
-        this.submittedVariantWriter = submittedVariantWriter;
-    }
-
     @Bean(CLUSTERING_FROM_MONGO_STEP)
-    public Step clusteringVariantStepMongReader(StepBuilderFactory stepBuilderFactory,
-                                                SimpleCompletionPolicy chunkSizeCompletionPolicy) {
+    public Step clusteringVariantStepMongReader(
+            @Qualifier(MONGO_READER) ItemStreamReader<SubmittedVariantEntity> mongoReader,
+            @Qualifier(CLUSTERING_WRITER) ItemWriter<SubmittedVariantEntity> submittedVariantWriter,
+            StepBuilderFactory stepBuilderFactory,
+            SimpleCompletionPolicy chunkSizeCompletionPolicy) {
         TaskletStep step = stepBuilderFactory.get(CLUSTERING_FROM_MONGO_STEP)
                 .<SubmittedVariantEntity, SubmittedVariantEntity>chunk(chunkSizeCompletionPolicy)
                 .reader(mongoReader)

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringFromVcfStepConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringFromVcfStepConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.accession.clustering.configuration.batch.steps;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.step.tasklet.TaskletStep;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
+
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_FROM_VCF_STEP;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_WRITER;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.VARIANT_TO_SUBMITTED_VARIANT_ENTITY_PROCESSOR;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.VCF_READER;
+
+@Configuration
+@EnableBatchProcessing
+public class ClusteringFromVcfStepConfiguration {
+
+    private ItemReader<Variant> vcfReader;
+
+    private ItemProcessor<Variant, SubmittedVariantEntity> processor;
+
+    private ItemWriter<SubmittedVariantEntity> submittedVariantWriter;
+
+    public ClusteringFromVcfStepConfiguration(
+            @Qualifier(VCF_READER)ItemReader<Variant> vcfReader,
+            @Qualifier(VARIANT_TO_SUBMITTED_VARIANT_ENTITY_PROCESSOR)ItemProcessor<Variant, SubmittedVariantEntity> processor,
+            @Qualifier(CLUSTERING_WRITER)ItemWriter<SubmittedVariantEntity> submittedVariantWriter) {
+        this.vcfReader = vcfReader;
+        this.processor = processor;
+        this.submittedVariantWriter = submittedVariantWriter;
+    }
+
+    @Bean(CLUSTERING_FROM_VCF_STEP)
+    public Step clusteringVariantsStep(StepBuilderFactory stepBuilderFactory,
+                                       SimpleCompletionPolicy chunkSizeCompletionPolicy) {
+        TaskletStep step = stepBuilderFactory.get(CLUSTERING_FROM_VCF_STEP)
+                .<Variant, SubmittedVariantEntity>chunk(chunkSizeCompletionPolicy)
+                .reader(vcfReader)
+                .processor(processor)
+                .writer(submittedVariantWriter)
+                .build();
+        return step;
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringFromVcfStepConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringFromVcfStepConfiguration.java
@@ -39,24 +39,13 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.VCF_REA
 @EnableBatchProcessing
 public class ClusteringFromVcfStepConfiguration {
 
-    private ItemReader<Variant> vcfReader;
-
-    private ItemProcessor<Variant, SubmittedVariantEntity> processor;
-
-    private ItemWriter<SubmittedVariantEntity> submittedVariantWriter;
-
-    public ClusteringFromVcfStepConfiguration(
-            @Qualifier(VCF_READER)ItemReader<Variant> vcfReader,
-            @Qualifier(VARIANT_TO_SUBMITTED_VARIANT_ENTITY_PROCESSOR)ItemProcessor<Variant, SubmittedVariantEntity> processor,
-            @Qualifier(CLUSTERING_WRITER)ItemWriter<SubmittedVariantEntity> submittedVariantWriter) {
-        this.vcfReader = vcfReader;
-        this.processor = processor;
-        this.submittedVariantWriter = submittedVariantWriter;
-    }
-
     @Bean(CLUSTERING_FROM_VCF_STEP)
-    public Step clusteringVariantsStep(StepBuilderFactory stepBuilderFactory,
-                                       SimpleCompletionPolicy chunkSizeCompletionPolicy) {
+    public Step clusteringVariantsStep(
+            @Qualifier(VCF_READER) ItemReader<Variant> vcfReader,
+            @Qualifier(VARIANT_TO_SUBMITTED_VARIANT_ENTITY_PROCESSOR) ItemProcessor<Variant, SubmittedVariantEntity> processor,
+            @Qualifier(CLUSTERING_WRITER) ItemWriter<SubmittedVariantEntity> submittedVariantWriter,
+            StepBuilderFactory stepBuilderFactory,
+            SimpleCompletionPolicy chunkSizeCompletionPolicy) {
         TaskletStep step = stepBuilderFactory.get(CLUSTERING_FROM_VCF_STEP)
                 .<Variant, SubmittedVariantEntity>chunk(chunkSizeCompletionPolicy)
                 .reader(vcfReader)

--- a/eva-accession-clustering/src/main/resources/application.properties
+++ b/eva-accession-clustering/src/main/resources/application.properties
@@ -1,0 +1,29 @@
+spring.batch.job.names=
+
+accessioning.instanceId=
+accessioning.clustered.categoryId=rs
+accessioning.monotonic.rs.blockSize=100000
+accessioning.monotonic.rs.blockStartValue=3000000000
+accessioning.monotonic.rs.nextBlockInterval=1000000000
+
+parameters.vcf=
+parameters.projectAccession=
+parameters.assemblyAccession=
+parameters.chunkSize=
+
+spring.data.mongodb.database=
+spring.data.mongodb.host=
+spring.data.mongodb.port=
+spring.data.mongodb.username=
+spring.data.mongodb.password=
+spring.data.mongodb.authentication-database=
+mongodb.read-preference=
+
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=
+spring.datasource.username=
+spring.datasource.password=
+spring.datasource.tomcat.max-active=3
+
+# Only to set up the database!
+# spring.jpa.generate-ddl=true

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringMongoReaderTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringMongoReaderTest.java
@@ -92,8 +92,8 @@ public class ClusteringMongoReaderTest {
 
     @Test
     public void readNotClusteredSubmittedVariants() {
-        List<SubmittedVariantEntity> variants = readIntoList();
         assertEquals(6, mongoTemplate.getCollection(SUBMITTED_VARIANT_ENTITY).count());
+        List<SubmittedVariantEntity> variants = readIntoList();
         assertEquals(5, variants.size());
         assertFalse(variants.stream().anyMatch(x -> x.getId().equals(CLUSTERED_SUBMITTED_VARIANT_ID)));
         assertTrue(variants.stream().anyMatch(x -> x.getId().equals(NOT_CLUSTERED_SUBMITTED_VARIANT_ID)));

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringMongoReaderTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringMongoReaderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.io;
+
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbConfigurationBuilder;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
+import com.mongodb.MongoClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.ac.ebi.eva.accession.clustering.test.configuration.MongoTestConfiguration;
+import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
+import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(SpringRunner.class)
+@TestPropertySource("classpath:clustering-pipeline-test.properties")
+@UsingDataSet(locations = {"/test-data/submittedVariantEntityMongoReader.json"})
+@ContextConfiguration(classes = {MongoConfiguration.class, MongoTestConfiguration.class})
+public class ClusteringMongoReaderTest {
+
+    private static final String TEST_DB = "test-db";
+
+    private static final String ASSEMBLY = "GCA_000000001.1";
+
+    private static final int CHUNK_SIZE = 5;
+
+    private static final String SUBMITTED_VARIANT_ENTITY = "submittedVariantEntity";
+
+    private static final String CLUSTERED_SUBMITTED_VARIANT_ID = "4C1C9CE98428A4F0A6033237BA00C31E33B540D0";
+
+    private static final String NOT_CLUSTERED_SUBMITTED_VARIANT_ID = "0993FBC8C6D0A20D35B0A6DA755663B3C849676D";
+
+    private ClusteringMongoReader reader;
+
+    @Autowired
+    private MongoClient mongoClient;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    //Required by nosql-unit
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Rule
+    public MongoDbRule mongoDbRule = new FixSpringMongoDbRule(
+            MongoDbConfigurationBuilder.mongoDb().databaseName(TEST_DB).build());
+
+    @Before
+    public void setUp() throws Exception {
+        ExecutionContext executionContext = new ExecutionContext();
+        reader = new ClusteringMongoReader(mongoClient, TEST_DB, mongoTemplate, ASSEMBLY, CHUNK_SIZE);
+        reader.open(executionContext);
+    }
+
+    @After
+    public void tearDown() {
+        reader.close();
+        mongoClient.dropDatabase(TEST_DB);
+    }
+
+    @Test
+    public void readNotClusteredSubmittedVariants() {
+        List<SubmittedVariantEntity> variants = readIntoList();
+        assertEquals(6, mongoTemplate.getCollection(SUBMITTED_VARIANT_ENTITY).count());
+        assertEquals(5, variants.size());
+        assertFalse(variants.stream().anyMatch(x -> x.getId().equals(CLUSTERED_SUBMITTED_VARIANT_ID)));
+        assertTrue(variants.stream().anyMatch(x -> x.getId().equals(NOT_CLUSTERED_SUBMITTED_VARIANT_ID)));
+    }
+
+    private List<SubmittedVariantEntity> readIntoList() {
+        SubmittedVariantEntity variant;
+        List<SubmittedVariantEntity> variants = new ArrayList<>();
+        while ((variant = reader.read()) != null) {
+            variants.add(variant);
+        }
+        return variants;
+    }
+}

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/test/configuration/BatchTestConfiguration.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/test/configuration/BatchTestConfiguration.java
@@ -17,31 +17,46 @@
  */
 package uk.ac.ebi.eva.accession.clustering.test.configuration;
 
+import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.transaction.PlatformTransactionManager;
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.ClusteringMongoReaderConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.ClusteringWriterConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.VcfReaderConfiguration;
-import uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs.ClusteringVariantJobConfiguration;
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs.ClusteringFromMongoJobConfiguration;
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs.ClusteringFromVcfJobConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.policies.ChunkSizeCompletionPolicyConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.processors.ClusteringVariantProcessorConfiguration;
-import uk.ac.ebi.eva.accession.clustering.configuration.batch.steps.ClusteringVariantStepConfiguration;
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.steps.ClusteringFromMongoStepConfiguration;
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.steps.ClusteringFromVcfStepConfiguration;
 
 import javax.sql.DataSource;
 
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_FROM_MONGO_JOB;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_FROM_VCF_JOB;
+
 @EnableAutoConfiguration
-@Import({ClusteringVariantJobConfiguration.class,
-        ClusteringVariantStepConfiguration.class,
+@Import({ClusteringFromVcfJobConfiguration.class,
+        ClusteringFromMongoJobConfiguration.class,
+        ClusteringFromVcfStepConfiguration.class,
+        ClusteringFromMongoStepConfiguration.class,
         VcfReaderConfiguration.class,
+        ClusteringMongoReaderConfiguration.class,
         ClusteringVariantProcessorConfiguration.class,
         ClusteringWriterConfiguration.class,
         ChunkSizeCompletionPolicyConfiguration.class})
 public class BatchTestConfiguration {
+
+    public static final String JOB_LAUNCHER_FROM_VCF = "JOB_LAUNCHER_FROM_VCF";
+
+    public static final String JOB_LAUNCHER_FROM_MONGO = "JOB_LAUNCHER_FROM_MONGO";
 
     @Autowired
     private BatchProperties properties;
@@ -55,8 +70,27 @@ public class BatchTestConfiguration {
     @Autowired
     private PlatformTransactionManager platformTransactionManager;
 
-    @Bean
+    @Bean(JOB_LAUNCHER_FROM_VCF)
     public JobLauncherTestUtils jobLauncherTestUtils() {
-        return new JobLauncherTestUtils();
+
+        return new JobLauncherTestUtils() {
+            @Override
+            @Autowired
+            public void setJob(@Qualifier(CLUSTERING_FROM_VCF_JOB) Job job) {
+                super.setJob(job);
+            }
+        };
+    }
+
+    @Bean(JOB_LAUNCHER_FROM_MONGO)
+    public JobLauncherTestUtils jobLauncherTestUtilsFromMongo() {
+
+        return new JobLauncherTestUtils() {
+            @Override
+            @Autowired
+            public void setJob(@Qualifier(CLUSTERING_FROM_MONGO_JOB) Job job) {
+                super.setJob(job);
+            }
+        };
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/test/configuration/MongoTestConfiguration.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/test/configuration/MongoTestConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.test.configuration;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EntityScan(basePackages = {"uk.ac.ebi.eva.accession.core.persistence"})
+@EnableMongoRepositories(basePackages = {
+        "uk.ac.ebi.eva.accession.core.persistence",
+        "uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.repository"})
+@EnableMongoAuditing
+@AutoConfigureDataMongo
+public class MongoTestConfiguration {
+}

--- a/eva-accession-clustering/src/test/resources/test-data/submittedVariantEntityMongoReader.json
+++ b/eva-accession-clustering/src/test/resources/test-data/submittedVariantEntityMongoReader.json
@@ -1,0 +1,77 @@
+{
+  "submittedVariantEntity": [
+    {
+      "_id": "0993FBC8C6D0A20D35B0A6DA755663B3C849676D",
+      "seq": "GCA_000000001.1",
+      "tax": 1000,
+      "study": "",
+      "contig": "1",
+      "start": NumberLong(1000),
+      "ref": "T",
+      "alt": "A",
+      "accession": NumberLong(1),
+      "version": 1
+    },
+    {
+      "_id": "6EE63124DFD82B0C941E34B40A3342757174F77B",
+      "seq": "GCA_000000001.1",
+      "tax": 1000,
+      "study": "",
+      "contig": "1",
+      "start": NumberLong(1000),
+      "ref": "T",
+      "alt": "G",
+      "accession": NumberLong(2),
+      "version": 1
+    },
+    {
+      "_id": "F033E9F5E8E1B53321C6932DEF78136B22E058CC",
+      "seq": "GCA_000000001.1",
+      "tax": 1000,
+      "study": "",
+      "contig": "1",
+      "start": NumberLong(1000),
+      "ref": "",
+      "alt": "A",
+      "accession": NumberLong(3),
+      "version": 1
+    },
+    {
+      "_id": "08D31D2BD7F6A13CDEC0E0931A13DA1599CCA07E",
+      "seq": "GCA_000000001.1",
+      "tax": 1000,
+      "study": "",
+      "contig": "1",
+      "start": NumberLong(1000),
+      "ref": "T",
+      "alt": "",
+      "accession": NumberLong(4),
+      "version": 1
+    },
+    {
+      "_id": "4C1C9CE98428A4F0A6033237BA00C31E33B540DC",
+      "seq": "GCA_000000001.1",
+      "tax": 3000,
+      "study": "",
+      "contig": "1",
+      "start": NumberLong(3000),
+      "ref": "C",
+      "alt": "G",
+      "accession": NumberLong(5),
+      "version": 1
+    },
+    {
+      "_id": "4C1C9CE98428A4F0A6033237BA00C31E33B540D0",
+      "seq": "GCA_000000001.1",
+      "tax": 3000,
+      "study": "",
+      "contig": "2",
+      "start": NumberLong(3000),
+      "ref": "T",
+      "alt": "G",
+      "accession": NumberLong(5),
+      "version": 1,
+      "rs": NumberLong(1)
+    }
+  ]
+}


### PR DESCRIPTION
This PR includes:
- Mongo Reader implementation
- Configuration to have two different jobs: `CLUSTERING_FROM_VCF_JOB` and `CLUSTERING_FROM_MONGO_JOB` so the appropriate can be run depending on the data source 