### PR TITLE
EVA-2174 - Release automation fixes/enhancements

### DIFF
--- a/eva-accession-release-automation/run_release_in_embassy/copy_accessioning_collections_to_embassy.py
+++ b/eva-accession-release-automation/run_release_in_embassy/copy_accessioning_collections_to_embassy.py
@@ -78,16 +78,18 @@ def mongo_data_copy_to_remote_host(local_forwarded_port, private_config_xml_file
 
 
 def copy_accessioning_collections_to_embassy(private_config_xml_file, taxonomy_id, assembly_accession,
-                                             collections_to_copy, release_species_inventory_table, dump_dir):
+                                             collections_to_copy, release_species_inventory_table, release_version,
+                                             dump_dir):
     exit_code = 0
     try:
         port_forwarding_process_id, mongo_port = open_mongo_port_to_tempmongo(private_config_xml_file, taxonomy_id,
-                                                                              release_species_inventory_table)
+                                                                              release_species_inventory_table,
+                                                                              release_version)
         with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file),
                               user="evadev") as \
                 metadata_connection_handle:
             tempmongo_instance = get_target_mongo_instance_for_taxonomy(taxonomy_id, release_species_inventory_table,
-                                                                        metadata_connection_handle)
+                                                                        release_version, metadata_connection_handle)
             logger.info("Beginning data copy to remote MongoDB host {0} on port {1}...".format(tempmongo_instance,
                                                                                                mongo_port))
             mongo_data_copy_to_remote_host(mongo_port, private_config_xml_file,
@@ -110,12 +112,14 @@ def copy_accessioning_collections_to_embassy(private_config_xml_file, taxonomy_i
               required=False)
 @click.option("--release-species-inventory-table", default="dbsnp_ensembl_species.release_species_inventory",
               required=False)
+@click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.option("--dump-dir", help="ex: /path/to/dump", required=True)
 @click.command()
 def main(private_config_xml_file, taxonomy_id, assembly_accession, collections_to_copy, release_species_inventory_table,
-         dump_dir):
+         release_version, dump_dir):
     copy_accessioning_collections_to_embassy(private_config_xml_file, taxonomy_id, assembly_accession,
-                                             collections_to_copy, release_species_inventory_table, dump_dir)
+                                             collections_to_copy, release_species_inventory_table, release_version,
+                                             dump_dir)
 
 
 if __name__ == "__main__":

--- a/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
+++ b/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
@@ -47,6 +47,9 @@ def get_release_properties_for_assembly(private_config_xml_file, taxonomy_id, as
                                                                                       release_species_inventory_table,
                                                                                       release_version,
                                                                                       metadata_connection_handle)
+    if not release_inventory_info_for_assembly["report_path"].startswith("file:"):
+        release_inventory_info_for_assembly["report_path"] = "file:" + \
+                                                             release_inventory_info_for_assembly["report_path"]
     release_inventory_info_for_assembly["output_folder"] = os.path.join(release_folder, assembly_accession)
     release_inventory_info_for_assembly["mongo_accessioning_db"] = "acc_" + assembly_accession.replace('.', '_')
     return merge_two_dicts(release_inventory_info_for_assembly,

--- a/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
+++ b/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
@@ -39,12 +39,13 @@ def get_release_job_repo_properties(private_config_xml_file):
 
 
 def get_release_properties_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession,
-                                        release_species_inventory_table, release_folder):
+                                        release_species_inventory_table, release_version, release_folder):
     with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file),
                           user="evadev") as \
             metadata_connection_handle:
         release_inventory_info_for_assembly = get_release_inventory_info_for_assembly(taxonomy_id, assembly_accession,
                                                                                       release_species_inventory_table,
+                                                                                      release_version,
                                                                                       metadata_connection_handle)
     release_inventory_info_for_assembly["output_folder"] = os.path.join(release_folder, assembly_accession)
     release_inventory_info_for_assembly["mongo_accessioning_db"] = "acc_" + assembly_accession.replace('.', '_')
@@ -53,12 +54,14 @@ def get_release_properties_for_assembly(private_config_xml_file, taxonomy_id, as
 
 
 def create_release_properties_file_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession,
-                                                release_species_inventory_table, release_folder, job_repo_url):
+                                                release_species_inventory_table, release_version, release_folder,
+                                                job_repo_url):
     assembly_release_folder = os.path.join(release_folder, assembly_accession)
     os.makedirs(assembly_release_folder, exist_ok=True)
     output_file = "{0}/{1}_release.properties".format(assembly_release_folder, assembly_accession)
     release_properties = get_release_properties_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession,
-                                                             release_species_inventory_table, release_folder)
+                                                             release_species_inventory_table, release_version,
+                                                             release_folder)
     # TODO: Production Spring Job repository URL won't be used for Release 2
     #  since it hasn't been upgraded to support Spring Boot 2 metadata schema. Therefore a separate job repository
     #  has been created (with similar credentials)  and passed in through the job_repo_url parameter.
@@ -110,10 +113,11 @@ def create_release_properties_file_for_assembly(private_config_xml_file, taxonom
 @click.option("--release-folder", required=True)
 @click.option("--job-repo-url", required=True)
 @click.command()
-def main(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table, release_folder,
-         job_repo_url):
+def main(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
+         release_folder, job_repo_url):
     create_release_properties_file_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession,
-                                                release_species_inventory_table, release_folder, job_repo_url)
+                                                release_species_inventory_table, release_version, release_folder,
+                                                job_repo_url)
 
 
 if __name__ == "__main__":

--- a/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
+++ b/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
@@ -110,6 +110,7 @@ def create_release_properties_file_for_assembly(private_config_xml_file, taxonom
 @click.option("--assembly-accession", help="ex: GCA_000003055.6", required=True)
 @click.option("--release-species-inventory-table", default="dbsnp_ensembl_species.release_species_inventory",
               required=False)
+@click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.option("--release-folder", required=True)
 @click.option("--job-repo-url", required=True)
 @click.command()

--- a/eva-accession-release-automation/run_release_in_embassy/merge_dbsnp_eva_release_files.py
+++ b/eva-accession-release-automation/run_release_in_embassy/merge_dbsnp_eva_release_files.py
@@ -63,10 +63,9 @@ def merge_dbsnp_eva_vcf_headers(file1, file2, output_file):
                                                               ("contig", None), ("reference", None)])
     for category in metainfo_category_tempfile_map.keys():
         metainfo_category_tempfile_map[category] = open(tempfile.mktemp(prefix=category, dir=working_folder), "a+")
-    with gzip.open(file1) as file1_handle, gzip.open(file2) as file2_handle:
+    with open(file1) as file1_handle, open(file2) as file2_handle:
         for file_handle in [file1_handle, file2_handle]:
-            for line_bytes in file_handle:
-                line = line_bytes.decode("utf-8")
+            for line in file_handle:
                 if line.startswith("##"):
                     metainfo_category = line.split("=")[0].split("##")[-1].lower()
                     metainfo_category_tempfile_map[metainfo_category].write(line)
@@ -104,12 +103,11 @@ def merge_dbsnp_eva_vcf_files(bgzip_path, tabix_path, bcftools_path, vcf_sort_sc
                         .format(vcf_file_category))
     file_prefixes = set([os.path.basename(filename).split("_")[0].lower() for filename in files_in_category])
     if "eva" in file_prefixes and "dbsnp" in file_prefixes:
+        merge_dbsnp_eva_vcf_headers(files_in_category[0], files_in_category[1], unsorted_release_file_path)
         # Merge commands require input VCF files to be sorted, bgzipped and tabixed!!
         vcf_merge_commands.extend(
             get_bgzip_and_tabix_commands(bgzip_path, tabix_path, vcf_sort_script_path, files_in_category))
         sorted_file_names = [name.replace("_unsorted", "") for name in files_in_category]
-        merge_dbsnp_eva_vcf_headers(sorted_file_names[0] + ".gz", sorted_file_names[1] + ".gz",
-                                    unsorted_release_file_path)
         vcf_merge_commands.append(
             "(({0} merge --no-version -O v {1}.gz {2}.gz | grep -v ^##) >> {3})".format(bcftools_path,
                                                                                         sorted_file_names[0],

--- a/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
@@ -25,7 +25,8 @@ from ebi_eva_common_pyutils.network_utils import get_available_local_port, forwa
 logger = logging.getLogger(__name__)
 
 
-def open_mongo_port_to_tempmongo(private_config_xml_file, taxonomy_id, release_species_inventory_table):
+def open_mongo_port_to_tempmongo(private_config_xml_file, taxonomy_id, release_species_inventory_table,
+                                 release_version):
     MONGO_PORT = 27017
     local_forwarded_port = get_available_local_port(MONGO_PORT)
     try:
@@ -33,7 +34,7 @@ def open_mongo_port_to_tempmongo(private_config_xml_file, taxonomy_id, release_s
                               user="evadev") as \
                 metadata_connection_handle:
             tempmongo_instance = get_target_mongo_instance_for_taxonomy(taxonomy_id, release_species_inventory_table,
-                                                                        metadata_connection_handle)
+                                                                        release_version, metadata_connection_handle)
             logger.info("Forwarding remote MongoDB port 27017 to local port {0}...".format(local_forwarded_port))
             port_forwarding_process_id = forward_remote_port_to_local_port(tempmongo_instance, MONGO_PORT,
                                                                            local_forwarded_port)

--- a/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
@@ -46,11 +46,13 @@ def get_assemblies_to_import_for_dbsnp_species(metadata_connection_handle, dbsnp
     return []
 
 
-def get_target_mongo_instance_for_taxonomy(taxonomy_id, release_species_inventory_table,
+def get_target_mongo_instance_for_taxonomy(taxonomy_id, release_species_inventory_table, release_version,
                                            metadata_connection_handle):
     results = get_all_results_for_query(metadata_connection_handle, "select distinct tempmongo_instance from {0} "
-                                                                    "where taxonomy_id = '{1}'"
-                                        .format(release_species_inventory_table, taxonomy_id))
+                                                                    "where taxonomy_id = '{1}' "
+                                                                    "and release_version = {2} "
+                                                                    "and should_be_processed"
+                                        .format(release_species_inventory_table, taxonomy_id, release_version))
     if len(results) == 0:
         raise Exception("Could not find target Mongo instance in Embassy for taxonomy ID: " + taxonomy_id)
     if len(results) > 1:
@@ -60,22 +62,25 @@ def get_target_mongo_instance_for_taxonomy(taxonomy_id, release_species_inventor
 
 
 def get_release_assemblies_for_taxonomy(taxonomy_id, release_species_inventory_table,
-                                        metadata_connection_handle):
+                                        release_version, metadata_connection_handle):
     results = get_all_results_for_query(metadata_connection_handle, "select assembly from {0} "
-                                                                    "where taxonomy_id = '{1}'"
-                                        .format(release_species_inventory_table, taxonomy_id))
+                                                                    "where taxonomy_id = '{1}' "
+                                                                    "and release_version = {2} and should_be_processed"
+                                        .format(release_species_inventory_table, taxonomy_id, release_version))
     if len(results) == 0:
         raise Exception("Could not find assemblies pertaining to taxonomy ID: " + taxonomy_id)
     return [result[0] for result in results]
 
 
 def get_release_inventory_info_for_assembly(taxonomy_id, assembly_accession, release_species_inventory_table,
-                                            metadata_connection_handle):
+                                            release_version, metadata_connection_handle):
     results = get_all_results_for_query(metadata_connection_handle, "select row_to_json(row) from "
                                                                     "(select * from {0} where "
                                                                     "taxonomy_id = '{1}' and "
-                                                                    "assembly = '{2}') row"
-                                        .format(release_species_inventory_table, taxonomy_id, assembly_accession))
+                                                                    "assembly = '{2}' and release_version = {3} "
+                                                                    "and should_be_processed) row"
+                                        .format(release_species_inventory_table, taxonomy_id, assembly_accession,
+                                                release_version))
     if len(results) == 0:
         raise Exception("Could not find release inventory pertaining to taxonomy ID: {0} and assembly: {1} "
                         .format(taxonomy_id, assembly_accession))

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_assembly.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_assembly.py
@@ -26,11 +26,12 @@ logger = logging.getLogger(__name__)
 
 
 def run_release_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table,
-                             release_folder, release_jar_path, job_repo_url, memory):
+                             release_version, release_folder, release_jar_path, job_repo_url, memory):
     exit_code = 0
     try:
         port_forwarding_process_id, mongo_port = open_mongo_port_to_tempmongo(private_config_xml_file, taxonomy_id,
-                                                                              release_species_inventory_table)
+                                                                              release_species_inventory_table,
+                                                                              release_version)
         release_properties_file = create_release_properties_file_for_assembly(private_config_xml_file, taxonomy_id,
                                                                               assembly_accession,
                                                                               release_species_inventory_table,
@@ -53,6 +54,7 @@ def run_release_for_assembly(private_config_xml_file, taxonomy_id, assembly_acce
 @click.option("--assembly-accession", help="ex: GCA_000003055.6", required=True)
 @click.option("--release-species-inventory-table", default="dbsnp_ensembl_species.release_species_inventory",
               required=False)
+@click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.option("--release-folder", required=True)
 @click.option("--release-jar-path", required=True)
 # TODO: Production Spring Job repository URL won't be used for Release 2
@@ -62,10 +64,10 @@ def run_release_for_assembly(private_config_xml_file, taxonomy_id, assembly_acce
 @click.option("--job-repo-url", required=True)
 @click.option("--memory",  help="Memory in GB. ex: 8", default=8, type=int, required=False)
 @click.command()
-def main(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table, release_folder,
-         release_jar_path, job_repo_url, memory):
+def main(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
+         release_folder, release_jar_path, job_repo_url, memory):
     run_release_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table,
-                             release_folder, release_jar_path, job_repo_url, memory)
+                             release_version, release_folder, release_jar_path, job_repo_url, memory)
 
 
 if __name__ == "__main__":

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_assembly.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_assembly.py
@@ -35,7 +35,8 @@ def run_release_for_assembly(private_config_xml_file, taxonomy_id, assembly_acce
         release_properties_file = create_release_properties_file_for_assembly(private_config_xml_file, taxonomy_id,
                                                                               assembly_accession,
                                                                               release_species_inventory_table,
-                                                                              release_folder, job_repo_url)
+                                                                              release_version, release_folder,
+                                                                              job_repo_url)
         release_command = 'java -Xmx{0}g -jar {1} --spring.config.location="{2}" -Dspring.data.mongodb.port={3}'\
             .format(memory, release_jar_path, release_properties_file, mongo_port)
         run_command_with_output("Running release pipeline for assembly: " + assembly_accession, release_command)

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
@@ -44,7 +44,8 @@ workflow_process_arguments_map = collections.OrderedDict(
                                      "assembly-accession", "release-species-inventory-table",
                                      "release-folder",
                                      "vcf-validator-path", "assembly-checker-path"]),
-     ("count_rs_ids_in_release_files", ["count-ids-script-path", "assembly-accession", "release-folder"])
+     ("count_rs_ids_in_release_files", ["count-ids-script-path", "assembly-accession", "release-folder"]),
+     ("update_release_status_for_assembly", ["taxonomy-id", "assembly-accession", "release-version"])
      ])
 
 workflow_process_template_for_nextflow = """

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
@@ -45,7 +45,8 @@ workflow_process_arguments_map = collections.OrderedDict(
                                      "release-folder",
                                      "vcf-validator-path", "assembly-checker-path"]),
      ("count_rs_ids_in_release_files", ["count-ids-script-path", "assembly-accession", "release-folder"]),
-     ("update_release_status_for_assembly", ["taxonomy-id", "assembly-accession", "release-version"])
+     ("update_release_status_for_assembly", ["private-config-xml-file", "taxonomy-id", "assembly-accession",
+                                             "release-version"])
      ])
 
 workflow_process_template_for_nextflow = """

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
@@ -30,10 +30,10 @@ timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 # Processes, in order, that make up the workflow and the arguments that they take
 workflow_process_arguments_map = collections.OrderedDict(
     [("copy_accessioning_collections_to_embassy", ["private-config-xml-file", "taxonomy-id", "assembly-accession",
-                                                   "release-species-inventory-table", "dump-dir"]),
+                                                   "release-species-inventory-table", "release-version", "dump-dir"]),
      ("run_release_for_assembly", ["private-config-xml-file", "taxonomy-id",
                                    "assembly-accession", "release-species-inventory-table",
-                                   "release-folder", "release-jar-path", "job-repo-url", "memory"]),
+                                   "release-version", "release-folder", "release-jar-path", "job-repo-url", "memory"]),
      ("merge_dbsnp_eva_release_files", ["bgzip-path", "tabix-path", "bcftools-path",
                                         "vcf-sort-script-path", "assembly-accession",
                                         "release-folder"]),
@@ -41,7 +41,7 @@ workflow_process_arguments_map = collections.OrderedDict(
                                          "vcf-sort-script-path", "assembly-accession",
                                          "release-folder"]),
      ("validate_release_vcf_files", ["private-config-xml-file", "taxonomy-id",
-                                     "assembly-accession", "release-species-inventory-table",
+                                     "assembly-accession", "release-species-inventory-table", "release-version",
                                      "release-folder",
                                      "vcf-validator-path", "assembly-checker-path"]),
      ("count_rs_ids_in_release_files", ["count-ids-script-path", "assembly-accession", "release-folder"]),
@@ -126,10 +126,11 @@ def run_release_for_species(common_release_properties_file, taxonomy_id, memory)
     common_release_properties = get_common_release_properties(common_release_properties_file)
     private_config_xml_file = common_release_properties["private-config-xml-file"]
     release_species_inventory_table = common_release_properties["release-species-inventory-table"]
+    release_version = common_release_properties["release-version"]
     with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file), user="evadev") \
         as metadata_connection_handle:
         release_assemblies = get_release_assemblies_for_taxonomy(taxonomy_id, release_species_inventory_table,
-                                                                 metadata_connection_handle)
+                                                                 release_version, metadata_connection_handle)
         release_assembly_workflow_files = [prepare_release_workflow_file_for_assembly(common_release_properties,
                                                                                       taxonomy_id, assembly_accession,
                                                                                       memory)

--- a/eva-accession-release-automation/run_release_in_embassy/update_release_status_for_assembly.py
+++ b/eva-accession-release-automation/run_release_in_embassy/update_release_status_for_assembly.py
@@ -1,0 +1,46 @@
+# Copyright 2020 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+import logging
+import psycopg2
+
+
+from run_release_in_embassy.release_metadata import update_release_progress_status, release_progress_table
+from ebi_eva_common_pyutils.config_utils import get_pg_metadata_uri_for_eva_profile
+
+
+logger = logging.getLogger(__name__)
+
+
+def update_release_status_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession, release_version):
+    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file),
+                          user = "evadev") as metadata_connection_handle:
+        update_release_progress_status(metadata_connection_handle, taxonomy_id, assembly_accession, release_version,
+                                       release_status='done')
+        logger.info("Successfully marked release status as 'Done' in {0} for taxonomy {1} and assembly {2}"
+                    .format(release_progress_table, taxonomy_id, assembly_accession))
+
+
+@click.option("--private-config-xml-file", help="ex: /path/to/eva-maven-settings.xml", required=True)
+@click.option("--taxonomy-id", help="ex: 9913", required=True)
+@click.option("--assembly-accession", help="ex: GCA_000003055.6", required=True)
+@click.option("--release-version", help="ex: 2", type=int, required=True)
+@click.command()
+def main(private_config_xml_file, taxonomy_id, assembly_accession, release_version):
+    update_release_status_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession, release_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/eva-accession-release-automation/run_release_in_embassy/validate_release_vcf_files.py
+++ b/eva-accession-release-automation/run_release_in_embassy/validate_release_vcf_files.py
@@ -24,7 +24,7 @@ from ebi_eva_common_pyutils.config_utils import get_pg_metadata_uri_for_eva_prof
 
 
 def validate_release_vcf_files(private_config_xml_file, taxonomy_id, assembly_accession,
-                               release_species_inventory_table, release_folder, vcf_validator_path,
+                               release_species_inventory_table, release_version, release_folder, vcf_validator_path,
                                assembly_checker_path):
     validate_release_vcf_files_commands = []
     with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file),
@@ -32,6 +32,7 @@ def validate_release_vcf_files(private_config_xml_file, taxonomy_id, assembly_ac
             metadata_connection_handle:
         release_inventory_info_for_assembly = get_release_inventory_info_for_assembly(taxonomy_id, assembly_accession,
                                                                                       release_species_inventory_table,
+                                                                                      release_version,
                                                                                       metadata_connection_handle)
         fasta_path = release_inventory_info_for_assembly["fasta_path"]
         assembly_report_path = release_inventory_info_for_assembly["report_path"]
@@ -60,14 +61,15 @@ def validate_release_vcf_files(private_config_xml_file, taxonomy_id, assembly_ac
 @click.option("--assembly-accession", help="ex: GCA_000003055.6", required=True)
 @click.option("--release-species-inventory-table", default="dbsnp_ensembl_species.release_species_inventory",
               required=False)
+@click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.option("--release-folder", required=True)
 @click.option("--vcf-validator-path", help="/path/to/vcf/validator/binary", required=True)
 @click.option("--assembly-checker-path", help="/path/to/assembly/checker/binary", required=True)
 @click.command()
-def main(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table, release_folder,
-         vcf_validator_path, assembly_checker_path):
+def main(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
+         release_folder, vcf_validator_path, assembly_checker_path):
     validate_release_vcf_files(private_config_xml_file, taxonomy_id, assembly_accession,
-                               release_species_inventory_table, release_folder, vcf_validator_path,
+                               release_species_inventory_table, release_version, release_folder, vcf_validator_path,
                                assembly_checker_path)
 
 


### PR DESCRIPTION
* bcftools merge produces the following output -   weirdness with the contig names order in the header - ![Pasted image](https://dynalist.io/u/zzOMPDeaIl0oFskGwgBVkh5w)
	* Ensure that the contigs line up in the merged file - addressed by adding a separate [function](https://github.com/sundarvenkata-EBI/eva-accession/commit/17466e7e7d589bdaa67a14ddd8f3114e2f3bd6eb#diff-00849c43c1cf839f5439988977aa7cbdR56) to merge headers
	* Ensure that the internal details about the merge command does not appear in the merged file - addressed in [this commit](https://github.com/sundarvenkata-EBI/eva-accession/commit/17466e7e7d589bdaa67a14ddd8f3114e2f3bd6eb#diff-00849c43c1cf839f5439988977aa7cbdR114) by adding a **--no-version** switch to the merge commands

