### PR TITLE
EVA-2463: Fixes from end-to-end testing

### DIFF
--- a/eva-accession-clustering-automation/README.md
+++ b/eva-accession-clustering-automation/README.md
@@ -13,6 +13,7 @@ The clustering automation script have the following parameters:
 * **private-config-xml-file\*:** Maven settings.xml file with the profiles that hold database connection data
 * **profile\*:** Profile to run the pipeline. e.g. production
 * **output-directory:** Directory where the generated files will be stored
+* **logs-directory:** Directory where the logs will be stored
 * **clustering-artifact\*:** Clustering artifact path is the latest version of the clustering pipeline
 * **only-printing:** Is a flag to only get the commands but not run them
 * **memory:** Amount of memory to use when running the clustering jobs
@@ -21,12 +22,12 @@ The clustering automation script have the following parameters:
 ## Examples
 * Example using Mongo as source
     ```bash
-    python3 path/to/eva-accession/eva-accession-clustering-automation/cluster_multiple_assemblies.py --source MONGO --assembly-list GCA_000233375.4 GCA_000002285.2 --output-directory /output/clustering_automation --only-printing --clustering-artifact cluster.jar --profile production --private-config-xml-file /configuration/eva-maven-settings.xml     
+    python3 path/to/eva-accession/eva-accession-clustering-automation/cluster_multiple_assemblies.py --source MONGO --assembly-list GCA_000233375.4 GCA_000002285.2 --output-directory /output/clustering_automation --logs-directory /output/logs --only-printing --clustering-artifact cluster.jar --profile production --private-config-xml-file /configuration/eva-maven-settings.xml
     ```
 
 * Example using VCF as source
     ```bash
-    python3 path/to/eva-accession/eva-accession-clustering-automation/cluster_multiple_assemblies.py --source VCF --asm-vcf-prj-list GCA_000233375.4#/nfs/eva/accessioned.vcf.gz#PRJEB1111 GCA_000002285.2#/nfs/eva/file.vcf.gz#PRJEB2222 --output-directory /output/clustering_automation --only-printing --clustering-artifact cluster.jar --profile production --private-config-xml-file /configuration/eva-maven-settings.xml 
+    python3 path/to/eva-accession/eva-accession-clustering-automation/cluster_multiple_assemblies.py --source VCF --asm-vcf-prj-list GCA_000233375.4#/nfs/eva/accessioned.vcf.gz#PRJEB1111 GCA_000002285.2#/nfs/eva/file.vcf.gz#PRJEB2222 --output-directory /output/clustering_automation --logs-directory /output/logs --only-printing --clustering-artifact cluster.jar --profile production --private-config-xml-file /configuration/eva-maven-settings.xml
     ```
   
 

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/runner/ClusteringCommandLineRunner.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/runner/ClusteringCommandLineRunner.java
@@ -117,7 +117,7 @@ public class ClusteringCommandLineRunner extends JobLauncherCommandLineRunner im
             if (inputParameters.isForceRestart()) {
                 JobExecution previousJobExecution = CommandLineRunnerUtils.getLastJobExecution(jobName, jobExplorer,
                                                                                                jobParameters);
-                markPreviousJobAsFailed(
+                CommandLineRunnerUtils.markPreviousJobAsFailed(jobName, jobRepository,
                         previousJobExecution != null ? previousJobExecution.getJobParameters() : jobParameters);
             }
             else {
@@ -151,11 +151,5 @@ public class ClusteringCommandLineRunner extends JobLauncherCommandLineRunner im
             JobParametersNotFoundException {
         logger.info("Running job '" + jobName + "' with parameters: " + jobParameters);
         super.execute(job, jobParameters);
-    }
-
-    private void markPreviousJobAsFailed(JobParameters jobParameters) throws
-            NoPreviousJobExecutionException {
-        logger.info("Force restartPreviousExecution of job '" + jobName + "' with parameters: " + jobParameters);
-        JobStatusManager.markLastJobAsFailed(jobRepository, jobName, jobParameters);
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/runner/ClusteringCommandLineRunnerTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/runner/ClusteringCommandLineRunnerTest.java
@@ -217,7 +217,7 @@ public class ClusteringCommandLineRunnerTest {
         assertEquals(Collections.EMPTY_LIST, jobExplorer.getJobNames());
         runner.run();
 
-        assertEquals(ClusteringCommandLineRunner.EXIT_WITH_ERRORS, runner.getExitCode());
+        assertEquals(ClusteringCommandLineRunner.EXIT_WITHOUT_ERRORS, runner.getExitCode());
     }
 
     @Test

--- a/eva-accession-core/pom.xml
+++ b/eva-accession-core/pom.xml
@@ -17,6 +17,10 @@
             <artifactId>variation-commons-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>variation-commons-batch</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-batch</artifactId>
         </dependency>

--- a/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/runner/DbsnpJsonImportVariantsJobLauncherCommandLineRunner.java
+++ b/eva-accession-import-dbsnp2/src/main/java/uk/ac/ebi/eva/accession/dbsnp2/runner/DbsnpJsonImportVariantsJobLauncherCommandLineRunner.java
@@ -120,7 +120,7 @@ public class DbsnpJsonImportVariantsJobLauncherCommandLineRunner extends JobLaun
             if (inputParameters.isForceRestart()) {
                 JobExecution previousJobExecution = CommandLineRunnerUtils.getLastJobExecution(jobName, jobExplorer,
                                                                                                jobParameters);
-                markPreviousJobAsFailed(
+                CommandLineRunnerUtils.markPreviousJobAsFailed(jobName, jobRepository,
                         previousJobExecution != null ? previousJobExecution.getJobParameters() : jobParameters);
             }
             else {
@@ -151,11 +151,5 @@ public class DbsnpJsonImportVariantsJobLauncherCommandLineRunner extends JobLaun
             JobParametersNotFoundException {
         logger.info("Running job '" + jobName + "' with parameters: " + jobParameters);
         super.execute(job, jobParameters);
-    }
-
-    private void markPreviousJobAsFailed(JobParameters jobParameters) throws
-            NoPreviousJobExecutionException {
-        logger.info("Force restartPreviousExecution of job '" + jobName + "' with parameters: " + jobParameters);
-        JobStatusManager.markLastJobAsFailed(jobRepository, jobName, jobParameters);
     }
 }

--- a/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/runner/DbsnpJsonImportVariantsJobLauncherCommandLineRunnerTest.java
+++ b/eva-accession-import-dbsnp2/src/test/java/uk/ac/ebi/eva/accession/dbsnp2/runner/DbsnpJsonImportVariantsJobLauncherCommandLineRunnerTest.java
@@ -187,7 +187,7 @@ public class DbsnpJsonImportVariantsJobLauncherCommandLineRunnerTest {
         assertEquals(Collections.EMPTY_LIST, jobExplorer.getJobNames());
         runner.run();
 
-        assertEquals(EXIT_WITH_ERRORS, runner.getExitCode());
+        assertEquals(EXIT_WITHOUT_ERRORS, runner.getExitCode());
     }
 
     @Test

--- a/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/runner/DbsnpImportVariantsJobLauncherCommandLineRunner.java
+++ b/eva-accession-import/src/main/java/uk/ac/ebi/eva/accession/dbsnp/runner/DbsnpImportVariantsJobLauncherCommandLineRunner.java
@@ -119,7 +119,7 @@ public class DbsnpImportVariantsJobLauncherCommandLineRunner extends JobLauncher
                 JobExecution previousJobExecution =
                         CommandLineRunnerUtils.getLastJobExecution(jobName, jobExplorer,
                                                                    jobParameters);
-                markPreviousJobAsFailed(
+                CommandLineRunnerUtils.markPreviousJobAsFailed(jobName, jobRepository,
                         previousJobExecution != null ? previousJobExecution.getJobParameters() : jobParameters);
             }
             else {
@@ -154,11 +154,5 @@ public class DbsnpImportVariantsJobLauncherCommandLineRunner extends JobLauncher
             JobParametersNotFoundException {
         logger.info("Running job '" + jobName + "' with parameters: " + jobParameters);
         super.execute(job, jobParameters);
-    }
-
-    private void markPreviousJobAsFailed(JobParameters jobParameters) throws
-            NoPreviousJobExecutionException {
-        logger.info("Force restartPreviousExecution of job '" + jobName + "' with parameters: " + jobParameters);
-        JobStatusManager.markLastJobAsFailed(jobRepository, jobName, jobParameters);
     }
 }

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/runner/EvaAccessionJobLauncherCommandLineRunner.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/runner/EvaAccessionJobLauncherCommandLineRunner.java
@@ -125,7 +125,7 @@ public class EvaAccessionJobLauncherCommandLineRunner extends JobLauncherCommand
             if (inputParameters.isForceRestart()) {
                 JobExecution previousJobExecution = CommandLineRunnerUtils.getLastJobExecution(jobName, jobExplorer,
                                                                                                jobParameters);
-                markPreviousJobAsFailed(
+                CommandLineRunnerUtils.markPreviousJobAsFailed(jobName, jobRepository,
                         previousJobExecution != null ? previousJobExecution.getJobParameters() : jobParameters);
             }
             else {
@@ -159,11 +159,5 @@ public class EvaAccessionJobLauncherCommandLineRunner extends JobLauncherCommand
             JobParametersNotFoundException {
         logger.info("Running job '" + jobName + "' with parameters: " + jobParameters);
         super.execute(job, jobParameters);
-    }
-
-    private void markPreviousJobAsFailed(JobParameters jobParameters) throws
-            NoPreviousJobExecutionException {
-        logger.info("Force restartPreviousExecution of job '" + jobName + "' with parameters: " + jobParameters);
-        JobStatusManager.markLastJobAsFailed(jobRepository, jobName, jobParameters);
     }
 }

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/runner/EvaAccessionJobLauncherCommandLineRunnerTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/runner/EvaAccessionJobLauncherCommandLineRunnerTest.java
@@ -208,7 +208,7 @@ public class EvaAccessionJobLauncherCommandLineRunnerTest {
         assertEquals(Collections.EMPTY_LIST, jobExplorer.getJobNames());
         runner.run();
 
-        assertEquals(EvaAccessionJobLauncherCommandLineRunner.EXIT_WITH_ERRORS, runner.getExitCode());
+        assertEquals(EvaAccessionJobLauncherCommandLineRunner.EXIT_WITHOUT_ERRORS, runner.getExitCode());
     }
 
     @Test

--- a/eva-accession-release-automation/.gitignore
+++ b/eva-accession-release-automation/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+*.egg*

--- a/eva-accession-release-automation/README.md
+++ b/eva-accession-release-automation/README.md
@@ -26,7 +26,6 @@ release-species-inventory-table:
 release-progress-table:
 
 release-jar-path:
-job-repo-url:
 
 bgzip-path:
 tabix-path:

--- a/eva-accession-release-automation/README.md
+++ b/eva-accession-release-automation/README.md
@@ -1,0 +1,42 @@
+# Pre-requisites
+Install release automation python module and dependencies:
+```bash
+pip install -e /path/to/eva-accession/eva-accession-release-automation
+```
+
+
+# Usage
+The release automation script `run_release_for_species.py` has the following parameters:
+* **common-release-properties-file:** Path to yaml config file, see below
+* **taxonomy-id:** Taxonomy to release
+* **memory:** Amount of memory to use when running the release jobs
+
+You also need to set `PYTHONPATH=/path/to/eva-accession/eva-accession-release-automation/run_release_in_embassy`.
+
+
+## Config template
+```yaml
+private-config-xml-file:
+profile:
+
+release-version:
+release-folder:
+public-ftp-release-base-folder:
+release-species-inventory-table:
+release-progress-table:
+
+release-jar-path:
+job-repo-url:
+
+bgzip-path:
+tabix-path:
+bcftools-path:
+vcf-sort-script-path:
+vcf-validator-path:
+assembly-checker-path:
+count-ids-script-path:
+python3-path:
+
+nextflow-binary-path:
+nextflow-config-path:
+```

--- a/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
+++ b/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
@@ -73,7 +73,7 @@ def create_release_properties_file_for_assembly(private_config_xml_file, profile
         parameters.assemblyReportUrl={report_path}
         parameters.chunkSize=1000
         parameters.fasta={fasta_path}
-        parameters.forceRestart=false
+        parameters.forceRestart=true
         parameters.outputFolder={output_folder}
         
         # job repository datasource

--- a/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
+++ b/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
@@ -66,7 +66,6 @@ def create_release_properties_file_for_assembly(private_config_xml_file, profile
     release_properties = get_release_properties_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession,
                                                              release_species_inventory_table, release_version,
                                                              species_release_folder)
-    # TODO forceRestart should be true once no previous job exception is handled appropriately by pipeline
     properties_string = """
         spring.batch.job.names=ACCESSION_RELEASE_JOB
         parameters.assemblyAccession={assembly}

--- a/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
+++ b/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
@@ -66,6 +66,7 @@ def create_release_properties_file_for_assembly(private_config_xml_file, profile
     release_properties = get_release_properties_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession,
                                                              release_species_inventory_table, release_version,
                                                              species_release_folder)
+    # TODO forceRestart should be true once no previous job exception is handled appropriately by pipeline
     properties_string = """
         spring.batch.job.names=ACCESSION_RELEASE_JOB
         parameters.assemblyAccession={assembly}

--- a/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
+++ b/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
@@ -72,7 +72,7 @@ def create_release_properties_file_for_assembly(private_config_xml_file, profile
         parameters.assemblyReportUrl={report_path}
         parameters.chunkSize=1000
         parameters.fasta={fasta_path}
-        parameters.forceRestart=true
+        parameters.forceRestart=false
         parameters.outputFolder={output_folder}
         
         # job repository datasource

--- a/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
+++ b/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
@@ -59,19 +59,13 @@ def get_release_properties_for_assembly(private_config_xml_file, profile, taxono
 
 def create_release_properties_file_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession,
                                                 release_species_inventory_table, release_version,
-                                                species_release_folder, job_repo_url):
+                                                species_release_folder):
     assembly_species_release_folder = os.path.join(species_release_folder, assembly_accession)
     os.makedirs(assembly_species_release_folder, exist_ok=True)
     output_file = "{0}/{1}_release.properties".format(assembly_species_release_folder, assembly_accession)
     release_properties = get_release_properties_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession,
                                                              release_species_inventory_table, release_version,
                                                              species_release_folder)
-    # TODO: Production Spring Job repository URL won't be used for Release 2
-    #  since it hasn't been upgraded to support Spring Boot 2 metadata schema. Therefore a separate job repository
-    #  has been created (with similar credentials)  and passed in through the job_repo_url parameter.
-    #  The following line + job_repo_url parameter should be removed after the
-    #  production upgrade to the Spring Boot 2 metadata schema
-    release_properties["job_repo_url"] = job_repo_url
     properties_string = """
         spring.batch.job.names=ACCESSION_RELEASE_JOB
         parameters.assemblyAccession={assembly}
@@ -117,13 +111,12 @@ def create_release_properties_file_for_assembly(private_config_xml_file, profile
               required=False)
 @click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.option("--species-release-folder", required=True)
-@click.option("--job-repo-url", required=True)
 @click.command()
-def main(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
-         species_release_folder, job_repo_url):
+def main(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table,
+         release_version, species_release_folder):
     create_release_properties_file_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession,
                                                 release_species_inventory_table, release_version,
-                                                species_release_folder, job_repo_url)
+                                                species_release_folder)
 
 
 if __name__ == "__main__":

--- a/eva-accession-release-automation/run_release_in_embassy/merge_dbsnp_eva_release_files.py
+++ b/eva-accession-release-automation/run_release_in_embassy/merge_dbsnp_eva_release_files.py
@@ -169,10 +169,10 @@ def merge_dbsnp_eva_text_files(assembly_accession, species_release_folder, text_
     return text_release_file_merge_commands
 
 
-def merge_dbsnp_eva_release_files(private_config_xml_file, bgzip_path, tabix_path, bcftools_path, vcf_sort_script_path,
+def merge_dbsnp_eva_release_files(private_config_xml_file, profile, bgzip_path, tabix_path, bcftools_path, vcf_sort_script_path,
                                   taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
                                   species_release_folder):
-    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file), user="evadev") \
+    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile(profile, private_config_xml_file), user="evadev") \
         as metadata_connection_handle:
         release_info = get_release_inventory_info_for_assembly(taxonomy_id, assembly_accession,
                                                                release_species_inventory_table,
@@ -191,6 +191,7 @@ def merge_dbsnp_eva_release_files(private_config_xml_file, bgzip_path, tabix_pat
 
 
 @click.option("--private-config-xml-file", help="ex: /path/to/eva-maven-settings.xml", required=True)
+@click.option("--profile", help="Maven profile to use, ex: internal", required=True)
 @click.option("--bgzip-path", help="ex: /path/to/bgzip/binary", required=True)
 @click.option("--tabix-path", help="ex: /path/to/tabix/binary", required=True)
 @click.option("--bcftools-path", help="ex: /path/to/vcftools/binary", required=True)
@@ -202,9 +203,9 @@ def merge_dbsnp_eva_release_files(private_config_xml_file, bgzip_path, tabix_pat
 @click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.option("--species-release-folder", required=True)
 @click.command()
-def main(private_config_xml_file, bgzip_path, tabix_path, bcftools_path, vcf_sort_script_path, taxonomy_id,
+def main(private_config_xml_file, profile, bgzip_path, tabix_path, bcftools_path, vcf_sort_script_path, taxonomy_id,
          assembly_accession, release_species_inventory_table, release_version, species_release_folder):
-    merge_dbsnp_eva_release_files(private_config_xml_file, bgzip_path, tabix_path, bcftools_path, vcf_sort_script_path,
+    merge_dbsnp_eva_release_files(private_config_xml_file, profile, bgzip_path, tabix_path, bcftools_path, vcf_sort_script_path,
                                   taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
                                   species_release_folder)
 

--- a/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
@@ -26,12 +26,12 @@ from ebi_eva_common_pyutils.taxonomy import taxonomy
 logger = logging.getLogger(__name__)
 
 
-def open_mongo_port_to_tempmongo(private_config_xml_file, taxonomy_id, release_species_inventory_table,
+def open_mongo_port_to_tempmongo(private_config_xml_file, profile, taxonomy_id, release_species_inventory_table,
                                  release_version):
     MONGO_PORT = 27017
     local_forwarded_port = get_available_local_port(MONGO_PORT)
     try:
-        with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file),
+        with psycopg2.connect(get_pg_metadata_uri_for_eva_profile(profile, private_config_xml_file),
                               user="evadev") as \
                 metadata_connection_handle:
             tempmongo_instance = get_target_mongo_instance_for_taxonomy(taxonomy_id, release_species_inventory_table,

--- a/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
@@ -19,11 +19,9 @@ release_text_file_categories = ["deprecated_ids", "merged_deprecated_ids"]
 vcf_validation_output_file_pattern = "*.vcf.errors_summary.*"
 asm_report_output_file_pattern = "*.vcf.text_assembly_report.*"
 
-release_progress_table = "dbsnp_ensembl_species.rs_release_progress"
 
-
-def update_release_progress_status(metadata_connection_handle, taxonomy, assembly_accession, release_version,
-                                   release_status):
+def update_release_progress_status(metadata_connection_handle, release_progress_table, taxonomy, assembly_accession,
+                                   release_version, release_status):
     insert_sql = '''
        INSERT INTO {table_name} (taxonomy, assembly_accession, release_version, release_status)
             VALUES (%s, %s, %s, %s)

--- a/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
@@ -66,11 +66,19 @@ def get_target_mongo_instance_for_taxonomy(taxonomy_id, release_species_inventor
 
 def get_release_assemblies_for_taxonomy(taxonomy_id, release_species_inventory_table,
                                         release_version, metadata_connection_handle):
-    results = get_all_results_for_query(metadata_connection_handle, "select assembly from {0} "
-                                                                    "where taxonomy_id = '{1}' "
-                                                                    "and release_version = {2} and should_be_processed "
-                                                                    "and number_variants_to_process > 0"
-                                        .format(release_species_inventory_table, taxonomy_id, release_version))
+    # TODO do we need a release inventory table that is different from the remapping progress table?
+    if release_version == 3:
+            results = get_all_results_for_query(metadata_connection_handle, "select assembly_accession from {0} "
+                                                                            "where taxid = '{1}' "
+                                                                            "and release_number = {2} "
+                                                                            "and number_submitted_variants > 0"
+                                                .format(release_species_inventory_table, taxonomy_id, release_version))
+    else:
+        results = get_all_results_for_query(metadata_connection_handle, "select assembly from {0} "
+                                                                        "where taxonomy_id = '{1}' "
+                                                                        "and release_version = {2} and should_be_processed "
+                                                                        "and number_variants_to_process > 0"
+                                            .format(release_species_inventory_table, taxonomy_id, release_version))
     if len(results) == 0:
         raise Exception("Could not find assemblies pertaining to taxonomy ID: " + taxonomy_id)
     return [result[0] for result in results]

--- a/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
@@ -27,8 +27,7 @@ def update_release_progress_status(metadata_connection_handle, release_progress_
             VALUES (%s, %s, %s, %s)
             ON CONFLICT (taxonomy, assembly_accession, release_version)
             DO UPDATE SET
-               (release_status)
-                = (EXCLUDED.release_status) ;
+               release_status = (EXCLUDED.release_status) ;
     '''
     with metadata_connection_handle.cursor() as cursor:
         cursor.execute(insert_sql.format(table_name=release_progress_table), (taxonomy, assembly_accession,

--- a/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_metadata.py
@@ -66,19 +66,11 @@ def get_target_mongo_instance_for_taxonomy(taxonomy_id, release_species_inventor
 
 def get_release_assemblies_for_taxonomy(taxonomy_id, release_species_inventory_table,
                                         release_version, metadata_connection_handle):
-    # TODO do we need a release inventory table that is different from the remapping progress table?
-    if release_version == 3:
-            results = get_all_results_for_query(metadata_connection_handle, "select assembly_accession from {0} "
-                                                                            "where taxid = '{1}' "
-                                                                            "and release_number = {2} "
-                                                                            "and number_submitted_variants > 0"
-                                                .format(release_species_inventory_table, taxonomy_id, release_version))
-    else:
-        results = get_all_results_for_query(metadata_connection_handle, "select assembly from {0} "
-                                                                        "where taxonomy_id = '{1}' "
-                                                                        "and release_version = {2} and should_be_processed "
-                                                                        "and number_variants_to_process > 0"
-                                            .format(release_species_inventory_table, taxonomy_id, release_version))
+    results = get_all_results_for_query(metadata_connection_handle, "select assembly from {0} "
+                                                                    "where taxonomy_id = '{1}' "
+                                                                    "and release_version = {2} and should_be_processed "
+                                                                    "and number_variants_to_process > 0"
+                                        .format(release_species_inventory_table, taxonomy_id, release_version))
     if len(results) == 0:
         raise Exception("Could not find assemblies pertaining to taxonomy ID: " + taxonomy_id)
     return [result[0] for result in results]

--- a/eva-accession-release-automation/run_release_in_embassy/requirements.txt
+++ b/eva-accession-release-automation/run_release_in_embassy/requirements.txt
@@ -1,4 +1,4 @@
-ebi_eva_common_pyutils==0.3.6
+ebi_eva_common_pyutils==0.3.13
 click==7.1.2
 pyyaml==5.3.1
 requests==2.22.0

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_assembly.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_assembly.py
@@ -25,14 +25,14 @@ from ebi_eva_common_pyutils.command_utils import run_command_with_output
 logger = logging.getLogger(__name__)
 
 
-def run_release_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table,
+def run_release_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table,
                              release_version, species_release_folder, release_jar_path, job_repo_url, memory):
     exit_code = 0
     try:
-        port_forwarding_process_id, mongo_port = open_mongo_port_to_tempmongo(private_config_xml_file, taxonomy_id,
+        port_forwarding_process_id, mongo_port = open_mongo_port_to_tempmongo(private_config_xml_file, profile, taxonomy_id,
                                                                               release_species_inventory_table,
                                                                               release_version)
-        release_properties_file = create_release_properties_file_for_assembly(private_config_xml_file, taxonomy_id,
+        release_properties_file = create_release_properties_file_for_assembly(private_config_xml_file, profile, taxonomy_id,
                                                                               assembly_accession,
                                                                               release_species_inventory_table,
                                                                               release_version, species_release_folder,
@@ -51,6 +51,7 @@ def run_release_for_assembly(private_config_xml_file, taxonomy_id, assembly_acce
 
 
 @click.option("--private-config-xml-file", help="ex: /path/to/eva-maven-settings.xml", required=True)
+@click.option("--profile", help="Maven profile to use, ex: internal", required=True)
 @click.option("--taxonomy-id", help="ex: 9913", required=True)
 @click.option("--assembly-accession", help="ex: GCA_000003055.6", required=True)
 @click.option("--release-species-inventory-table", default="dbsnp_ensembl_species.release_species_inventory",
@@ -65,9 +66,9 @@ def run_release_for_assembly(private_config_xml_file, taxonomy_id, assembly_acce
 @click.option("--job-repo-url", required=True)
 @click.option("--memory",  help="Memory in GB. ex: 8", default=8, type=int, required=False)
 @click.command()
-def main(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
+def main(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
          species_release_folder, release_jar_path, job_repo_url, memory):
-    run_release_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table,
+    run_release_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table,
                              release_version, species_release_folder, release_jar_path, job_repo_url, memory)
 
 

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_assembly.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_assembly.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def run_release_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table,
-                             release_version, species_release_folder, release_jar_path, job_repo_url, memory):
+                             release_version, species_release_folder, release_jar_path, memory):
     exit_code = 0
     try:
         port_forwarding_process_id, mongo_port = open_mongo_port_to_tempmongo(private_config_xml_file, profile, taxonomy_id,
@@ -35,8 +35,7 @@ def run_release_for_assembly(private_config_xml_file, profile, taxonomy_id, asse
         release_properties_file = create_release_properties_file_for_assembly(private_config_xml_file, profile, taxonomy_id,
                                                                               assembly_accession,
                                                                               release_species_inventory_table,
-                                                                              release_version, species_release_folder,
-                                                                              job_repo_url)
+                                                                              release_version, species_release_folder)
         release_command = 'java -Xmx{0}g -jar {1} --spring.config.location="{2}" -Dspring.data.mongodb.port={3}'\
             .format(memory, release_jar_path, release_properties_file, mongo_port)
         run_command_with_output("Running release pipeline for assembly: " + assembly_accession, release_command)
@@ -59,17 +58,12 @@ def run_release_for_assembly(private_config_xml_file, profile, taxonomy_id, asse
 @click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.option("--species-release-folder", required=True)
 @click.option("--release-jar-path", required=True)
-# TODO: Production Spring Job repository URL won't be used for Release 2
-#  since it hasn't been upgraded to support Spring Boot 2 metadata schema. Therefore a separate job repository
-#  has been created (with similar credentials)  and passed in through the job_repo_url property.
-#  The following argument is not needed after the production repository upgrade to the Spring Boot 2 metadata schema
-@click.option("--job-repo-url", required=True)
 @click.option("--memory",  help="Memory in GB. ex: 8", default=8, type=int, required=False)
 @click.command()
 def main(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
-         species_release_folder, release_jar_path, job_repo_url, memory):
+         species_release_folder, release_jar_path, memory):
     run_release_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table,
-                             release_version, species_release_folder, release_jar_path, job_repo_url, memory)
+                             release_version, species_release_folder, release_jar_path, memory)
 
 
 if __name__ == "__main__":

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
@@ -160,9 +160,10 @@ def get_common_release_properties(common_release_properties_file):
 def run_release_for_species(common_release_properties_file, taxonomy_id, memory):
     common_release_properties = get_common_release_properties(common_release_properties_file)
     private_config_xml_file = common_release_properties["private-config-xml-file"]
+    profile = common_release_properties["profile"]
     release_species_inventory_table = common_release_properties["release-species-inventory-table"]
     release_version = common_release_properties["release-version"]
-    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file), user="evadev") \
+    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile(profile, private_config_xml_file), user="evadev") \
         as metadata_connection_handle:
         release_assemblies = get_release_assemblies_for_taxonomy(taxonomy_id, release_species_inventory_table,
                                                                  release_version, metadata_connection_handle)

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
@@ -32,28 +32,28 @@ timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 copy_process = "copy_accessioning_collections_to_embassy"
 # Processes, in order, that make up the workflow and the arguments that they take
 workflow_process_arguments_map = collections.OrderedDict(
-    [(copy_process, ["private-config-xml-file", "taxonomy-id",
+    [(copy_process, ["private-config-xml-file", "profile", "taxonomy-id",
                      "release-species-inventory-table", "release-version", "dump-dir"]),
-     ("run_release_for_assembly", ["private-config-xml-file", "taxonomy-id",
+     ("run_release_for_assembly", ["private-config-xml-file", "profile", "taxonomy-id",
                                    "assembly-accession", "release-species-inventory-table",
                                    "release-version", "species-release-folder", "release-jar-path", "job-repo-url",
                                    "memory"]),
-     ("merge_dbsnp_eva_release_files", ["private-config-xml-file", "bgzip-path", "tabix-path", "bcftools-path",
+     ("merge_dbsnp_eva_release_files", ["private-config-xml-file", "profile", "bgzip-path", "tabix-path", "bcftools-path",
                                         "vcf-sort-script-path", "taxonomy-id", "assembly-accession",
                                         "release-species-inventory-table", "release-version",
                                         "species-release-folder"]),
      ("sort_bgzip_tabix_release_files", ["bgzip-path", "tabix-path",
                                          "vcf-sort-script-path", "assembly-accession",
                                          "species-release-folder"]),
-     ("validate_release_vcf_files", ["private-config-xml-file", "taxonomy-id",
+     ("validate_release_vcf_files", ["private-config-xml-file", "profile", "taxonomy-id",
                                      "assembly-accession", "release-species-inventory-table", "release-version",
                                      "species-release-folder",
                                      "vcf-validator-path", "assembly-checker-path"]),
      ("analyze_vcf_validation_results", ["species-release-folder", "assembly-accession"]),
      ("count_rs_ids_in_release_files", ["count-ids-script-path", "assembly-accession", "species-release-folder"]),
-     ("validate_rs_release_files", ["private-config-xml-file", "taxonomy-id", "assembly-accession",
+     ("validate_rs_release_files", ["private-config-xml-file", "profile", "taxonomy-id", "assembly-accession",
                                     "release-species-inventory-table", "release-version", "species-release-folder"]),
-     ("update_release_status_for_assembly", ["private-config-xml-file", "taxonomy-id", "assembly-accession",
+     ("update_release_status_for_assembly", ["private-config-xml-file", "profile", "taxonomy-id", "assembly-accession",
                                              "release-version"])
      ])
 

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
@@ -36,7 +36,7 @@ workflow_process_arguments_map = collections.OrderedDict(
                      "release-species-inventory-table", "release-version", "dump-dir"]),
      ("run_release_for_assembly", ["private-config-xml-file", "profile", "taxonomy-id",
                                    "assembly-accession", "release-species-inventory-table",
-                                   "release-version", "species-release-folder", "release-jar-path", "job-repo-url",
+                                   "release-version", "species-release-folder", "release-jar-path",
                                    "memory"]),
      ("merge_dbsnp_eva_release_files", ["private-config-xml-file", "profile", "bgzip-path", "tabix-path", "bcftools-path",
                                         "vcf-sort-script-path", "taxonomy-id", "assembly-accession",

--- a/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
+++ b/eva-accession-release-automation/run_release_in_embassy/run_release_for_species.py
@@ -53,8 +53,8 @@ workflow_process_arguments_map = collections.OrderedDict(
      ("count_rs_ids_in_release_files", ["count-ids-script-path", "assembly-accession", "species-release-folder"]),
      ("validate_rs_release_files", ["private-config-xml-file", "profile", "taxonomy-id", "assembly-accession",
                                     "release-species-inventory-table", "release-version", "species-release-folder"]),
-     ("update_release_status_for_assembly", ["private-config-xml-file", "profile", "taxonomy-id", "assembly-accession",
-                                             "release-version"])
+     ("update_release_status_for_assembly", ["private-config-xml-file", "profile", "release-progress-table",
+                                             "taxonomy-id", "assembly-accession", "release-version"])
      ])
 
 workflow_process_template_for_nextflow = """

--- a/eva-accession-release-automation/run_release_in_embassy/update_release_status_for_assembly.py
+++ b/eva-accession-release-automation/run_release_in_embassy/update_release_status_for_assembly.py
@@ -24,9 +24,9 @@ from ebi_eva_common_pyutils.config_utils import get_pg_metadata_uri_for_eva_prof
 logger = logging.getLogger(__name__)
 
 
-def update_release_status_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession, release_version):
-    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file),
-                          user = "evadev") as metadata_connection_handle:
+def update_release_status_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_version):
+    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile(profile, private_config_xml_file),
+                          user="evadev") as metadata_connection_handle:
         update_release_progress_status(metadata_connection_handle, taxonomy_id, assembly_accession, release_version,
                                        release_status='done')
         logger.info("Successfully marked release status as 'Done' in {0} for taxonomy {1} and assembly {2}"
@@ -34,12 +34,13 @@ def update_release_status_for_assembly(private_config_xml_file, taxonomy_id, ass
 
 
 @click.option("--private-config-xml-file", help="ex: /path/to/eva-maven-settings.xml", required=True)
+@click.option("--profile", help="Maven profile to use, ex: internal", required=True)
 @click.option("--taxonomy-id", help="ex: 9913", required=True)
 @click.option("--assembly-accession", help="ex: GCA_000003055.6", required=True)
 @click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.command()
-def main(private_config_xml_file, taxonomy_id, assembly_accession, release_version):
-    update_release_status_for_assembly(private_config_xml_file, taxonomy_id, assembly_accession, release_version)
+def main(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_version):
+    update_release_status_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_version)
 
 
 if __name__ == "__main__":

--- a/eva-accession-release-automation/run_release_in_embassy/update_release_status_for_assembly.py
+++ b/eva-accession-release-automation/run_release_in_embassy/update_release_status_for_assembly.py
@@ -17,17 +17,18 @@ import logging
 import psycopg2
 
 
-from run_release_in_embassy.release_metadata import update_release_progress_status, release_progress_table
+from run_release_in_embassy.release_metadata import update_release_progress_status
 from ebi_eva_common_pyutils.config_utils import get_pg_metadata_uri_for_eva_profile
 
 
 logger = logging.getLogger(__name__)
 
 
-def update_release_status_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_version):
+def update_release_status_for_assembly(private_config_xml_file, profile, release_progress_table, taxonomy_id, assembly_accession, release_version):
     with psycopg2.connect(get_pg_metadata_uri_for_eva_profile(profile, private_config_xml_file),
                           user="evadev") as metadata_connection_handle:
-        update_release_progress_status(metadata_connection_handle, taxonomy_id, assembly_accession, release_version,
+        update_release_progress_status(metadata_connection_handle, release_progress_table,
+                                       taxonomy_id, assembly_accession, release_version,
                                        release_status='done')
         logger.info("Successfully marked release status as 'Done' in {0} for taxonomy {1} and assembly {2}"
                     .format(release_progress_table, taxonomy_id, assembly_accession))
@@ -35,12 +36,13 @@ def update_release_status_for_assembly(private_config_xml_file, profile, taxonom
 
 @click.option("--private-config-xml-file", help="ex: /path/to/eva-maven-settings.xml", required=True)
 @click.option("--profile", help="Maven profile to use, ex: internal", required=True)
+@click.option("--release-progress-table", help="Name of release progress table", required=True)
 @click.option("--taxonomy-id", help="ex: 9913", required=True)
 @click.option("--assembly-accession", help="ex: GCA_000003055.6", required=True)
 @click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.command()
-def main(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_version):
-    update_release_status_for_assembly(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_version)
+def main(private_config_xml_file, profile, release_progress_table, taxonomy_id, assembly_accession, release_version):
+    update_release_status_for_assembly(private_config_xml_file, profile, release_progress_table, taxonomy_id, assembly_accession, release_version)
 
 
 if __name__ == "__main__":

--- a/eva-accession-release-automation/run_release_in_embassy/validate_release_vcf_files.py
+++ b/eva-accession-release-automation/run_release_in_embassy/validate_release_vcf_files.py
@@ -24,7 +24,7 @@ from ebi_eva_common_pyutils.command_utils import run_command_with_output
 from ebi_eva_common_pyutils.config_utils import get_pg_metadata_uri_for_eva_profile
 
 
-def validate_release_vcf_files(private_config_xml_file, taxonomy_id, assembly_accession,
+def validate_release_vcf_files(private_config_xml_file, profile, taxonomy_id, assembly_accession,
                                release_species_inventory_table, release_version, species_release_folder,
                                vcf_validator_path, assembly_checker_path):
     run_command_with_output("Remove existing VCF validation and assembly report outputs...",
@@ -32,7 +32,7 @@ def validate_release_vcf_files(private_config_xml_file, taxonomy_id, assembly_ac
                                                                    vcf_validation_output_file_pattern,
                                                                    asm_report_output_file_pattern))
     validate_release_vcf_files_commands = []
-    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("development", private_config_xml_file),
+    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile(profile, private_config_xml_file),
                           user="evadev") as \
             metadata_connection_handle:
         release_inventory_info_for_assembly = get_release_inventory_info_for_assembly(taxonomy_id, assembly_accession,
@@ -63,6 +63,7 @@ def validate_release_vcf_files(private_config_xml_file, taxonomy_id, assembly_ac
 
 
 @click.option("--private-config-xml-file", help="ex: /path/to/eva-maven-settings.xml", required=True)
+@click.option("--profile", help="Maven profile to use, ex: internal", required=True)
 @click.option("--taxonomy-id", help="ex: 9913", required=True)
 @click.option("--assembly-accession", help="ex: GCA_000003055.6", required=True)
 @click.option("--release-species-inventory-table", default="dbsnp_ensembl_species.release_species_inventory",
@@ -72,9 +73,9 @@ def validate_release_vcf_files(private_config_xml_file, taxonomy_id, assembly_ac
 @click.option("--vcf-validator-path", help="/path/to/vcf/validator/binary", required=True)
 @click.option("--assembly-checker-path", help="/path/to/assembly/checker/binary", required=True)
 @click.command()
-def main(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
+def main(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
          species_release_folder, vcf_validator_path, assembly_checker_path):
-    validate_release_vcf_files(private_config_xml_file, taxonomy_id, assembly_accession,
+    validate_release_vcf_files(private_config_xml_file, profile, taxonomy_id, assembly_accession,
                                release_species_inventory_table, release_version, species_release_folder,
                                vcf_validator_path, assembly_checker_path)
 

--- a/eva-accession-release-automation/run_release_in_embassy/validate_rs_release_files.py
+++ b/eva-accession-release-automation/run_release_in_embassy/validate_rs_release_files.py
@@ -436,11 +436,11 @@ def export_unique_rs_ids_from_mongo(mongo_port, db_name_in_tempmongo_instance, a
                                                                mongo_unique_rs_ids_file))
 
 
-def validate_rs_release_files(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table,
+def validate_rs_release_files(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table,
                               release_version, species_release_folder):
     port_forwarding_process_id, mongo_port, exit_code  = None, None, None
     try:
-        port_forwarding_process_id, mongo_port = open_mongo_port_to_tempmongo(private_config_xml_file, taxonomy_id,
+        port_forwarding_process_id, mongo_port = open_mongo_port_to_tempmongo(private_config_xml_file, profile, taxonomy_id,
                                                                               release_species_inventory_table,
                                                                               release_version)
         db_name_in_tempmongo_instance = get_release_db_name_in_tempmongo_instance(taxonomy_id)
@@ -466,6 +466,7 @@ def validate_rs_release_files(private_config_xml_file, taxonomy_id, assembly_acc
 
 
 @click.option("--private-config-xml-file", help="ex: /path/to/eva-maven-settings.xml", required=True)
+@click.option("--profile", help="Maven profile to use, ex: internal", required=True)
 @click.option("--taxonomy-id", help="ex: 9913", required=True)
 @click.option("--assembly-accession", help="ex: GCA_000003055.6", required=True)
 @click.option("--release-species-inventory-table", default="dbsnp_ensembl_species.release_species_inventory",
@@ -473,9 +474,9 @@ def validate_rs_release_files(private_config_xml_file, taxonomy_id, assembly_acc
 @click.option("--release-version", help="ex: 2", type=int, required=True)
 @click.option("--species-release-folder", required=True)
 @click.command()
-def main(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
+def main(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table, release_version,
          species_release_folder):
-    validate_rs_release_files(private_config_xml_file, taxonomy_id, assembly_accession, release_species_inventory_table,
+    validate_rs_release_files(private_config_xml_file, profile, taxonomy_id, assembly_accession, release_species_inventory_table,
                               release_version, species_release_folder)
 
 

--- a/eva-accession-release-automation/setup.py
+++ b/eva-accession-release-automation/setup.py
@@ -1,9 +1,10 @@
-from setuptools import setup, find_packages
+import os
+from setuptools import find_packages, setup
 
 
 def get_requires():
     requires = []
-    with open("run_release_in_embassy/requirements.txt", "rt") as req_file:
+    with open(os.path.join(os.path.dirname(__file__), "run_release_in_embassy", "requirements.txt"), "rt") as req_file:
         for line in req_file:
             requires.append(line.rstrip())
     return requires

--- a/eva-accession-release-automation/setup.py
+++ b/eva-accession-release-automation/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, find_packages
+
+
+def get_requires():
+    requires = []
+    with open("run_release_in_embassy/requirements.txt", "rt") as req_file:
+        for line in req_file:
+            requires.append(line.rstrip())
+    return requires
+
+
+setup(name='run_release_in_embassy',
+      version='0.0.1',
+      packages=find_packages(),
+      install_requires=get_requires(),
+      tests_require=get_requires(),
+      setup_requires=get_requires()
+)

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/runner/AccessionReleaseJobLauncherCommandLineRunner.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/runner/AccessionReleaseJobLauncherCommandLineRunner.java
@@ -120,7 +120,7 @@ public class AccessionReleaseJobLauncherCommandLineRunner extends JobLauncherCom
             if (inputParameters.isForceRestart()) {
                 JobExecution previousJobExecution = CommandLineRunnerUtils.getLastJobExecution(jobName, jobExplorer,
                                                                                                jobParameters);
-                markPreviousJobAsFailed(
+                CommandLineRunnerUtils.markPreviousJobAsFailed(jobName, jobRepository,
                         previousJobExecution != null ? previousJobExecution.getJobParameters() : jobParameters);
             }
             else {
@@ -155,11 +155,5 @@ public class AccessionReleaseJobLauncherCommandLineRunner extends JobLauncherCom
             JobParametersNotFoundException {
         logger.info("Running job '" + jobName + "' with parameters: " + jobParameters);
         super.execute(job, jobParameters);
-    }
-
-    private void markPreviousJobAsFailed(JobParameters jobParameters) throws
-            NoPreviousJobExecutionException {
-        logger.info("Force restartPreviousExecution of job '" + jobName + "' with parameters: " + jobParameters);
-        JobStatusManager.markLastJobAsFailed(jobRepository, jobName, jobParameters);
     }
 }

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/runner/AccessionReleaseJobLauncherCommandLineRunnerTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/runner/AccessionReleaseJobLauncherCommandLineRunnerTest.java
@@ -246,7 +246,7 @@ public class AccessionReleaseJobLauncherCommandLineRunnerTest {
         assertEquals(Collections.EMPTY_LIST, jobExplorer.getJobNames());
         runner.run();
 
-        assertEquals(EXIT_WITH_ERRORS, runner.getExitCode());
+        assertEquals(EXIT_WITHOUT_ERRORS, runner.getExitCode());
     }
 
 }

--- a/eva-remapping-get-source/src/main/java/uk/ac/ebi/eva/remapping/source/runner/AccessionRemappingJobLauncherCommandLineRunner.java
+++ b/eva-remapping-get-source/src/main/java/uk/ac/ebi/eva/remapping/source/runner/AccessionRemappingJobLauncherCommandLineRunner.java
@@ -120,7 +120,7 @@ public class AccessionRemappingJobLauncherCommandLineRunner extends JobLauncherC
             if (inputParameters.isForceRestart()) {
                 JobExecution previousJobExecution = CommandLineRunnerUtils.getLastJobExecution(jobName, jobExplorer,
                                                                                                jobParameters);
-                markPreviousJobAsFailed(
+                CommandLineRunnerUtils.markPreviousJobAsFailed(jobName, jobRepository,
                         previousJobExecution != null ? previousJobExecution.getJobParameters() : jobParameters);
             }
             else {
@@ -155,11 +155,5 @@ public class AccessionRemappingJobLauncherCommandLineRunner extends JobLauncherC
             JobParametersNotFoundException {
         logger.info("Running job '" + jobName + "' with parameters: " + jobParameters);
         super.execute(job, jobParameters);
-    }
-
-    private void markPreviousJobAsFailed(JobParameters jobParameters) throws
-            NoPreviousJobExecutionException {
-        logger.info("Force restartPreviousExecution of job '" + jobName + "' with parameters: " + jobParameters);
-        JobStatusManager.markLastJobAsFailed(jobRepository, jobName, jobParameters);
     }
 }

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/runner/IngestRemappedCommandLineRunner.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/runner/IngestRemappedCommandLineRunner.java
@@ -119,7 +119,7 @@ public class IngestRemappedCommandLineRunner extends JobLauncherCommandLineRunne
             if (inputParameters.isForceRestart()) {
                 JobExecution previousJobExecution = CommandLineRunnerUtils.getLastJobExecution(jobName, jobExplorer,
                                                                                                jobParameters);
-                markPreviousJobAsFailed(
+                CommandLineRunnerUtils.markPreviousJobAsFailed(jobName, jobRepository,
                         previousJobExecution != null ? previousJobExecution.getJobParameters() : jobParameters);
             }
             else {
@@ -153,11 +153,5 @@ public class IngestRemappedCommandLineRunner extends JobLauncherCommandLineRunne
             JobParametersNotFoundException {
         logger.info("Running job '" + jobName + "' with parameters: " + jobParameters);
         super.execute(job, jobParameters);
-    }
-
-    private void markPreviousJobAsFailed(JobParameters jobParameters) throws
-            NoPreviousJobExecutionException {
-        logger.info("Force restartPreviousExecution of job '" + jobName + "' with parameters: " + jobParameters);
-        JobStatusManager.markLastJobAsFailed(jobRepository, jobName, jobParameters);
     }
 }


### PR DESCRIPTION
Updates to the python automation scripts:
* Clustering automation works without modification, but I added a logs directory param for usability
* Release automation needs maven profile and release progress table name in config rather than hardcoded to run in internal
* Remove `job-repo-url` param as Spring Boot 2 upgrade should be done
* Added a skeletal readme to the release automation

Updates to java pipeline:
* Be more forgiving if no previous job execution found