### PR TITLE
EVA-2070 Add created date to operations

### DIFF
--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
@@ -36,7 +36,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.repositories.ContiguousIdBlockRepository;
-
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
@@ -46,6 +45,7 @@ import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.ISubmittedVariant;
 import uk.ac.ebi.eva.accession.core.model.SubmittedVariant;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
 import uk.ac.ebi.eva.accession.core.service.nonhuman.ClusteredVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.summary.ClusteredVariantSummaryFunction;
 import uk.ac.ebi.eva.accession.core.summary.SubmittedVariantSummaryFunction;
@@ -219,5 +219,7 @@ public class IssueAccessionClusteringWriterTest {
         assertEquals(5, collection.countDocuments());
         List<Long> expectedAccessions = Arrays.asList(5000000001L, 5000000002L, 5000000003L, 5000000004L, 5000000005L);
         assertGeneratedAccessions(SUBMITTED_VARIANT_OPERATION_COLLECTION, "accession", expectedAccessions);
+        assertTrue(mongoTemplate.findAll(SubmittedVariantOperationEntity.class).stream()
+                .allMatch(s -> s.getCreatedDate() != null));
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
@@ -37,7 +37,6 @@ import uk.ac.ebi.ampt2d.commons.accession.core.models.EventType;
 import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.repositories.ContiguousIdBlockRepository;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.EventDocument;
-
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
@@ -69,6 +68,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static uk.ac.ebi.eva.accession.clustering.test.VariantAssertions.assertAccessionEqual;
 import static uk.ac.ebi.eva.accession.clustering.test.VariantAssertions.assertAssemblyAccessionEqual;
@@ -296,7 +296,7 @@ public class MergeAccessionClusteringWriterTest {
         assertEquals(EventType.MERGED, clusteredOp.getEventType());
         assertEquals(originalAccession, clusteredOp.getAccession());
         assertEquals(mergedInto, clusteredOp.getMergedInto());
-
+        assertNotNull(clusteredOp.getCreatedDate());
 
         List<? extends EventDocument<ISubmittedVariant, Long, ? extends SubmittedVariantInactiveEntity>> submittedOps =
                 mongoTemplate.findAll(SubmittedVariantOperationEntity.class);

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/dbsnp/DbsnpClusteredVariantOperationEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/dbsnp/DbsnpClusteredVariantOperationEntity.java
@@ -19,12 +19,19 @@ package uk.ac.ebi.eva.accession.core.model.dbsnp;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.EventDocument;
-
 import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
+
+import java.time.LocalDateTime;
 
 @Document
 public class DbsnpClusteredVariantOperationEntity extends EventDocument<IClusteredVariant, Long,
         DbsnpClusteredVariantInactiveEntity> {
+
+    public DbsnpClusteredVariantOperationEntity() {
+        super();
+        //Set the created date to assure is is assigned when performing bulk operations
+        setCreatedDate(LocalDateTime.now());
+    }
 
     @Override
     public String toString() {

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/dbsnp/DbsnpSubmittedVariantOperationEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/dbsnp/DbsnpSubmittedVariantOperationEntity.java
@@ -19,13 +19,19 @@ package uk.ac.ebi.eva.accession.core.model.dbsnp;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.EventDocument;
-
 import uk.ac.ebi.eva.accession.core.model.ISubmittedVariant;
+
+import java.time.LocalDateTime;
 
 @Document
 public class DbsnpSubmittedVariantOperationEntity extends EventDocument<ISubmittedVariant, Long,
         DbsnpSubmittedVariantInactiveEntity> {
 
+    public DbsnpSubmittedVariantOperationEntity() {
+        super();
+        //Set the created date to assure is is assigned when performing bulk operations
+        setCreatedDate(LocalDateTime.now());
+    }
 
     @Override
     public String toString() {

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/ClusteredVariantOperationEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/ClusteredVariantOperationEntity.java
@@ -22,9 +22,17 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.EventDocument;
 import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
 
+import java.time.LocalDateTime;
+
 @Document
 public class ClusteredVariantOperationEntity extends EventDocument<IClusteredVariant, Long,
         ClusteredVariantInactiveEntity> {
+
+    public ClusteredVariantOperationEntity() {
+        super();
+        //Set the created date to assure is is assigned when performing bulk operations
+        setCreatedDate(LocalDateTime.now());
+    }
 
     @Override
     public String toString() {

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/SubmittedVariantOperationEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/SubmittedVariantOperationEntity.java
@@ -19,12 +19,19 @@ package uk.ac.ebi.eva.accession.core.model.eva;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.EventDocument;
-
 import uk.ac.ebi.eva.accession.core.model.ISubmittedVariant;
+
+import java.time.LocalDateTime;
 
 @Document
 public class SubmittedVariantOperationEntity extends EventDocument<ISubmittedVariant, Long,
         SubmittedVariantInactiveEntity> {
+
+    public SubmittedVariantOperationEntity() {
+        super();
+        //Set the created date to assure is is assigned when performing bulk operations
+        setCreatedDate(LocalDateTime.now());
+    }
 
     @Override
     public String toString() {

--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-mongodb</artifactId>
-                <version>0.7.1-SNAPSHOT</version>
+                <version>0.7.1</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-monotonic-generator-jpa</artifactId>
-                <version>0.7.1-SNAPSHOT</version>
+                <version>0.7.1</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-mongodb</artifactId>
-                <version>0.7.0</version>
+                <version>0.7.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-monotonic-generator-jpa</artifactId>
-                <version>0.7.0</version>
+                <version>0.7.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.13</junit.version>
         <variation-commons-version>0.7.5</variation-commons-version>
+        <accession-commons-version>0.7.1</accession-commons-version>
     </properties>
 
     <parent>
@@ -49,12 +50,12 @@
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-mongodb</artifactId>
-                <version>0.7.1</version>
+                <version>${accession-commons-version}</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.ampt2d</groupId>
                 <artifactId>accession-commons-monotonic-generator-jpa</artifactId>
-                <version>0.7.1</version>
+                <version>${accession-commons-version}</version>
             </dependency>
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>


### PR DESCRIPTION
Merge this PR after:

- [x] EBIVariation/accession-commons#64 is merged (setCreatedDate implementation)
- [x] The accession-commons version is bumped to 0.7.1 and updated in the POM 

As mongo bulk operations don't fill the created date it has to be set manually in the operation entities constructor. 