### PR TITLE
EVA-2042 Add summary metrics for the clustering pipeline

### DIFF
--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
@@ -16,7 +16,6 @@
 package uk.ac.ebi.eva.accession.clustering.batch.io;
 
 import com.mongodb.MongoBulkWriteException;
-import com.mongodb.bulk.BulkWriteResult;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -29,6 +28,7 @@ import uk.ac.ebi.ampt2d.commons.accession.core.models.GetOrCreateAccessionWrappe
 import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.EventDocument;
 
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
 import uk.ac.ebi.eva.accession.core.model.ClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.ISubmittedVariant;
@@ -83,10 +83,13 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
 
     private Long accessioningMonotonicInitRs;
 
+    private ClusteringCounts clusteringCounts;
+
     public ClusteringWriter(MongoTemplate mongoTemplate,
                             ClusteredVariantAccessioningService clusteredVariantAccessioningService,
                             Long accessioningMonotonicInitSs,
-                            Long accessioningMonotonicInitRs) {
+                            Long accessioningMonotonicInitRs,
+                            ClusteringCounts clusteringCounts) {
         this.mongoTemplate = mongoTemplate;
         this.clusteredService = clusteredVariantAccessioningService;
         this.clusteredHashingFunction = new ClusteredVariantSummaryFunction().andThen(new SHA1HashingFunction());
@@ -94,6 +97,7 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
         Assert.notNull(accessioningMonotonicInitSs, "accessioningMonotonicInitSs must not be null. Check autowiring.");
         this.accessioningMonotonicInitSs = accessioningMonotonicInitSs;
         this.accessioningMonotonicInitRs = accessioningMonotonicInitRs;
+        this.clusteringCounts = clusteringCounts;
     }
 
     @Override
@@ -117,6 +121,8 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
             List<GetOrCreateAccessionWrapper<IClusteredVariant, String, Long>> accessionWrappers =
                     clusteredService.getOrCreate(clusteredVariants);
             accessionWrappers.forEach(x -> assignedAccessions.put(x.getHash(), x.getAccession()));
+            long newAccessions = accessionWrappers.stream().filter(GetOrCreateAccessionWrapper::isNewAccession).count();
+            clusteringCounts.addClusteredVariantsCreated(newAccessions);
         }
         checkForMerges(submittedVariantEntities);
     }
@@ -175,9 +181,11 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
                                        .map(c -> buildClusteredOperation(c, prioritised.accessionToKeep))
                                        .collect(Collectors.toList());
         mongoTemplate.insert(operations, getClusteredOperationCollection(prioritised.accessionToBeMerged));
+        clusteringCounts.addClusteredVariantsMergeOperationsWritten(clusteredVariantToMerge.size());
 
         mongoTemplate.updateMulti(queryClustered, update(ACCESSION_KEY, prioritised.accessionToKeep),
                                   getClusteredVariantCollection(prioritised.accessionToBeMerged));
+        clusteringCounts.addClusteredVariantsUpdated(clusteredVariantToMerge.size());
 
         // Update submitted variants linked to the clustered variant we just merged.
         // This has to happen for both EVA and dbsnp SS because previous cross merges might have happened.
@@ -245,6 +253,7 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
         Update update = new Update();
         update.set(RS_KEY, prioritised.accessionToKeep);
         mongoTemplate.updateMulti(querySubmitted, update, submittedVariantCollection);
+        clusteringCounts.addSubmittedVariantsUpdated(svToUpdate.size());
 
         if (!svToUpdate.isEmpty()) {
             List<SubmittedVariantOperationEntity> operations =
@@ -252,6 +261,7 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
                               .map(sv -> buildSubmittedOperation(sv, prioritised.accessionToKeep))
                               .collect(Collectors.toList());
             mongoTemplate.insert(operations, submittedOperationCollection);
+            clusteringCounts.addSubmittedVariantsUpdateOperationWritten(operations.size());
         }
     }
 
@@ -320,11 +330,15 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
         }
         if (numUpdates > 0) {
             bulkOperations.execute();
+            clusteringCounts.addSubmittedVariantsUpdated(numUpdates);
             bulkHistoryOperations.execute();
+            clusteringCounts.addSubmittedVariantsUpdateOperationWritten(numUpdates);
         }
         if (numDbsnpUpdates > 0) {
             dbsnpBulkOperations.execute();
+            clusteringCounts.addSubmittedVariantsUpdated(numDbsnpUpdates);
             dbsnpBulkHistoryOperations.execute();
+            clusteringCounts.addSubmittedVariantsUpdateOperationWritten(numDbsnpUpdates);
         }
     }
 

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
@@ -253,7 +253,7 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
         Update update = new Update();
         update.set(RS_KEY, prioritised.accessionToKeep);
         mongoTemplate.updateMulti(querySubmitted, update, submittedVariantCollection);
-        clusteringCounts.addSubmittedVariantsUpdated(svToUpdate.size());
+        clusteringCounts.addSubmittedVariantsUpdatedRs(svToUpdate.size());
 
         if (!svToUpdate.isEmpty()) {
             List<SubmittedVariantOperationEntity> operations =
@@ -330,13 +330,13 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
         }
         if (numUpdates > 0) {
             bulkOperations.execute();
-            clusteringCounts.addSubmittedVariantsUpdated(numUpdates);
+            clusteringCounts.addSubmittedVariantsClustered(numUpdates);
             bulkHistoryOperations.execute();
             clusteringCounts.addSubmittedVariantsUpdateOperationWritten(numUpdates);
         }
         if (numDbsnpUpdates > 0) {
             dbsnpBulkOperations.execute();
-            clusteringCounts.addSubmittedVariantsUpdated(numDbsnpUpdates);
+            clusteringCounts.addSubmittedVariantsClustered(numDbsnpUpdates);
             dbsnpBulkHistoryOperations.execute();
             clusteringCounts.addSubmittedVariantsUpdateOperationWritten(numDbsnpUpdates);
         }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/listeners/ClusteringCounts.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/listeners/ClusteringCounts.java
@@ -23,7 +23,9 @@ public class ClusteringCounts {
 
     private long clusteredVariantsMergeOperationsWritten;
 
-    private long submittedVariantsUpdated;
+    private long submittedVariantsClustered;
+
+    private long submittedVariantsUpdatedRs;
 
     private long submittedVariantsUpdateOperationWritten;
 
@@ -31,7 +33,8 @@ public class ClusteringCounts {
         this.clusteredVariantsCreated = 0;
         this.clusteredVariantsUpdated = 0;
         this.clusteredVariantsMergeOperationsWritten = 0;
-        this.submittedVariantsUpdated = 0;
+        this.submittedVariantsClustered = 0;
+        this.submittedVariantsUpdatedRs = 0;
         this.submittedVariantsUpdateOperationWritten = 0;
     }
 
@@ -71,16 +74,28 @@ public class ClusteringCounts {
         this.clusteredVariantsMergeOperationsWritten = clusteredVariantsMergeOperationsWritten;
     }
 
-    public void addSubmittedVariantsUpdated(long submittedVariantsUpdated) {
-        this.submittedVariantsUpdated += submittedVariantsUpdated;
+    public void addSubmittedVariantsClustered(long submittedVariantsClustered) {
+        this.submittedVariantsClustered += submittedVariantsClustered;
     }
 
-    public long getSubmittedVariantsUpdated() {
-        return submittedVariantsUpdated;
+    public long getSubmittedVariantsClustered() {
+        return submittedVariantsClustered;
     }
 
-    public void setSubmittedVariantsUpdated(long submittedVariantsUpdated) {
-        this.submittedVariantsUpdated = submittedVariantsUpdated;
+    public void setSubmittedVariantsClustered(long submittedVariantsClustered) {
+        this.submittedVariantsClustered = submittedVariantsClustered;
+    }
+
+    public void addSubmittedVariantsUpdatedRs(long submittedVariantsUpdatedRs) {
+        this.submittedVariantsUpdatedRs += submittedVariantsUpdatedRs;
+    }
+
+    public long getSubmittedVariantsUpdatedRs() {
+        return submittedVariantsUpdatedRs;
+    }
+
+    public void setSubmittedVariantsUpdatedRs(long submittedVariantsUpdatedRs) {
+        this.submittedVariantsUpdatedRs = submittedVariantsUpdatedRs;
     }
 
     public void addSubmittedVariantsUpdateOperationWritten(long submittedVariantsUpdateOperationWritten) {

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/listeners/ClusteringCounts.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/listeners/ClusteringCounts.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.listeners;
+
+public class ClusteringCounts {
+
+    private long clusteredVariantsCreated;
+
+    private long clusteredVariantsUpdated;
+
+    private long clusteredVariantsMergeOperationsWritten;
+
+    private long submittedVariantsUpdated;
+
+    private long submittedVariantsUpdateOperationWritten;
+
+    public ClusteringCounts() {
+        this.clusteredVariantsCreated = 0;
+        this.clusteredVariantsUpdated = 0;
+        this.clusteredVariantsMergeOperationsWritten = 0;
+        this.submittedVariantsUpdated = 0;
+        this.submittedVariantsUpdateOperationWritten = 0;
+    }
+
+    public void addClusteredVariantsCreated(long clusteredVariantsCreated) {
+        this.clusteredVariantsCreated += clusteredVariantsCreated;
+    }
+
+    public long getClusteredVariantsCreated() {
+        return clusteredVariantsCreated;
+    }
+
+    public void setClusteredVariantsCreated(long clusteredVariantsCreated) {
+        this.clusteredVariantsCreated = clusteredVariantsCreated;
+    }
+
+    public void addClusteredVariantsUpdated(long clusteredVariantsUpdated) {
+        this.clusteredVariantsUpdated += clusteredVariantsUpdated;
+    }
+
+    public long getClusteredVariantsUpdated() {
+        return clusteredVariantsUpdated;
+    }
+
+    public void setClusteredVariantsUpdated(long clusteredVariantsUpdated) {
+        this.clusteredVariantsUpdated = clusteredVariantsUpdated;
+    }
+
+    public void addClusteredVariantsMergeOperationsWritten(long clusteredVariantsMergeOperationsWritten) {
+        this.clusteredVariantsMergeOperationsWritten += clusteredVariantsMergeOperationsWritten;
+    }
+
+    public long getClusteredVariantsMergeOperationsWritten() {
+        return clusteredVariantsMergeOperationsWritten;
+    }
+
+    public void setClusteredVariantsMergeOperationsWritten(long clusteredVariantsMergeOperationsWritten) {
+        this.clusteredVariantsMergeOperationsWritten = clusteredVariantsMergeOperationsWritten;
+    }
+
+    public void addSubmittedVariantsUpdated(long submittedVariantsUpdated) {
+        this.submittedVariantsUpdated += submittedVariantsUpdated;
+    }
+
+    public long getSubmittedVariantsUpdated() {
+        return submittedVariantsUpdated;
+    }
+
+    public void setSubmittedVariantsUpdated(long submittedVariantsUpdated) {
+        this.submittedVariantsUpdated = submittedVariantsUpdated;
+    }
+
+    public void addSubmittedVariantsUpdateOperationWritten(long submittedVariantsUpdateOperationWritten) {
+        this.submittedVariantsUpdateOperationWritten += submittedVariantsUpdateOperationWritten;
+    }
+
+    public long getSubmittedVariantsUpdateOperationWritten() {
+        return submittedVariantsUpdateOperationWritten;
+    }
+
+    public void setSubmittedVariantsUpdateOperationWritten(long submittedVariantsUpdateOperationWritten) {
+        this.submittedVariantsUpdateOperationWritten = submittedVariantsUpdateOperationWritten;
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/listeners/ClusteringProgressListener.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/listeners/ClusteringProgressListener.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.listeners;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import uk.ac.ebi.eva.accession.core.batch.listeners.GenericProgressListener;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
+
+public class ClusteringProgressListener extends GenericProgressListener<Variant, SubmittedVariantEntity> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClusteringProgressListener.class);
+
+    private final ClusteringCounts clusteringCounts;
+
+    public ClusteringProgressListener(long chunkSize, ClusteringCounts clusteringCounts) {
+        super(chunkSize);
+        this.clusteringCounts = clusteringCounts;
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        ExitStatus status = super.afterStep(stepExecution);
+
+        String stepName = stepExecution.getStepName();
+        long numTotalItemsRead = stepExecution.getReadCount();
+        logger.info("Step {} finished: Items read = {}, rs created = {}, rs updated = {}, rs merge operations = {}, " +
+                        "ss updated = {}, ss update operations = {}",
+                stepName, numTotalItemsRead,
+                clusteringCounts.getClusteredVariantsCreated(),
+                clusteringCounts.getClusteredVariantsUpdated(),
+                clusteringCounts.getClusteredVariantsMergeOperationsWritten(),
+                clusteringCounts.getSubmittedVariantsUpdated(),
+                clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
+        return status;
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/listeners/ClusteringProgressListener.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/listeners/ClusteringProgressListener.java
@@ -41,12 +41,13 @@ public class ClusteringProgressListener extends GenericProgressListener<Variant,
         String stepName = stepExecution.getStepName();
         long numTotalItemsRead = stepExecution.getReadCount();
         logger.info("Step {} finished: Items read = {}, rs created = {}, rs updated = {}, rs merge operations = {}, " +
-                        "ss updated = {}, ss update operations = {}",
+                        "ss clustered = {}, ss updated rs merged = {}, ss update operations = {}",
                 stepName, numTotalItemsRead,
                 clusteringCounts.getClusteredVariantsCreated(),
                 clusteringCounts.getClusteredVariantsUpdated(),
                 clusteringCounts.getClusteredVariantsMergeOperationsWritten(),
-                clusteringCounts.getSubmittedVariantsUpdated(),
+                clusteringCounts.getSubmittedVariantsClustered(),
+                clusteringCounts.getSubmittedVariantsUpdatedRs(),
                 clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
         return status;
     }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/ClusteringWriterConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/ClusteringWriterConfiguration.java
@@ -19,8 +19,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
-
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.ClusteredVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.SubmittedVariantAccessioningConfiguration;
@@ -37,8 +37,9 @@ public class ClusteringWriterConfiguration {
     public ClusteringWriter clusteringWriter(MongoTemplate mongoTemplate,
                                              ClusteredVariantAccessioningService accessioningService,
                                              Long accessioningMonotonicInitSs,
-                                             Long accessioningMonotonicInitRs) {
+                                             Long accessioningMonotonicInitRs,
+                                             ClusteringCounts clusteringCounts) {
         return new ClusteringWriter(mongoTemplate, accessioningService, accessioningMonotonicInitSs,
-                                    accessioningMonotonicInitRs);
+                                    accessioningMonotonicInitRs, clusteringCounts);
     }
 }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/listeners/ListenersConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/listeners/ListenersConfiguration.java
@@ -1,11 +1,10 @@
 package uk.ac.ebi.eva.accession.clustering.configuration.batch.listeners;
 
-import org.springframework.batch.core.listener.StepListenerSupport;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringProgressListener;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
-import uk.ac.ebi.eva.accession.core.batch.listeners.GenericProgressListener;
 
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROGRESS_LISTENER;
 
@@ -13,7 +12,13 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROGRES
 public class ListenersConfiguration {
 
     @Bean(PROGRESS_LISTENER)
-    public <R, W> StepListenerSupport<R, W> progressListener(InputParameters parameters) {
-        return new GenericProgressListener<>(parameters.getChunkSize());
+    public ClusteringProgressListener clusteringProgressListener(InputParameters parameters,
+                                                                 ClusteringCounts clusteringCounts) {
+        return new ClusteringProgressListener(parameters.getChunkSize(), clusteringCounts);
+    }
+
+    @Bean
+    public ClusteringCounts importCounts() {
+        return new ClusteringCounts();
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ClusteringWriterTestUtils.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ClusteringWriterTestUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.io.clustering_writer;
+
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringProgressListener;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClusteringWriterTestUtils {
+
+    /**
+     * Clustering counts are used by the listener {@link ClusteringProgressListener} to summarize the counts after
+     * the step is finished
+     */
+    static void assertClusteringCounts(ClusteringCounts clusteringCounts,
+                                        long expectedClusteredVariantsCreated,
+                                        long expectedClusteredVariantsUpdated,
+                                        long expectedClusteredVariantsMergeOperationsWritten,
+                                        long expectedSubmittedVariantsNewRs,
+                                        long expectedSubmittedVariantsUpdatedRs,
+                                        long expectedSubmittedVariantsUpdateOperationWritten) {
+        assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
+        assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
+        assertEquals(expectedClusteredVariantsMergeOperationsWritten,
+                clusteringCounts.getClusteredVariantsMergeOperationsWritten());
+        assertEquals(expectedSubmittedVariantsNewRs, clusteringCounts.getSubmittedVariantsClustered());
+        assertEquals(expectedSubmittedVariantsUpdatedRs, clusteringCounts.getSubmittedVariantsUpdatedRs());
+        assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
+                clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
+    }
+}

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
@@ -139,7 +139,7 @@ public class IssueAccessionClusteringWriterTest {
         assertClusteredVariantsCreated();
         assertSubmittedVariantsUpdated();
         assertSubmittedVariantsOperationInserted();
-        assertClusteringCounts(4, 0, 0, 5, 5);
+        assertClusteringCounts(4, 0, 0, 5, 0, 5);
     }
 
     private List<SubmittedVariantEntity> createSubmittedVariantEntities() {
@@ -236,13 +236,15 @@ public class IssueAccessionClusteringWriterTest {
      */
     private void assertClusteringCounts(long expectedClusteredVariantsCreated, long expectedClusteredVariantsUpdated,
                                         long expectedClusteredVariantsMergeOperationsWritten,
-                                        long expectedSubmittedVariantsUpdated,
+                                        long expectedSubmittedVariantsNewRs,
+                                        long expectedSubmittedVariantsUpdatedRs,
                                         long expectedSubmittedVariantsUpdateOperationWritten) {
         assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
         assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
         assertEquals(expectedClusteredVariantsMergeOperationsWritten,
                 clusteringCounts.getClusteredVariantsMergeOperationsWritten());
-        assertEquals(expectedSubmittedVariantsUpdated, clusteringCounts.getSubmittedVariantsUpdated());
+        assertEquals(expectedSubmittedVariantsNewRs, clusteringCounts.getSubmittedVariantsClustered());
+        assertEquals(expectedSubmittedVariantsUpdatedRs, clusteringCounts.getSubmittedVariantsUpdatedRs());
         assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
                 clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
     }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
@@ -38,7 +38,6 @@ import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.repositories.ContiguousIdBlockRepository;
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
 import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
-import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringProgressListener;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
@@ -60,6 +59,7 @@ import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.accession.clustering.batch.io.clustering_writer.ClusteringWriterTestUtils.assertClusteringCounts;
 
 /**
  * This class handles the simplest scenarios of ClusteringWriter.
@@ -139,7 +139,7 @@ public class IssueAccessionClusteringWriterTest {
         assertClusteredVariantsCreated();
         assertSubmittedVariantsUpdated();
         assertSubmittedVariantsOperationInserted();
-        assertClusteringCounts(4, 0, 0, 5, 0, 5);
+        assertClusteringCounts(clusteringCounts, 4, 0, 0, 5, 0, 5);
     }
 
     private List<SubmittedVariantEntity> createSubmittedVariantEntities() {
@@ -227,25 +227,5 @@ public class IssueAccessionClusteringWriterTest {
         assertGeneratedAccessions(SUBMITTED_VARIANT_OPERATION_COLLECTION, "accession", expectedAccessions);
         assertTrue(mongoTemplate.findAll(SubmittedVariantOperationEntity.class).stream()
                 .allMatch(s -> s.getCreatedDate() != null));
-    }
-
-    /**
-     * Clustering counts are used by the listener
-     * {@link ClusteringProgressListener}
-     * to summarize the counts after a the step is finished
-     */
-    private void assertClusteringCounts(long expectedClusteredVariantsCreated, long expectedClusteredVariantsUpdated,
-                                        long expectedClusteredVariantsMergeOperationsWritten,
-                                        long expectedSubmittedVariantsNewRs,
-                                        long expectedSubmittedVariantsUpdatedRs,
-                                        long expectedSubmittedVariantsUpdateOperationWritten) {
-        assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
-        assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
-        assertEquals(expectedClusteredVariantsMergeOperationsWritten,
-                clusteringCounts.getClusteredVariantsMergeOperationsWritten());
-        assertEquals(expectedSubmittedVariantsNewRs, clusteringCounts.getSubmittedVariantsClustered());
-        assertEquals(expectedSubmittedVariantsUpdatedRs, clusteringCounts.getSubmittedVariantsUpdatedRs());
-        assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
-                clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
@@ -37,6 +37,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.repositories.ContiguousIdBlockRepository;
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringProgressListener;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
@@ -93,6 +95,9 @@ public class IssueAccessionClusteringWriterTest {
     private MongoTemplate mongoTemplate;
 
     @Autowired
+    private ClusteringCounts clusteringCounts;
+
+    @Autowired
     private ClusteredVariantAccessioningService clusteredVariantAccessioningService;
 
     @Autowired
@@ -114,8 +119,8 @@ public class IssueAccessionClusteringWriterTest {
 
     @Before
     public void setUp() {
-        clusteringWriter = new ClusteringWriter(mongoTemplate, clusteredVariantAccessioningService,
-                                                EVA_SUBMITTED_VARIANT_RANGE_START, EVA_CLUSTERED_VARIANT_RANGE_START);
+        clusteringWriter = new ClusteringWriter(mongoTemplate, clusteredVariantAccessioningService, EVA_SUBMITTED_VARIANT_RANGE_START,
+                EVA_CLUSTERED_VARIANT_RANGE_START, clusteringCounts);
         hashingFunction = new SubmittedVariantSummaryFunction().andThen(new SHA1HashingFunction());
         clusteredHashingFunction = new ClusteredVariantSummaryFunction().andThen(new SHA1HashingFunction());
     }
@@ -134,6 +139,7 @@ public class IssueAccessionClusteringWriterTest {
         assertClusteredVariantsCreated();
         assertSubmittedVariantsUpdated();
         assertSubmittedVariantsOperationInserted();
+        assertClusteringCounts(4, 0, 0, 5, 5);
     }
 
     private List<SubmittedVariantEntity> createSubmittedVariantEntities() {
@@ -221,5 +227,23 @@ public class IssueAccessionClusteringWriterTest {
         assertGeneratedAccessions(SUBMITTED_VARIANT_OPERATION_COLLECTION, "accession", expectedAccessions);
         assertTrue(mongoTemplate.findAll(SubmittedVariantOperationEntity.class).stream()
                 .allMatch(s -> s.getCreatedDate() != null));
+    }
+
+    /**
+     * Clustering counts are used by the listener
+     * {@link ClusteringProgressListener}
+     * to summarize the counts after a the step is finished
+     */
+    private void assertClusteringCounts(long expectedClusteredVariantsCreated, long expectedClusteredVariantsUpdated,
+                                        long expectedClusteredVariantsMergeOperationsWritten,
+                                        long expectedSubmittedVariantsUpdated,
+                                        long expectedSubmittedVariantsUpdateOperationWritten) {
+        assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
+        assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
+        assertEquals(expectedClusteredVariantsMergeOperationsWritten,
+                clusteringCounts.getClusteredVariantsMergeOperationsWritten());
+        assertEquals(expectedSubmittedVariantsUpdated, clusteringCounts.getSubmittedVariantsUpdated());
+        assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
+                clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
@@ -236,7 +236,7 @@ public class MergeAccessionClusteringWriterTest {
         assertDatabaseCounts(expectedDbsnpCve, expectedCve, expectedDbsnpCvOperations, expectedCvOperations,
                              expectedDbsnpSve, expectedSve, expectedDbsnpSvOperations, expectedSvOperations);
 
-        assertClusteringCounts(0, 1, 1, 1, 1);
+        assertClusteringCounts(0, 1, 1, 0, 1, 1);
 
         assertAssembliesPresent(Sets.newTreeSet(asm1, asm2));
     }
@@ -248,13 +248,15 @@ public class MergeAccessionClusteringWriterTest {
      */
     private void assertClusteringCounts(long expectedClusteredVariantsCreated, long expectedClusteredVariantsUpdated,
                                         long expectedClusteredVariantsMergeOperationsWritten,
-                                        long expectedSubmittedVariantsUpdated,
+                                        long expectedSubmittedVariantsNewRs,
+                                        long expectedSubmittedVariantsUpdatedRs,
                                         long expectedSubmittedVariantsUpdateOperationWritten) {
         assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
         assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
         assertEquals(expectedClusteredVariantsMergeOperationsWritten,
                 clusteringCounts.getClusteredVariantsMergeOperationsWritten());
-        assertEquals(expectedSubmittedVariantsUpdated, clusteringCounts.getSubmittedVariantsUpdated());
+        assertEquals(expectedSubmittedVariantsNewRs, clusteringCounts.getSubmittedVariantsClustered());
+        assertEquals(expectedSubmittedVariantsUpdatedRs, clusteringCounts.getSubmittedVariantsUpdatedRs());
         assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
                 clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
     }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
@@ -39,7 +39,6 @@ import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.repositories
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.EventDocument;
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
 import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
-import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringProgressListener;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
@@ -72,6 +71,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.accession.clustering.batch.io.clustering_writer.ClusteringWriterTestUtils.assertClusteringCounts;
 import static uk.ac.ebi.eva.accession.clustering.test.VariantAssertions.assertAccessionEqual;
 import static uk.ac.ebi.eva.accession.clustering.test.VariantAssertions.assertAssemblyAccessionEqual;
 import static uk.ac.ebi.eva.accession.clustering.test.VariantAssertions.assertClusteredVariantAccessionEqual;
@@ -236,29 +236,9 @@ public class MergeAccessionClusteringWriterTest {
         assertDatabaseCounts(expectedDbsnpCve, expectedCve, expectedDbsnpCvOperations, expectedCvOperations,
                              expectedDbsnpSve, expectedSve, expectedDbsnpSvOperations, expectedSvOperations);
 
-        assertClusteringCounts(0, 1, 1, 0, 1, 1);
+        assertClusteringCounts(clusteringCounts, 0, 1, 1, 0, 1, 1);
 
         assertAssembliesPresent(Sets.newTreeSet(asm1, asm2));
-    }
-
-    /**
-     * Clustering counts are used by the listener
-     * {@link ClusteringProgressListener}
-     * to summarize the counts after a the step is finished
-     */
-    private void assertClusteringCounts(long expectedClusteredVariantsCreated, long expectedClusteredVariantsUpdated,
-                                        long expectedClusteredVariantsMergeOperationsWritten,
-                                        long expectedSubmittedVariantsNewRs,
-                                        long expectedSubmittedVariantsUpdatedRs,
-                                        long expectedSubmittedVariantsUpdateOperationWritten) {
-        assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
-        assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
-        assertEquals(expectedClusteredVariantsMergeOperationsWritten,
-                clusteringCounts.getClusteredVariantsMergeOperationsWritten());
-        assertEquals(expectedSubmittedVariantsNewRs, clusteringCounts.getSubmittedVariantsClustered());
-        assertEquals(expectedSubmittedVariantsUpdatedRs, clusteringCounts.getSubmittedVariantsUpdatedRs());
-        assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
-                clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
     }
 
     private ClusteredVariantEntity createClusteredVariantEntity(String assembly, Long rs) {

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
@@ -38,6 +38,8 @@ import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.repositories.ContiguousIdBlockRepository;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.EventDocument;
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringProgressListener;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
@@ -109,6 +111,9 @@ public class MergeAccessionClusteringWriterTest {
     private MongoTemplate mongoTemplate;
 
     @Autowired
+    private ClusteringCounts clusteringCounts;
+
+    @Autowired
     private ClusteredVariantAccessioningService clusteredVariantAccessioningService;
 
     @Autowired
@@ -132,7 +137,7 @@ public class MergeAccessionClusteringWriterTest {
     public void setUp() {
         mongoTemplate.getDb().drop();
         clusteringWriter = new ClusteringWriter(mongoTemplate, clusteredVariantAccessioningService,
-                                                EVA_SUBMITTED_VARIANT_RANGE_START, EVA_CLUSTERED_VARIANT_RANGE_START);
+                EVA_SUBMITTED_VARIANT_RANGE_START, EVA_CLUSTERED_VARIANT_RANGE_START, clusteringCounts);
         hashingFunction = new SubmittedVariantSummaryFunction().andThen(new SHA1HashingFunction());
         clusteredHashingFunction = new ClusteredVariantSummaryFunction().andThen(new SHA1HashingFunction());
     }
@@ -231,8 +236,27 @@ public class MergeAccessionClusteringWriterTest {
         assertDatabaseCounts(expectedDbsnpCve, expectedCve, expectedDbsnpCvOperations, expectedCvOperations,
                              expectedDbsnpSve, expectedSve, expectedDbsnpSvOperations, expectedSvOperations);
 
+        assertClusteringCounts(0, 1, 1, 1, 1);
 
         assertAssembliesPresent(Sets.newTreeSet(asm1, asm2));
+    }
+
+    /**
+     * Clustering counts are used by the listener
+     * {@link ClusteringProgressListener}
+     * to summarize the counts after a the step is finished
+     */
+    private void assertClusteringCounts(long expectedClusteredVariantsCreated, long expectedClusteredVariantsUpdated,
+                                        long expectedClusteredVariantsMergeOperationsWritten,
+                                        long expectedSubmittedVariantsUpdated,
+                                        long expectedSubmittedVariantsUpdateOperationWritten) {
+        assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
+        assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
+        assertEquals(expectedClusteredVariantsMergeOperationsWritten,
+                clusteringCounts.getClusteredVariantsMergeOperationsWritten());
+        assertEquals(expectedSubmittedVariantsUpdated, clusteringCounts.getSubmittedVariantsUpdated());
+        assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
+                clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
     }
 
     private ClusteredVariantEntity createClusteredVariantEntity(String assembly, Long rs) {

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
@@ -39,7 +39,6 @@ import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.repositories.ContiguousIdBlockRepository;
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
 import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
-import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringProgressListener;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
@@ -65,6 +64,7 @@ import java.util.function.Function;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static uk.ac.ebi.eva.accession.clustering.batch.io.clustering_writer.ClusteringWriterTestUtils.assertClusteringCounts;
 
 /**
  * This class handles some scenarios of ClusteringWriter where an existing RS is reused.
@@ -154,7 +154,7 @@ public class ReuseAccessionClusteringWriterTest {
         clusteringWriter.write(Collections.singletonList(sveNonClustered));
         assertEquals(2, mongoTemplate.count(new Query(), ClusteredVariantEntity.class));
 
-        assertClusteringCounts(1, 0, 0, 2, 0, 2);
+        assertClusteringCounts(clusteringCounts, 1, 0, 0, 2, 0, 2);
     }
 
     private SubmittedVariantEntity createSubmittedVariantEntity(String assembly, Long rs, Long ss) {
@@ -226,7 +226,7 @@ public class ReuseAccessionClusteringWriterTest {
                 new Query(), SubmittedVariantOperationEntity.class);
         assertEquals(sveNonClustered.getAccession(), afterClusteringOperation.getAccession());
 
-        assertClusteringCounts(0, 0, 0, 1, 0, 1);
+        assertClusteringCounts(clusteringCounts, 0, 0, 0, 1, 0, 1);
     }
 
     @Test
@@ -274,26 +274,6 @@ public class ReuseAccessionClusteringWriterTest {
                 new Query(), DbsnpSubmittedVariantOperationEntity.class);
         assertEquals(sveNonClustered.getAccession(), afterClusteringOperation.getAccession());
 
-        assertClusteringCounts(0, 0, 0, 1, 0, 1);
-    }
-
-    /**
-     * Clustering counts are used by the listener
-     * {@link ClusteringProgressListener}
-     * to summarize the counts after a the step is finished
-     */
-    private void assertClusteringCounts(long expectedClusteredVariantsCreated, long expectedClusteredVariantsUpdated,
-                                        long expectedClusteredVariantsMergeOperationsWritten,
-                                        long expectedSubmittedVariantsNewRs,
-                                        long expectedSubmittedVariantsUpdatedRs,
-                                        long expectedSubmittedVariantsUpdateOperationWritten) {
-        assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
-        assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
-        assertEquals(expectedClusteredVariantsMergeOperationsWritten,
-                clusteringCounts.getClusteredVariantsMergeOperationsWritten());
-        assertEquals(expectedSubmittedVariantsNewRs, clusteringCounts.getSubmittedVariantsClustered());
-        assertEquals(expectedSubmittedVariantsUpdatedRs, clusteringCounts.getSubmittedVariantsUpdatedRs());
-        assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
-                clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
+        assertClusteringCounts(clusteringCounts, 0, 0, 0, 1, 0, 1);
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
@@ -154,7 +154,7 @@ public class ReuseAccessionClusteringWriterTest {
         clusteringWriter.write(Collections.singletonList(sveNonClustered));
         assertEquals(2, mongoTemplate.count(new Query(), ClusteredVariantEntity.class));
 
-        assertClusteringCounts(1, 0, 0, 2, 2);
+        assertClusteringCounts(1, 0, 0, 2, 0, 2);
     }
 
     private SubmittedVariantEntity createSubmittedVariantEntity(String assembly, Long rs, Long ss) {
@@ -226,7 +226,7 @@ public class ReuseAccessionClusteringWriterTest {
                 new Query(), SubmittedVariantOperationEntity.class);
         assertEquals(sveNonClustered.getAccession(), afterClusteringOperation.getAccession());
 
-        assertClusteringCounts(0, 0, 0, 1, 1);
+        assertClusteringCounts(0, 0, 0, 1, 0, 1);
     }
 
     @Test
@@ -274,7 +274,7 @@ public class ReuseAccessionClusteringWriterTest {
                 new Query(), DbsnpSubmittedVariantOperationEntity.class);
         assertEquals(sveNonClustered.getAccession(), afterClusteringOperation.getAccession());
 
-        assertClusteringCounts(0, 0, 0, 1, 1);
+        assertClusteringCounts(0, 0, 0, 1, 0, 1);
     }
 
     /**
@@ -284,13 +284,15 @@ public class ReuseAccessionClusteringWriterTest {
      */
     private void assertClusteringCounts(long expectedClusteredVariantsCreated, long expectedClusteredVariantsUpdated,
                                         long expectedClusteredVariantsMergeOperationsWritten,
-                                        long expectedSubmittedVariantsUpdated,
+                                        long expectedSubmittedVariantsNewRs,
+                                        long expectedSubmittedVariantsUpdatedRs,
                                         long expectedSubmittedVariantsUpdateOperationWritten) {
         assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
         assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
         assertEquals(expectedClusteredVariantsMergeOperationsWritten,
                 clusteringCounts.getClusteredVariantsMergeOperationsWritten());
-        assertEquals(expectedSubmittedVariantsUpdated, clusteringCounts.getSubmittedVariantsUpdated());
+        assertEquals(expectedSubmittedVariantsNewRs, clusteringCounts.getSubmittedVariantsClustered());
+        assertEquals(expectedSubmittedVariantsUpdatedRs, clusteringCounts.getSubmittedVariantsUpdatedRs());
         assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
                 clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
     }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
@@ -38,6 +38,8 @@ import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionMergedExcepti
 import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.repositories.ContiguousIdBlockRepository;
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringProgressListener;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
@@ -90,6 +92,9 @@ public class ReuseAccessionClusteringWriterTest {
     private MongoTemplate mongoTemplate;
 
     @Autowired
+    private ClusteringCounts clusteringCounts;
+
+    @Autowired
     private ClusteredVariantAccessioningService clusteredVariantAccessioningService;
 
     @Autowired
@@ -112,8 +117,8 @@ public class ReuseAccessionClusteringWriterTest {
     @Before
     public void setUp() {
         mongoTemplate.getDb().drop();
-        clusteringWriter = new ClusteringWriter(mongoTemplate, clusteredVariantAccessioningService,
-                                                EVA_SUBMITTED_VARIANT_RANGE_START, EVA_CLUSTERED_VARIANT_RANGE_START);
+        clusteringWriter = new ClusteringWriter(mongoTemplate, clusteredVariantAccessioningService, EVA_SUBMITTED_VARIANT_RANGE_START,
+                EVA_CLUSTERED_VARIANT_RANGE_START, clusteringCounts);
         hashingFunction = new SubmittedVariantSummaryFunction().andThen(new SHA1HashingFunction());
         clusteredHashingFunction = new ClusteredVariantSummaryFunction().andThen(new SHA1HashingFunction());
     }
@@ -148,6 +153,8 @@ public class ReuseAccessionClusteringWriterTest {
         // for the same submitted variant without an assigned RS (rs=null), getOrCreate should not create another RS
         clusteringWriter.write(Collections.singletonList(sveNonClustered));
         assertEquals(2, mongoTemplate.count(new Query(), ClusteredVariantEntity.class));
+
+        assertClusteringCounts(1, 0, 0, 2, 2);
     }
 
     private SubmittedVariantEntity createSubmittedVariantEntity(String assembly, Long rs, Long ss) {
@@ -218,6 +225,8 @@ public class ReuseAccessionClusteringWriterTest {
         SubmittedVariantOperationEntity afterClusteringOperation = mongoTemplate.findOne(
                 new Query(), SubmittedVariantOperationEntity.class);
         assertEquals(sveNonClustered.getAccession(), afterClusteringOperation.getAccession());
+
+        assertClusteringCounts(0, 0, 0, 1, 1);
     }
 
     @Test
@@ -264,5 +273,25 @@ public class ReuseAccessionClusteringWriterTest {
         DbsnpSubmittedVariantOperationEntity afterClusteringOperation = mongoTemplate.findOne(
                 new Query(), DbsnpSubmittedVariantOperationEntity.class);
         assertEquals(sveNonClustered.getAccession(), afterClusteringOperation.getAccession());
+
+        assertClusteringCounts(0, 0, 0, 1, 1);
+    }
+
+    /**
+     * Clustering counts are used by the listener
+     * {@link ClusteringProgressListener}
+     * to summarize the counts after a the step is finished
+     */
+    private void assertClusteringCounts(long expectedClusteredVariantsCreated, long expectedClusteredVariantsUpdated,
+                                        long expectedClusteredVariantsMergeOperationsWritten,
+                                        long expectedSubmittedVariantsUpdated,
+                                        long expectedSubmittedVariantsUpdateOperationWritten) {
+        assertEquals(expectedClusteredVariantsCreated, clusteringCounts.getClusteredVariantsCreated());
+        assertEquals(expectedClusteredVariantsUpdated, clusteringCounts.getClusteredVariantsUpdated());
+        assertEquals(expectedClusteredVariantsMergeOperationsWritten,
+                clusteringCounts.getClusteredVariantsMergeOperationsWritten());
+        assertEquals(expectedSubmittedVariantsUpdated, clusteringCounts.getSubmittedVariantsUpdated());
+        assertEquals(expectedSubmittedVariantsUpdateOperationWritten,
+                clusteringCounts.getSubmittedVariantsUpdateOperationWritten());
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringVariantStepConfigurationTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringVariantStepConfigurationTest.java
@@ -98,6 +98,7 @@ public class ClusteringVariantStepConfigurationTest {
     @After
     public void tearDown() {
         mongoTemplate.dropCollection(SubmittedVariantEntity.class);
+        mongoTemplate.dropCollection(ClusteredVariantEntity.class);
     }
 
     /**


### PR DESCRIPTION
This PR includes
- Adding the clustering counts to the progress listener so we can log
  - Clustered variants created (new accessions issued)
  - Clustered variants updated (changed the RS accession due to a merge)
  - Clustered variants merge operations
  - Submitted variants updated (RS accession assigned, this means the SS was clustered)
  - Submitted variants update operations
- Fix bug in getOrCreate method hardcoding `false` in the `newAccesion` field
- Tests for the clustering counts

This image shows the result after running the test for the step
![image](https://user-images.githubusercontent.com/30358133/89184292-77321800-d590-11ea-8299-9e4feddd36a8.png)
