### PR TITLE
EVA-2115 Fixes to clustering automation

### DIFF
--- a/eva-accession-clustering-automation/cluster_multiple_assemblies.py
+++ b/eva-accession-clustering-automation/cluster_multiple_assemblies.py
@@ -35,7 +35,7 @@ def generate_bsub_command(assembly_accession, properties_path, clustering_artifa
         memory_amount = memory
 
     command = 'bsub -J {job_name} -o {log_file} -e {error_file} -M {memory_amount} -R "rusage[mem={memory_amount}]" ' \
-              'java -jar {clustering_artifact} -Dspring.config.location={properties_path}'\
+              'java -jar {clustering_artifact} --spring.config.location=file:{properties_path}'\
         .format(job_name=job_name, log_file=log_file, error_file=error_file, memory_amount=memory_amount,
                 clustering_artifact=clustering_artifact, properties_path=properties_path)
 


### PR DESCRIPTION
- Change mongo uri for mongo host+port in application.properties
- Fix the bsub command to detect the application.properties file
- Remove some withe spaces in the application.properties that were causing a parse error
- Include the vcf and project accessions params even when the source is mongo because the configuration require them