### PR TITLE
EVA-2112 Fix eva-accession-release tests

### DIFF
--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/batch/io/AssemblyNameRetriever.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/batch/io/AssemblyNameRetriever.java
@@ -36,14 +36,14 @@ import java.util.stream.Collectors;
 /**
  * Use a curated list and the ENA webservices to return the assembly name associated with an assembly accession.
  *
- * The ENA webservices in URLs like https://www.ebi.ac.uk/ena/data/view/GCA_000001405.28&display=xml
+ * The ENA webservices for URLs like https://www.ebi.ac.uk/ena/browser/api/xml/GCA_000001405.28
  * can return an xml that starts like this:
  * <pre>
  * {@code
  * <?xml version="1.0" encoding="UTF-8"?>
- * <ROOT request="GCA_000001405.28&amp;display=xml">
- * <ASSEMBLY accession="GCA_000001405.28" ...>
- *      <NAME>GRCh38.p13</NAME>
+ *   <ASSEMBLY_SET>
+ *     <ASSEMBLY accession="GCA_000001405.10" alias="GRCh37.p9" center_name="Genome Reference Consortium">
+ *     <NAME>GRCh37.p9</NAME>
  * ...
  * }
  * </pre>
@@ -59,7 +59,7 @@ public class AssemblyNameRetriever {
 
     /**
      * These curated assembly names take priority over ENA assembly names because they are used in specific community
-     * databases, and these are more likely to be known by users than ENA names.
+     * databases, and these are more likely to be known by users than ENA names. See EVA-1644.
      */
     private static final Map<String, String> priorityAssemblyNames = ((Supplier<Map<String, String>>) () -> {
         Map<String, String> priorityNames = new HashMap<>();
@@ -121,16 +121,16 @@ public class AssemblyNameRetriever {
         return String.format(ENA_ASSEMBLY_API_URL_FORMAT_STRING, assemblyAccession);
     }
 
+    public String buildAssemblyHumanReadableUrl() {
+        return String.format(ENA_ASSEMBLY_VIEW_URL_FORMAT_STRING, assemblyAccession);
+    }
+
     public String getAssemblyAccession() {
         return assemblyAccession;
     }
 
     public Optional<String> getAssemblyName() {
         return assemblyName;
-    }
-
-    public String buildAssemblyHumanReadableUrl() {
-        return String.format(ENA_ASSEMBLY_VIEW_URL_FORMAT_STRING, assemblyAccession);
     }
 
     @XmlRootElement(name = "ASSEMBLY_SET")

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/batch/io/VariantContextWriter.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/batch/io/VariantContextWriter.java
@@ -123,7 +123,7 @@ public class VariantContextWriter implements ItemStreamWriter<VariantContext> {
     private String getReferenceAssemblyLine() {
         AssemblyNameRetriever assemblyNameRetriever = new AssemblyNameRetriever(referenceAssembly);
         Optional<String> assemblyName = assemblyNameRetriever.getAssemblyName();
-        String assemblyUrl = assemblyNameRetriever.buildAssemblyUrl();
+        String assemblyUrl = assemblyNameRetriever.buildAssemblyHumanReadableUrl();
 
         if (assemblyName.isPresent()) {
             return "<ID=" + assemblyName.get() + ",accession=" + referenceAssembly + ",URL=" + assemblyUrl + ">";

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/batch/io/AssemblyNameRetrieverTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/batch/io/AssemblyNameRetrieverTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class AssemblyNameRetrieverTest {
 
@@ -72,8 +73,13 @@ public class AssemblyNameRetrieverTest {
     }
 
     @Test
+    public void retrieveAssemblyWithWrongFormat() throws IOException, JAXBException {
+        assertThrows(RuntimeException.class, () -> new AssemblyNameRetriever("GCA_wrong_format"));
+    }
+
+    @Test
     public void retrieveNonExistentAssembly() throws IOException, JAXBException {
-        assertFalse(new AssemblyNameRetriever("GCA_non_existent").getAssemblyName().isPresent());
+        assertFalse(new AssemblyNameRetriever("GCA_000000000.1").getAssemblyName().isPresent());
     }
 
     @Test

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/batch/io/AssemblyNameRetrieverTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/batch/io/AssemblyNameRetrieverTest.java
@@ -42,9 +42,9 @@ public class AssemblyNameRetrieverTest {
     public void parseXml() throws IOException, JAXBException {
         File xml = temporaryFolderRule.newFile();
         FileWriter fileWriter = new FileWriter(xml);
-        fileWriter.write("<ROOT><ASSEMBLY accession=\"GCA_000001405.28\" "
-                         + "center_name=\"Genome Reference Consortium\">"
-                         + "<NAME>GRCh38.p13</NAME></ASSEMBLY></ROOT>");
+        fileWriter.write("<ASSEMBLY_SET><ASSEMBLY accession=\"GCA_000001405.28\">\n" +
+                                 "<NAME>GRCh38.p13</NAME>\n" +
+                                 "</ASSEMBLY></ASSEMBLY_SET>");
         fileWriter.close();
 
         JAXBContext jaxbContext = JAXBContext.newInstance(EnaAssemblyXml.class);
@@ -57,8 +57,7 @@ public class AssemblyNameRetrieverTest {
     public void parseMissingName() throws IOException, JAXBException {
         File xml = temporaryFolderRule.newFile();
         FileWriter fileWriter = new FileWriter(xml);
-        fileWriter.write("<ROOT><ASSEMBLY accession=\"GCA_000001405.28\" "
-                         + "center_name=\"Genome Reference Consortium\"></ASSEMBLY></ROOT>");
+        fileWriter.write("<ASSEMBLY_SET><ASSEMBLY></ASSEMBLY></ASSEMBLY_SET>");
         fileWriter.close();
 
         JAXBContext jaxbContext = JAXBContext.newInstance(EnaAssemblyXml.class);
@@ -83,9 +82,9 @@ public class AssemblyNameRetrieverTest {
     }
 
     @Test
-    public void buildUrl() {
-        assertEquals("https://www.ebi.ac.uk/ena/data/view/GCA_000001405.28",
-                     new AssemblyNameRetriever("GCA_000001405.28").buildAssemblyUrl());
+    public void buildHumanReadableUrl() {
+        assertEquals("https://www.ebi.ac.uk/ena/browser/view/GCA_000001405.28",
+                     new AssemblyNameRetriever("GCA_000001405.28").buildAssemblyHumanReadableUrl());
     }
 
     @Test

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/batch/io/VariantContextWriterTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/batch/io/VariantContextWriterTest.java
@@ -83,7 +83,7 @@ public class VariantContextWriterTest {
 
     private static final String STUDY_2 = "study_2";
 
-    private static final String REFERENCE_ASSEMBLY = "GCA_00000XXX.X";
+    private static final String REFERENCE_ASSEMBLY = "GCA_00000000.1";
 
     private static final int REF_COLUMN = 3;
 
@@ -166,7 +166,7 @@ public class VariantContextWriterTest {
 
         List<String> referenceLines = grepFile(output, "^##reference.*");
         assertEquals(1, referenceLines.size());
-        assertEquals("##reference=<ID=" + REFERENCE_ASSEMBLY + ",URL=https://www.ebi.ac.uk/ena/data/view/"
+        assertEquals("##reference=<ID=" + REFERENCE_ASSEMBLY + ",URL=https://www.ebi.ac.uk/ena/browser/view/"
                      + REFERENCE_ASSEMBLY + ">", referenceLines.get(0));
     }
 


### PR DESCRIPTION
Note that the new code still complies with the idea of using the human readable URLs in the release VCFs, but using the API URLs to retrieve the assembly names.