### PR TITLE
EVA-1793 - Changes to support Spring Boot 2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ test:
     services:
         - mongo:3.2.17
     script:
+        # Gitlab exposes services under their own hostnames. So test host should be "mongo" instead of "localhost".
         - mvn clean test --projects 'eva-accession-core,eva-accession-ws' -Deva.mongo.host.test=mongo
     environment:
         name: test-env

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
@@ -16,7 +16,7 @@
 package uk.ac.ebi.eva.accession.clustering.batch.io;
 
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.data.mongodb.BulkOperationException;
+import com.mongodb.MongoBulkWriteException;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
@@ -83,7 +83,7 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
                 bulkOperations.updateOne(query, update);
             }
             bulkOperations.execute();
-        } catch (BulkOperationException e) {
+        } catch (MongoBulkWriteException e) {
             throw e;
         }
     }

--- a/eva-accession-clustering/src/main/resources/application.properties
+++ b/eva-accession-clustering/src/main/resources/application.properties
@@ -27,3 +27,6 @@ spring.datasource.tomcat.max-active=3
 
 # Only to set up the database!
 # spring.jpa.generate-ddl=true
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriterTest.java
@@ -18,9 +18,9 @@ package uk.ac.ebi.eva.accession.clustering.batch.io;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.mongodb.MongoDbConfigurationBuilder;
 import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -150,8 +150,8 @@ public class ClusteringWriterTest {
     }
 
     private void assertClusteredVariantsCreated() {
-        DBCollection collection = mongoTemplate.getCollection(CLUSTERED_VARIANT_COLLECTION);
-        assertEquals(4, collection.count());
+        MongoCollection<Document> collection = mongoTemplate.getCollection(CLUSTERED_VARIANT_COLLECTION);
+        assertEquals(4, collection.countDocuments());
         List<Long> expectedAccessions = Arrays.asList(3000000000L, 3000000001L, 3000000002L, 3000000003L);
         assertGeneratedAccessions(CLUSTERED_VARIANT_COLLECTION, "accession", expectedAccessions);
     }
@@ -159,10 +159,10 @@ public class ClusteringWriterTest {
     private void assertGeneratedAccessions(String collectionName, String accessionField,
                                            List<Long> expectedAccessions) {
         List<Long> generatedAccessions = new ArrayList<>();
-        DBCollection collection = mongoTemplate.getCollection(collectionName);
-        DBCursor dbObjects = collection.find();
-        for (DBObject dbObject : dbObjects) {
-            Long accessionId = (Long) dbObject.get(accessionField);
+        MongoCollection<Document> collection = mongoTemplate.getCollection(collectionName);
+        FindIterable<Document> dbObjects = collection.find();
+        for (Document document : dbObjects) {
+            Long accessionId = (Long) document.get(accessionField);
             generatedAccessions.add(accessionId);
         }
         Collections.sort(generatedAccessions);
@@ -176,10 +176,10 @@ public class ClusteringWriterTest {
     }
 
     private boolean allSubmittedVariantsClustered() {
-        DBCollection collection = mongoTemplate.getCollection(SUBMITTED_VARIANT_COLLECTION);
-        DBCursor dbObjects = collection.find();
-        for (DBObject dbObject : dbObjects) {
-            if (dbObject.get("rs") == null){
+        MongoCollection<Document> collection = mongoTemplate.getCollection(SUBMITTED_VARIANT_COLLECTION);
+        FindIterable<Document> documents = collection.find();
+        for (Document document : documents) {
+            if (document.get("rs") == null){
                 return false;
             }
         }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringVariantStepConfigurationTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringVariantStepConfigurationTest.java
@@ -18,9 +18,9 @@ package uk.ac.ebi.eva.accession.clustering.configuration.batch.steps;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.mongodb.MongoDbConfigurationBuilder;
 import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -117,10 +117,10 @@ public class ClusteringVariantStepConfigurationTest {
     }
 
     private boolean allSubmittedVariantsNotClustered() {
-        DBCollection collection = mongoTemplate.getCollection(SUBMITTED_VARIANT_COLLECTION);
-        DBCursor dbObjects = collection.find();
-        for (DBObject dbObject : dbObjects) {
-            if (dbObject.get("rs") != null){
+        MongoCollection<Document> collection = mongoTemplate.getCollection(SUBMITTED_VARIANT_COLLECTION);
+        FindIterable<Document> documents = collection.find();
+        for (Document document : documents) {
+            if (document.get("rs") != null){
                 return false;
             }
         }
@@ -128,8 +128,8 @@ public class ClusteringVariantStepConfigurationTest {
     }
 
     private void assertClusteredVariantsCreated() {
-        DBCollection collection = mongoTemplate.getCollection(CLUSTERED_VARIANT_COLLECTION);
-        assertEquals(4, collection.count());
+        MongoCollection<Document> collection = mongoTemplate.getCollection(CLUSTERED_VARIANT_COLLECTION);
+        assertEquals(4, collection.countDocuments());
         List<Long> expectedAccessions = Arrays.asList(3000000000L, 3000000001L, 3000000002L, 3000000003L);
         assertGeneratedAccessions(CLUSTERED_VARIANT_COLLECTION, "accession", expectedAccessions);
     }
@@ -137,10 +137,10 @@ public class ClusteringVariantStepConfigurationTest {
     private void assertGeneratedAccessions(String collectionName, String accessionField,
                                            List<Long> expectedAccessions) {
         List<Long> generatedAccessions = new ArrayList<>();
-        DBCollection collection = mongoTemplate.getCollection(collectionName);
-        DBCursor dbObjects = collection.find();
-        for (DBObject dbObject : dbObjects) {
-            Long accessionId = (Long) dbObject.get(accessionField);
+        MongoCollection<Document> collection = mongoTemplate.getCollection(collectionName);
+        FindIterable<Document> documents = collection.find();
+        for (Document document : documents) {
+            Long accessionId = (Long) document.get(accessionField);
             generatedAccessions.add(accessionId);
         }
         Collections.sort(generatedAccessions);
@@ -154,10 +154,10 @@ public class ClusteringVariantStepConfigurationTest {
     }
 
     private boolean allSubmittedVariantsClustered() {
-        DBCollection collection = mongoTemplate.getCollection(SUBMITTED_VARIANT_COLLECTION);
-        DBCursor dbObjects = collection.find();
-        for (DBObject dbObject : dbObjects) {
-            if (dbObject.get("rs") == null){
+        MongoCollection<Document> collection = mongoTemplate.getCollection(SUBMITTED_VARIANT_COLLECTION);
+        FindIterable<Document> documents = collection.find();
+        for (Document document : documents) {
+            if (document.get("rs") == null){
                 return false;
             }
         }

--- a/eva-accession-clustering/src/test/resources/clustering-pipeline-test.properties
+++ b/eva-accession-clustering/src/test/resources/clustering-pipeline-test.properties
@@ -14,3 +14,6 @@ spring.data.mongodb.host=localhost
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/batch/io/DbsnpClusteredVariantOperationWriter.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/batch/io/DbsnpClusteredVariantOperationWriter.java
@@ -18,9 +18,10 @@
 
 package uk.ac.ebi.eva.accession.core.batch.io;
 
-import com.mongodb.BulkWriteResult;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.bulk.BulkWriteResult;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.data.mongodb.BulkOperationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
@@ -49,10 +50,11 @@ public class DbsnpClusteredVariantOperationWriter implements ItemWriter<DbsnpClu
             bulkOperations.insert(importedClusteredVariantsOperations);
             bulkOperations.execute();
             importCounts.addOperationsWritten(importedClusteredVariantsOperations.size());
-        } catch (BulkOperationException e) {
-            BulkWriteResult bulkWriteResult = e.getResult();
+        } catch (DuplicateKeyException exception) {
+            MongoBulkWriteException writeException = ((MongoBulkWriteException) exception.getCause());
+            BulkWriteResult bulkWriteResult = writeException.getWriteResult();
             importCounts.addOperationsWritten(bulkWriteResult.getInsertedCount());
-            throw e;
+            throw exception;
         }
     }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/batch/io/DbsnpClusteredVariantWriter.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/batch/io/DbsnpClusteredVariantWriter.java
@@ -15,9 +15,10 @@
  */
 package uk.ac.ebi.eva.accession.core.batch.io;
 
-import com.mongodb.BulkWriteResult;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.bulk.BulkWriteResult;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.data.mongodb.BulkOperationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantEntity;
@@ -44,10 +45,10 @@ public class DbsnpClusteredVariantWriter implements ItemWriter<DbsnpClusteredVar
             bulkOperations.insert(importedClusteredVariants);
             bulkOperations.execute();
             importCounts.addClusteredVariantsWritten(importedClusteredVariants.size());
-        } catch (BulkOperationException e) {
-            BulkWriteResult bulkWriteResult = e.getResult();
+        } catch (DuplicateKeyException exception) {
+            BulkWriteResult bulkWriteResult = ((MongoBulkWriteException) exception.getCause()).getWriteResult();
             importCounts.addClusteredVariantsWritten(bulkWriteResult.getInsertedCount());
-            throw e;
+            throw exception;
         }
     }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/human/HumanMongoConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/human/HumanMongoConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.mongo.MongoClientFactory;
 import org.springframework.boot.autoconfigure.mongo.MongoProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -75,7 +76,7 @@ public class HumanMongoConfiguration {
         mongoClientOptions = mongoClientOptionsBuilder.readPreference(ReadPreference.valueOf(readPreference))
                                                       .writeConcern(WriteConcern.MAJORITY)
                                                       .build();
-        return properties.createMongoClient(mongoClientOptions, environment);
+        return new MongoClientFactory(properties, environment).createMongoClient(mongoClientOptions);
     }
 
     @Bean("humanFactory")

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/nonhuman/MongoConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/nonhuman/MongoConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.mongo.MongoClientFactory;
 import org.springframework.boot.autoconfigure.mongo.MongoProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -70,7 +71,7 @@ public class MongoConfiguration {
         mongoClientOptions = mongoClientOptionsBuilder.readPreference(ReadPreference.valueOf(readPreference))
                                                       .writeConcern(WriteConcern.MAJORITY)
                                                       .build();
-        return properties.createMongoClient(mongoClientOptions, environment);
+        return new MongoClientFactory(properties, environment).createMongoClient(mongoClientOptions);
     }
 
     @Bean("primaryFactory")

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/exceptions/MongoBulkWriteExceptionUtils.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/exceptions/MongoBulkWriteExceptionUtils.java
@@ -15,18 +15,18 @@
  */
 package uk.ac.ebi.eva.accession.core.exceptions;
 
-import com.mongodb.BulkWriteError;
 import com.mongodb.ErrorCategory;
-import org.springframework.data.mongodb.BulkOperationException;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.bulk.BulkWriteError;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
- * Common utility class to assist in handling Mongo DB BulkOperationException
+ * Common utility class to assist in handling Mongo DB MongoBulkWriteException
  */
-public class BulkOperationExceptionUtils {
+public class MongoBulkWriteExceptionUtils {
 
     private static final String DUPLICATE_KEY_ERROR_MESSAGE_GROUP_NAME = "IDKEY";
 
@@ -35,10 +35,10 @@ public class BulkOperationExceptionUtils {
 
     private static final Pattern DUPLICATE_KEY_PATTERN = Pattern.compile(DUPLICATE_KEY_ERROR_MESSAGE_REGEX);
 
-    public static Stream<String> extractUniqueHashesForDuplicateKeyError(BulkOperationException exception) {
-        return exception.getErrors()
+    public static Stream<String> extractUniqueHashesForDuplicateKeyError(MongoBulkWriteException exception) {
+        return exception.getWriteErrors()
                         .stream()
-                        .filter(BulkOperationExceptionUtils::isDuplicateKeyError)
+                        .filter(MongoBulkWriteExceptionUtils::isDuplicateKeyError)
                         .map(error -> {
                             Matcher matcher = DUPLICATE_KEY_PATTERN.matcher(error.getMessage());
                             if (matcher.find()) {

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/repository/nonhuman/eva/SubmittedVariantAccessioningRepositoryImpl.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/repository/nonhuman/eva/SubmittedVariantAccessioningRepositoryImpl.java
@@ -40,8 +40,10 @@ public class SubmittedVariantAccessioningRepositoryImpl
         mongoOperations = mongoTemplate;
     }
 
-    List<AccessionProjection<Long>> findByAccessionGreaterThanEqualAndAccessionLessThanEqual(Long start, Long end) {
-        return mongoOperations.find(Query.query(Criteria.where("accession").gte(start).lte(end)),
+    public List<AccessionProjection<Long>> findByAccessionGreaterThanEqualAndAccessionLessThanEqual(Long start, Long end) {
+        Criteria criteria = new Criteria();
+        return mongoOperations.find(Query.query(criteria.andOperator(Criteria.where("accession").gte(start),
+                                                                     Criteria.where("accession").lte(end))),
                                     SubmittedVariantEntity.class)
                               .stream()
                               .map(AccessionedDocument::getAccession)

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/batch/io/DbsnpClusteredVariantWriterTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/batch/io/DbsnpClusteredVariantWriterTest.java
@@ -43,6 +43,7 @@ import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static uk.ac.ebi.eva.commons.core.models.VariantType.INDEL;
@@ -132,9 +133,10 @@ public class DbsnpClusteredVariantWriterTest {
         assertEquals(CREATED_DATE, storedVariants.get(0).getModel().getCreatedDate());
     }
 
-    @Test(expected = DuplicateKeyException.class)
+    @Test
     public void exceptionThrownOnDuplicateIdenticalVariant() {
-        dbsnpClusteredVariantWriter.write(Arrays.asList(variantEntity1, variantEntity1));
+        assertThrows(DuplicateKeyException.class, () ->
+                dbsnpClusteredVariantWriter.write(Arrays.asList(variantEntity1, variantEntity1)));
     }
 
     @Test

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/batch/io/DbsnpClusteredVariantWriterTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/batch/io/DbsnpClusteredVariantWriterTest.java
@@ -16,12 +16,10 @@
 package uk.ac.ebi.eva.accession.core.batch.io;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.BulkOperationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ContextConfiguration;
@@ -70,9 +68,6 @@ public class DbsnpClusteredVariantWriterTest {
     private static final String CONTIG = "contig";
 
     private static final LocalDateTime CREATED_DATE = LocalDateTime.of(2018, Month.SEPTEMBER, 18, 9, 0);
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private DbsnpClusteredVariantWriter dbsnpClusteredVariantWriter;
 
@@ -137,7 +132,7 @@ public class DbsnpClusteredVariantWriterTest {
         assertEquals(CREATED_DATE, storedVariants.get(0).getModel().getCreatedDate());
     }
 
-    @Test(expected = BulkOperationException.class)
+    @Test(expected = DuplicateKeyException.class)
     public void exceptionThrownOnDuplicateIdenticalVariant() {
         dbsnpClusteredVariantWriter.write(Arrays.asList(variantEntity1, variantEntity1));
     }

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/repository/nonhuman/eva/SubmittedVariantAccessioningRepositoryTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/repository/nonhuman/eva/SubmittedVariantAccessioningRepositoryTest.java
@@ -99,7 +99,7 @@ public class SubmittedVariantAccessioningRepositoryTest {
                 new SubmittedVariantEntity(firstAccession, "hash-1", submittedVariant, 1),
                 new SubmittedVariantEntity(secondAccession, "hash-2", newSubmittedVariant, 1));
 
-        repository.save(variants);
+        repository.saveAll(variants);
 
         assertAccessionsEquals(Arrays.asList(firstAccession),
                                repository.findByAccessionGreaterThanEqualAndAccessionLessThanEqual(1000L, 1000L));

--- a/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/service/nonhuman/SubmittedVariantAccessioningServiceTest.java
+++ b/eva-accession-core/src/test/java/uk/ac/ebi/eva/accession/core/service/nonhuman/SubmittedVariantAccessioningServiceTest.java
@@ -19,7 +19,8 @@ import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.MongoDbConfigurationBuilder;
 import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
-import com.mongodb.DBObject;
+import com.mongodb.client.MongoCursor;
+import org.bson.Document;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,6 +58,7 @@ import uk.ac.ebi.eva.accession.core.test.rule.FixSpringMongoDbRule;
 
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -438,11 +440,13 @@ public class SubmittedVariantAccessioningServiceTest {
 
         service.getOrCreate(Collections.singletonList(submittedVariant));
 
-        List<DBObject> submittedVariantEntities = mongoDbFactory.getDb()
-                                                                .getCollection("submittedVariantEntity")
-                                                                .find()
-                                                                .toArray();
-        assertEquals(1, submittedVariantEntities.size());
+
+        List<Document> submittedVariantEntities  = new ArrayList<>();
+        MongoCursor<Document> submittedVariantEntitiesCursor = mongoDbFactory.getDb()
+                                                                             .getCollection("submittedVariantEntity")
+                                                                             .find().iterator();
+
+        submittedVariantEntitiesCursor.forEachRemaining(submittedVariantEntities::add);
         assertEquals(NOT_DEFAULT_SUPPORTED_BY_EVIDENCE, submittedVariantEntities.get(0).get("evidence"));
         assertEquals(null, submittedVariantEntities.get(0).get("asmMatch"));
         assertEquals(null, submittedVariantEntities.get(0).get("allelesMatch"));

--- a/eva-accession-core/src/test/resources/properties/rs-accession-test.properties
+++ b/eva-accession-core/src/test/resources/properties/rs-accession-test.properties
@@ -10,3 +10,6 @@ spring.data.mongodb.host=|eva.mongo.host.test|
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-core/src/test/resources/properties/ss-accession-test.properties
+++ b/eva-accession-core/src/test/resources/properties/ss-accession-test.properties
@@ -10,12 +10,14 @@ accessioning.monotonic.test-rs.blockStartValue=3000000000
 accessioning.monotonic.test-rs.nextBlockInterval=1000000000
 
 spring.data.mongodb.database=submitted-variants-test
-spring.data.mongodb.host=|eva.mongo.host.test|
+spring.data.mongodb.host=localhost
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true
 
 human.mongodb.database=human-variants-test
-human.mongodb.host=|eva.mongo.host.test|
+human.mongodb.host=localhost
 human.mongodb.password=
 human.mongodb.port=27017
 

--- a/eva-accession-core/src/test/resources/properties/ss-accession-test.properties
+++ b/eva-accession-core/src/test/resources/properties/ss-accession-test.properties
@@ -10,14 +10,18 @@ accessioning.monotonic.test-rs.blockStartValue=3000000000
 accessioning.monotonic.test-rs.nextBlockInterval=1000000000
 
 spring.data.mongodb.database=submitted-variants-test
-spring.data.mongodb.host=localhost
+# This symbolic variable is required because
+# this will be replaced with a default value "localhost" when run locally
+# (due to the filtering attribute specified in this project's POM)
+# (OR) this variable can be overridden in Gitlab with "mongo" (Gitlab services are exposed under their own hostname)
+spring.data.mongodb.host=|eva.mongo.host.test|
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
 # See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
 spring.main.allow-bean-definition-overriding=true
 
 human.mongodb.database=human-variants-test
-human.mongodb.host=localhost
+human.mongodb.host=|eva.mongo.host.test|
 human.mongodb.password=
 human.mongodb.port=27017
 

--- a/eva-accession-core/src/test/resources/properties/test-variants-writer.properties
+++ b/eva-accession-core/src/test/resources/properties/test-variants-writer.properties
@@ -11,3 +11,6 @@ spring.data.mongodb.password=
 spring.data.mongodb.port=27017
 
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-deprecate/src/main/resources/application.properties
+++ b/eva-accession-deprecate/src/main/resources/application.properties
@@ -26,5 +26,7 @@ spring.data.mongodb.authentication-database=admin
 mongodb.read-preference=|eva.mongo.read-preference|
 
 spring.main.web-environment=false
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true
 
 logging.level.uk.ac.ebi.eva.accession.dbsnp=INFO

--- a/eva-accession-deprecate/src/test/resources/application.properties
+++ b/eva-accession-deprecate/src/test/resources/application.properties
@@ -3,3 +3,6 @@ mongodb.read-preference=primary
 
 parameters.chunk-size=10
 parameters.deprecateAll=true
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-deprecate/src/test/resources/application_species_subset.properties
+++ b/eva-accession-deprecate/src/test/resources/application_species_subset.properties
@@ -5,3 +5,6 @@ mongodb.read-preference=primary
 parameters.chunk-size=10
 parameters.assemblyAccession=GCA_000000001.1,GCA_000000003.1
 parameters.deprecateAll=false
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/batch/io/DbsnpJsonClusteredVariantsWriter.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/batch/io/DbsnpJsonClusteredVariantsWriter.java
@@ -15,10 +15,11 @@
  */
 package uk.ac.ebi.eva.accession.dbsnp2.batch.io;
 
+import com.mongodb.MongoBulkWriteException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.data.mongodb.BulkOperationException;
+import org.springframework.dao.DuplicateKeyException;
 import uk.ac.ebi.ampt2d.commons.accession.core.models.EventType;
 
 import uk.ac.ebi.eva.accession.core.batch.io.DbsnpClusteredVariantWriter;
@@ -68,10 +69,11 @@ public class DbsnpJsonClusteredVariantsWriter implements ItemWriter<DbsnpCluster
             else {
                 logger.warn("Could not find any clustered variants to write in the current chunk!");
             }
-        } catch (BulkOperationException exception) {
+        } catch (DuplicateKeyException exception) {
+            MongoBulkWriteException writeException = ((MongoBulkWriteException) exception.getCause());
             List<DbsnpClusteredVariantOperationEntity> mergeClusteredOperations =
                     clusteredOperationBuilder.buildMergeOperationsFromException(
-                            (List<DbsnpClusteredVariantEntity>) clusteredVariants, exception);
+                            (List<DbsnpClusteredVariantEntity>) clusteredVariants, writeException);
             if (!mergeClusteredOperations.isEmpty()) {
                 dbsnpClusteredVariantOperationWriter.write(mergeClusteredOperations);
             }

--- a/eva-accession-import-dbsnp2/src/main/resources/application.properties
+++ b/eva-accession-import-dbsnp2/src/main/resources/application.properties
@@ -20,3 +20,6 @@ spring.data.mongodb.password=
 spring.data.mongodb.database=
 
 mongodb.read-preference=primaryPreferred
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-import-dbsnp2/src/test/resources/application.properties
+++ b/eva-accession-import-dbsnp2/src/test/resources/application.properties
@@ -25,3 +25,6 @@ dbsnp.datasource.username=SA
 dbsnp.datasource.password=
 dbsnp.datasource.schema=../eva-accession-core/src/test/resources/test-data/dbsnp-mirror-schema.sql
 dbsnp.datasource.data=../eva-accession-core/src/test/resources/test-data/dbsnp-mirror-data.sql
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/batch/io/DbsnpSubmittedVariantOperationWriter.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/batch/io/DbsnpSubmittedVariantOperationWriter.java
@@ -18,9 +18,10 @@
 
 package uk.ac.ebi.eva.accession.dbsnp.batch.io;
 
-import com.mongodb.BulkWriteResult;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.bulk.BulkWriteResult;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.data.mongodb.BulkOperationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
@@ -49,10 +50,11 @@ public class DbsnpSubmittedVariantOperationWriter implements ItemWriter<DbsnpSub
             bulkOperations.insert(importedSubmittedVariantsOperations);
             bulkOperations.execute();
             importCounts.addOperationsWritten(importedSubmittedVariantsOperations.size());
-        } catch (BulkOperationException e) {
-            BulkWriteResult bulkWriteResult = e.getResult();
+        } catch (DuplicateKeyException exception) {
+            MongoBulkWriteException writeException = ((MongoBulkWriteException) exception.getCause());
+            BulkWriteResult bulkWriteResult = writeException.getWriteResult();
             importCounts.addOperationsWritten(bulkWriteResult.getInsertedCount());
-            throw e;
+            throw exception;
         }
     }
 }

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/batch/io/DbsnpSubmittedVariantWriter.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/batch/io/DbsnpSubmittedVariantWriter.java
@@ -15,9 +15,10 @@
  */
 package uk.ac.ebi.eva.accession.dbsnp.batch.io;
 
-import com.mongodb.BulkWriteResult;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.bulk.BulkWriteResult;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.data.mongodb.BulkOperationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
@@ -45,10 +46,11 @@ public class DbsnpSubmittedVariantWriter implements ItemWriter<DbsnpSubmittedVar
             bulkOperations.insert(importedSubmittedVariants);
             bulkOperations.execute();
             importCounts.addSubmittedVariantsWritten(importedSubmittedVariants.size());
-        } catch (BulkOperationException e) {
-            BulkWriteResult bulkWriteResult = e.getResult();
+        } catch (DuplicateKeyException exception) {
+            MongoBulkWriteException writeException = ((MongoBulkWriteException) exception.getCause());
+            BulkWriteResult bulkWriteResult = writeException.getWriteResult();
             importCounts.addSubmittedVariantsWritten(bulkWriteResult.getInsertedCount());
-            throw e;
+            throw exception;
         }
     }
 

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/runner/DbsnpImportVariantsJobLauncherCommandLineRunner.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/runner/DbsnpImportVariantsJobLauncherCommandLineRunner.java
@@ -17,13 +17,19 @@ package uk.ac.ebi.eva.accession.dbsnp.runner;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Entity;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.JobParametersInvalidException;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.JobParametersNotFoundException;
+import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRepository;
@@ -45,6 +51,8 @@ import uk.ac.ebi.eva.commons.batch.job.JobExecutionApplicationListener;
 import uk.ac.ebi.eva.commons.batch.job.JobStatusManager;
 
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 
 @Component
 public class DbsnpImportVariantsJobLauncherCommandLineRunner extends JobLauncherCommandLineRunner implements
@@ -58,12 +66,16 @@ public class DbsnpImportVariantsJobLauncherCommandLineRunner extends JobLauncher
 
     public static final int EXIT_WITH_ERRORS = 1;
 
+    private final JobExplorer jobExplorer;
+
     @Value("${" + SPRING_BATCH_JOB_NAME_PROPERTY + ":#{null}}")
     private String jobName;
 
     private Collection<Job> jobs;
 
     private JobRepository jobRepository;
+
+    private String RUN_ID_PARAMETER_NAME = "run.id";
 
     @Autowired
     private JobExecutionApplicationListener jobExecutionApplicationListener;
@@ -75,7 +87,8 @@ public class DbsnpImportVariantsJobLauncherCommandLineRunner extends JobLauncher
 
     public DbsnpImportVariantsJobLauncherCommandLineRunner(JobLauncher jobLauncher, JobExplorer jobExplorer,
                                                            JobRepository jobRepository) {
-        super(jobLauncher, jobExplorer);
+        super(jobLauncher, jobExplorer, jobRepository);
+        this.jobExplorer = jobExplorer;
         this.jobRepository = jobRepository;
     }
 
@@ -107,11 +120,13 @@ public class DbsnpImportVariantsJobLauncherCommandLineRunner extends JobLauncher
 
             // TODO: different jobs can have different parameters
             JobParameters jobParameters = inputParameters.toJobParameters();
-
             JobStatusManager.checkIfJobNameHasBeenDefined(jobName);
             JobStatusManager.checkIfPropertiesHaveBeenProvided(jobParameters);
             if (inputParameters.isForceRestart()) {
                 markPreviousJobAsFailed(jobParameters);
+            }
+            else {
+                jobParameters = addRunIDToJobParameters(jobParameters);
             }
             launchJob(jobParameters);
         } catch (NoJobToExecuteException | NoParametersHaveBeenPassedException | NoPreviousJobExecutionException
@@ -123,10 +138,47 @@ public class DbsnpImportVariantsJobLauncherCommandLineRunner extends JobLauncher
 
     }
 
+    private JobParameters addRunIDToJobParameters(JobParameters jobParameters) {
+        JobExecution lastJobExecution = getLastJobExecution();
+        if (lastJobExecution != null) {
+            Long runIdParameterFromLastExecution = lastJobExecution.getJobParameters()
+                                                                           .getLong(RUN_ID_PARAMETER_NAME);
+            if (runIdParameterFromLastExecution != 0 && lastJobExecution.getStatus() == BatchStatus.FAILED) {
+                // Spring Batch 4 uses all job parameters (including run.id) to detect previous instances of a job - see https://github.com/spring-projects/spring-boot/blob/86fb39d5c5f474fe3544159270d4c4e2d01d43ef/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java#L222
+                // as opposed to Spring 3 which uses only job name - see https://github.com/spring-projects/spring-boot/blob/541890f0e003a6e346f2234102c97105ab1292ee/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java#L131
+                // Therefore, run.id needs to be supplied for failed jobs in order for the job to be detected and resumed - see https://stackoverflow.com/a/59198742/2601814
+                return new JobParametersBuilder(jobParameters)
+                        .addLong(RUN_ID_PARAMETER_NAME, runIdParameterFromLastExecution).toJobParameters();
+            }
+        }
+
+        return jobParameters;
+    }
+
+    private JobExecution getLastJobExecution () {
+        int previousJobInstanceCount = getPreviousJobInstanceCount();
+        List<JobInstance> jobInstanceList = jobExplorer.getJobInstances(jobName, 0, previousJobInstanceCount);
+        if (!jobInstanceList.isEmpty()) {
+            return jobExplorer.getJobExecutions(jobInstanceList.get(0)).stream()
+                              .max(Comparator.comparingLong(Entity::getId)).get();
+        }
+        return null;
+    }
+    
+    private int getPreviousJobInstanceCount() {
+        try {
+            return jobExplorer.getJobInstanceCount(jobName);
+        }
+        catch (NoSuchJobException ex) {
+            return 0;
+        }        
+    }
+
     private void launchJob(JobParameters jobParameters) throws JobExecutionException, UnknownJobException {
         for (Job job : this.jobs) {
             // TODO is PatternMatchUtils necessary because the jobs discovered by Spring include package name? if not, remove it
             if (PatternMatchUtils.simpleMatch(jobName, job.getName())) {
+
                 execute(job, jobParameters);
                 return;
             }

--- a/eva-accession-import/src/main/resources/application.properties
+++ b/eva-accession-import/src/main/resources/application.properties
@@ -36,3 +36,5 @@ spring.data.mongodb.authentication-database=admin
 mongodb.read-preference=primaryPreferred
 
 spring.main.web-environment=false
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/batch/io/DbsnpSubmittedVariantWriterTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/batch/io/DbsnpSubmittedVariantWriterTest.java
@@ -16,9 +16,7 @@
 package uk.ac.ebi.eva.accession.dbsnp.batch.io;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -45,6 +43,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(SpringRunner.class)
 @EnableAutoConfiguration
@@ -79,9 +78,6 @@ public class DbsnpSubmittedVariantWriterTest {
     private MongoTemplate mongoTemplate;
 
     private Function<ISubmittedVariant, String> hashingFunction;
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private ImportCounts importCounts;
 
@@ -130,9 +126,9 @@ public class DbsnpSubmittedVariantWriterTest {
         DbsnpSubmittedVariantEntity secondVariant = new DbsnpSubmittedVariantEntity(
                 EXPECTED_ACCESSION_2, hashingFunction.apply(submittedVariant2), submittedVariant2, 1);
 
-        thrown.expect(DuplicateKeyException.class);
         try {
-            dbsnpSubmittedVariantWriter.write(Arrays.asList(firstVariant, secondVariant));
+            assertThrows(DuplicateKeyException.class, () ->
+                    dbsnpSubmittedVariantWriter.write(Arrays.asList(firstVariant, secondVariant)));
         } finally {
             assertEquals(1, importCounts.getSubmittedVariantsWritten());
         }
@@ -147,9 +143,9 @@ public class DbsnpSubmittedVariantWriterTest {
         DbsnpSubmittedVariantEntity variant = new DbsnpSubmittedVariantEntity(
                 EXPECTED_ACCESSION, hashingFunction.apply(submittedVariant), submittedVariant, 1);
 
-        thrown.expect(DuplicateKeyException.class);
         try {
-            dbsnpSubmittedVariantWriter.write(Arrays.asList(variant, variant));
+            assertThrows(DuplicateKeyException.class, () ->
+                    dbsnpSubmittedVariantWriter.write(Arrays.asList(variant, variant)));
         } finally {
             assertEquals(1, importCounts.getSubmittedVariantsWritten());
         }

--- a/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/batch/io/DbsnpSubmittedVariantWriterTest.java
+++ b/eva-accession-import/src/test/java/uk/ac/ebi/eva/accession/dbsnp/batch/io/DbsnpSubmittedVariantWriterTest.java
@@ -22,7 +22,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.data.mongodb.BulkOperationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ContextConfiguration;
@@ -130,7 +130,7 @@ public class DbsnpSubmittedVariantWriterTest {
         DbsnpSubmittedVariantEntity secondVariant = new DbsnpSubmittedVariantEntity(
                 EXPECTED_ACCESSION_2, hashingFunction.apply(submittedVariant2), submittedVariant2, 1);
 
-        thrown.expect(BulkOperationException.class);
+        thrown.expect(DuplicateKeyException.class);
         try {
             dbsnpSubmittedVariantWriter.write(Arrays.asList(firstVariant, secondVariant));
         } finally {
@@ -147,7 +147,7 @@ public class DbsnpSubmittedVariantWriterTest {
         DbsnpSubmittedVariantEntity variant = new DbsnpSubmittedVariantEntity(
                 EXPECTED_ACCESSION, hashingFunction.apply(submittedVariant), submittedVariant, 1);
 
-        thrown.expect(BulkOperationException.class);
+        thrown.expect(DuplicateKeyException.class);
         try {
             dbsnpSubmittedVariantWriter.write(Arrays.asList(variant, variant));
         } finally {

--- a/eva-accession-import/src/test/resources/application.properties
+++ b/eva-accession-import/src/test/resources/application.properties
@@ -20,3 +20,6 @@ spring.data.mongodb.database=test
 spring.data.mongodb.host=localhost
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-import/src/test/resources/contig-test.properties
+++ b/eva-accession-import/src/test/resources/contig-test.properties
@@ -15,3 +15,6 @@ parameters.chunkSize=100
 parameters.pageSize=100
 
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-import/src/test/resources/test-project-accession-mapping.properties
+++ b/eva-accession-import/src/test/resources/test-project-accession-mapping.properties
@@ -20,3 +20,6 @@ spring.data.mongodb.password=
 spring.data.mongodb.port=27017
 
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-import/src/test/resources/test-variants-writer.properties
+++ b/eva-accession-import/src/test/resources/test-variants-writer.properties
@@ -11,3 +11,6 @@ spring.data.mongodb.password=
 spring.data.mongodb.port=27017
 
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-import/src/test/resources/validate-contigs-fail.properties
+++ b/eva-accession-import/src/test/resources/validate-contigs-fail.properties
@@ -21,3 +21,6 @@ spring.data.mongodb.database=test
 spring.data.mongodb.host=localhost
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-import/src/test/resources/validate-contigs.properties
+++ b/eva-accession-import/src/test/resources/validate-contigs.properties
@@ -21,3 +21,6 @@ spring.data.mongodb.database=test
 spring.data.mongodb.host=localhost
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-pipeline/src/main/resources/application.properties
+++ b/eva-accession-pipeline/src/main/resources/application.properties
@@ -36,3 +36,5 @@ spring.datasource.tomcat.max-active=3
 # spring.jpa.generate-ddl=true
 
 spring.main.web-environment=false
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-pipeline/src/test/resources/accession-pipeline-interval-test.properties
+++ b/eva-accession-pipeline/src/test/resources/accession-pipeline-interval-test.properties
@@ -24,3 +24,6 @@ spring.data.mongodb.host=localhost
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-pipeline/src/test/resources/accession-pipeline-recover-test.properties
+++ b/eva-accession-pipeline/src/test/resources/accession-pipeline-recover-test.properties
@@ -29,3 +29,6 @@ spring.jpa.show-sql=true
 
 spring.data.mongodb.database=test-db
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-pipeline/src/test/resources/accession-pipeline-test.properties
+++ b/eva-accession-pipeline/src/test/resources/accession-pipeline-test.properties
@@ -24,3 +24,6 @@ spring.data.mongodb.host=localhost
 spring.data.mongodb.password=
 spring.data.mongodb.port=27017
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/batch/io/MongoDbCursorItemReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/batch/io/MongoDbCursorItemReader.java
@@ -180,7 +180,9 @@ public class MongoDbCursorItemReader<T> extends AbstractItemCountingItemStreamIt
             mongoQuery.withHint(hint);
         }
 
-        mongoQuery.with(sort);
+        if (sort != null) {
+            mongoQuery.with(sort);
+        }
 
         logger.info("Issuing MongoDB query: {}", mongoQuery);
 

--- a/eva-accession-release/src/main/resources/application.properties
+++ b/eva-accession-release/src/main/resources/application.properties
@@ -27,5 +27,7 @@ spring.data.mongodb.authentication-database=admin
 mongodb.read-preference=|eva.mongo.read-preference|
 
 spring.main.web-environment=false
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true
 
 logging.level.uk.ac.ebi.eva.accession.release=INFO

--- a/eva-accession-release/src/test/resources/application.properties
+++ b/eva-accession-release/src/test/resources/application.properties
@@ -17,3 +17,6 @@ parameters.chunkSize=1000
 
 spring.data.mongodb.database=test-db
 mongodb.read-preference=primary
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/EvaAccessionApplication.java
+++ b/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/EvaAccessionApplication.java
@@ -21,7 +21,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 @SpringBootApplication(exclude = {MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
 public class EvaAccessionApplication extends SpringBootServletInitializer {

--- a/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/configuration/ApplicationConfiguration.java
+++ b/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/configuration/ApplicationConfiguration.java
@@ -23,14 +23,16 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.web.HttpMessageConverters;
-import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.WebClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -48,7 +50,7 @@ import uk.ac.ebi.eva.accession.core.configuration.nonhuman.ClusteredVariantAcces
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.SubmittedVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.ws.response.NonRedirectingClientHttpRequestFactory;
 
-import java.util.List;
+import java.util.function.Supplier;
 
 @Configuration
 @EnableBasicRestControllerAdvice
@@ -95,13 +97,15 @@ public class ApplicationConfiguration {
     @Bean
     public RestTemplateBuilder restTemplateBuilder(
             ObjectProvider<HttpMessageConverters> messageConverters,
-            ObjectProvider<List<RestTemplateCustomizer>> restTemplateCustomizers) {
-        WebClientAutoConfiguration.RestTemplateConfiguration restTemplateConfiguration =
-                new WebClientAutoConfiguration.RestTemplateConfiguration(
+            ObjectProvider<RestTemplateCustomizer> restTemplateCustomizers) {
+
+        RestTemplateAutoConfiguration restTemplateConfiguration =
+                new RestTemplateAutoConfiguration(
                         messageConverters, restTemplateCustomizers);
         RestTemplateBuilder builder = restTemplateConfiguration.restTemplateBuilder();
 
-        builder = builder.requestFactory(new NonRedirectingClientHttpRequestFactory());
+        Supplier<ClientHttpRequestFactory> supplier = NonRedirectingClientHttpRequestFactory::new;
+        builder = builder.requestFactory(supplier);
 
         return builder;
     }

--- a/eva-accession-ws/src/main/resources/application.properties
+++ b/eva-accession-ws/src/main/resources/application.properties
@@ -19,3 +19,6 @@ human.mongodb.database=|eva.accession.mongo.human.database|
 
 management.endpoints.web.exposure.include=info,health
 management.info.git.mode=full
+
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-ws/src/test/resources/accession-ws-test.properties
+++ b/eva-accession-ws/src/test/resources/accession-ws-test.properties
@@ -10,6 +10,10 @@ accessioning.monotonic.test-rs.blockSize=100000
 accessioning.monotonic.test-rs.blockStartValue=3000000000
 accessioning.monotonic.test-rs.nextBlockInterval=1000000000
 
+# This symbolic variable is required because
+# this will be replaced with a default value "localhost" when run locally
+# (due to the filtering attribute specified in this project's POM)
+# (OR) this variable can be overridden in Gitlab with "mongo" (Gitlab services are exposed under their own hostname)
 spring.data.mongodb.uri=mongodb://|eva.mongo.host.test|:27017
 spring.data.mongodb.database=eva-accession-ws-test-db
 # See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding

--- a/eva-accession-ws/src/test/resources/accession-ws-test.properties
+++ b/eva-accession-ws/src/test/resources/accession-ws-test.properties
@@ -12,6 +12,8 @@ accessioning.monotonic.test-rs.nextBlockInterval=1000000000
 
 spring.data.mongodb.uri=mongodb://|eva.mongo.host.test|:27017
 spring.data.mongodb.database=eva-accession-ws-test-db
+# See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
+spring.main.allow-bean-definition-overriding=true
 mongodb.read-preference=primary
 
 human.mongodb.uri=mongodb://|eva.mongo.host.test|:27017

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.10.RELEASE</version>
+        <version>2.1.0.RELEASE</version>
     </parent>
 
     <dependencyManagement>
@@ -42,12 +42,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-mongodb</artifactId>
-                <version>0.6.4</version>
+                <version>0.7.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-monotonic-generator-jpa</artifactId>
-                <version>0.6.4</version>
+                <version>0.7.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>


### PR DESCRIPTION
Changes to support Spring Boot 2 MongoDB object models/methods
 - ClusteringWriterTest.java
 - ClusteringVariantStepConfigurationTest.java
 - ClusteredVariantsRestControllerTest.java
 - HumanMongoConfiguration.java
 - MongoConfiguration.java
 - SubmittedVariantAccessioningRepositoryTest.java
 - SubmittedVariantAccessioningServiceTest.java

Use MongoDBBulkWriteException instead of BulkOperationException
 - ClusteringWriter.java
 - MongoBulkWriteExceptionUtils.java
 - DbsnpClusteredVariantOperationWriter.java
 - DbsnpClusteredVariantWriter.java
 - DbsnpJsonClusteredVariantsWriter.java
 - DbsnpSubmittedVariantOperationWriter.java
 - DbsnpSubmittedVariantWriter.java
 - DbsnpVariantsWriter.java
 - MergeOperationBuilder.java
 - DeprecationWriter.java

Expect DuplicateKeyException instead of BulkOperationException for accession collisions
 - DbsnpClusteredVariantWriterTest.java
 - DbsnpSubmittedVariantWriterTest.java

SubmittedVariantAccessioningRepositoryImpl.java - Use Criteria object for "and" conditions and make the findByAccessionGreaterThanEqualAndAccessionLessThanEqual method public so that it can be called from the tests

Allow bean definition overriding in properties files across all projects

Adapt to different job resume semantics in Spring Boot 2
 - DbsnpImportVariantsJobLauncherCommandLineRunner.java

Spring Boot 2 does not allow "with" method with null sort parameter on a MongoQuery object
 - MongoDbCursorItemReader.java

Adapt to Spring 2 RestTemplateAutoConfiguration behavior and package paths
 - ApplicationConfiguration.java (eva-accession-ws)
 - EvaAccessionApplication.java (eva-accession-ws)