### PR TITLE
EVA-2574 - Fixes to support splits occurring due to duplicate SS ID + extract RS ID back-propagation step

### DIFF
--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2021 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.io;
+
+import com.mongodb.DuplicateKeyException;
+import com.mongodb.MongoBulkWriteException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.data.mongodb.core.BulkOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
+import uk.ac.ebi.ampt2d.commons.accession.core.models.EventType;
+import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.AccessionedDocument;
+
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
+import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpSubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpSubmittedVariantOperationEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.ClusteredVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantInactiveEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
+import uk.ac.ebi.eva.accession.core.service.nonhuman.SubmittedVariantAccessioningService;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+import static uk.ac.ebi.eva.accession.core.exceptions.MongoBulkWriteExceptionUtils.extractUniqueHashesForDuplicateKeyError;
+
+public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity> {
+
+    private static final Logger logger = LoggerFactory.getLogger(BackPropagatedRSWriter.class);
+
+    private final String originalAssembly;
+
+    private final String remappedAssembly;
+
+    private final ClusteringWriter clusteringWriter;
+
+    private final SubmittedVariantAccessioningService submittedVariantAccessioningService;
+
+    private static final String ID_ATTRIBUTE = "_id";
+
+    private static final String RS_ATTRIBUTE = "rs";
+
+    private final MongoTemplate mongoTemplate;
+
+    private final ClusteringCounts clusteringCounts;
+
+    public BackPropagatedRSWriter(String originalAssembly, String remappedAssembly, ClusteringWriter clusteringWriter,
+                                  SubmittedVariantAccessioningService submittedVariantAccessioningService,
+                                  MongoTemplate mongoTemplate,
+                                  ClusteringCounts clusteringCounts) {
+        this.originalAssembly = originalAssembly;
+        this.remappedAssembly = remappedAssembly;
+        this.clusteringWriter = clusteringWriter;
+        this.submittedVariantAccessioningService = submittedVariantAccessioningService;
+        this.mongoTemplate = mongoTemplate;
+        this.clusteringCounts = clusteringCounts;
+    }
+
+    @Override
+    public void write(
+            @Nonnull List<? extends SubmittedVariantEntity> submittedVariantEntitiesInOriginalAssemblyWithNoRS)
+            throws MongoBulkWriteException, AccessionCouldNotBeGeneratedException {
+        List<Long> ssIDsToLookupInRemappedAssembly =
+                submittedVariantEntitiesInOriginalAssemblyWithNoRS
+                        .stream()
+                        // Some dbSNP imported variants might have been explicitly de-clustered
+                        // because the REF/ALT allele data provided by dbSNP was internally inconsistent
+                        // and therefore the clustering was deemed unreliable.
+                        // See ss68617665 in GCA_000181335.3 for example.
+                        // Don't bring such variants in for clustering again.
+                        .filter(SubmittedVariantEntity::isAllelesMatch)
+                        .map(AccessionedDocument::getAccession).collect(Collectors.toList());
+        Map<Long, List<SubmittedVariantEntity>> ssInRemappedAssemblyGroupedByID =
+                submittedVariantAccessioningService
+                        .getAllActiveByAssemblyAndAccessionIn(remappedAssembly, ssIDsToLookupInRemappedAssembly)
+                        .stream()
+                        .map(entity -> new SubmittedVariantEntity(entity.getAccession(), entity.getHash(),
+                                                                  entity.getData(),
+                                                                  entity.getVersion()))
+                        .filter(entity -> Objects.nonNull(entity.getClusteredVariantAccession()))
+                        .collect(Collectors.groupingBy(SubmittedVariantEntity::getAccession));
+        backPropagateRS(submittedVariantEntitiesInOriginalAssemblyWithNoRS, ssInRemappedAssemblyGroupedByID);
+    }
+
+    /*
+      @see <a href="https://docs.google.com/spreadsheets/d/1KQLVCUy-vqXKgkCDt2czX6kuMfsjfCc9uBsS19MZ6dY/edit#rangeid=717877299"/>
+     */
+    private void backPropagateRS(
+            @Nonnull List<? extends SubmittedVariantEntity> submittedVariantEntitiesInOriginalAssemblyWithNoRS,
+            Map<Long, List<SubmittedVariantEntity>> ssInRemappedAssemblyGroupedByID) {
+
+        // Inserts to create RS record for back-propagated RS in the original assembly
+        BulkOperations evaCVEInserts = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                                                             ClusteredVariantEntity.class);
+        BulkOperations dbsnpCVEInserts = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                                                               DbsnpClusteredVariantEntity.class);
+
+        // Updates to Submitted Variant Entity (SVE) collection with the RS created above
+        BulkOperations evaSVEUpdates = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                                                             SubmittedVariantEntity.class);
+        BulkOperations dbsnpSVEUpdates = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                                                               DbsnpSubmittedVariantEntity.class);
+
+        // Inserts to Submitted Variant Operation Entity (SVOE) collection recording the RS updates made above
+        BulkOperations evaSVOEInserts = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                                                              SubmittedVariantOperationEntity.class);
+        BulkOperations dbsnpSVOEInserts = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                                                                DbsnpSubmittedVariantOperationEntity.class);
+
+
+        int numEvaRSAssignments = 0;
+        int numDbsnpRSAssignments = 0;
+        int numEVARSInserts = 0;
+        int numDbsnpRSInserts = 0;
+
+        for (SubmittedVariantEntity submittedVariantEntity: submittedVariantEntitiesInOriginalAssemblyWithNoRS) {
+            Long ssIDToAssignRS = submittedVariantEntity.getAccession();
+            if (ssInRemappedAssemblyGroupedByID.containsKey(ssIDToAssignRS)) {
+                BulkOperations bulkSVEUpdates, bulkSVOEInserts, bulkCVEInserts;
+                if (clusteringWriter.isEvaSubmittedVariant(submittedVariantEntity)) {
+                    bulkSVEUpdates = evaSVEUpdates;
+                    bulkSVOEInserts = evaSVOEInserts;
+                    numEvaRSAssignments += 1;
+                } else {
+                    bulkSVEUpdates = dbsnpSVEUpdates;
+                    bulkSVOEInserts = dbsnpSVOEInserts;
+                    numDbsnpRSAssignments += 1;
+                }
+                ClusteredVariantEntity newRSRecordForOriginalAssembly =
+                        getSuitableRSFromRemappedSS(ssInRemappedAssemblyGroupedByID, submittedVariantEntity);
+                Long rsToAssign = newRSRecordForOriginalAssembly.getAccession();
+
+                if (clusteringWriter.getClusteredVariantCollection(rsToAssign).equals(ClusteredVariantEntity.class)) {
+                    bulkCVEInserts = evaCVEInserts;
+                    numEVARSInserts += 1;
+                } else {
+                    bulkCVEInserts = dbsnpCVEInserts;
+                    numDbsnpRSInserts += 1;
+                }
+                bulkCVEInserts.insert(newRSRecordForOriginalAssembly);
+                clusteringCounts.addClusteredVariantsCreated(1);
+
+                Query queryToLookUpSSHash = query(where(ID_ATTRIBUTE).is(submittedVariantEntity.getHashedMessage()));
+                Update updateRSInOriginalAssembly = Update.update(RS_ATTRIBUTE, rsToAssign);
+                bulkSVEUpdates.updateOne(queryToLookUpSSHash, updateRSInOriginalAssembly);
+                clusteringCounts.addSubmittedVariantsClustered(1);
+
+                bulkSVOEInserts.insert(getUpdateOperation(submittedVariantEntity, rsToAssign));
+                clusteringCounts.addSubmittedVariantsUpdateOperationWritten(1);
+            }
+        }
+
+        handleClusteredVariantInserts(evaCVEInserts, dbsnpCVEInserts, numEVARSInserts, numDbsnpRSInserts);
+
+        if (numEvaRSAssignments > 0) {
+            evaSVEUpdates.execute();
+            evaSVOEInserts.execute();
+        }
+
+        if (numDbsnpRSAssignments > 0) {
+            dbsnpSVEUpdates.execute();
+            dbsnpSVOEInserts.execute();
+        }
+    }
+
+    private void handleClusteredVariantInserts(BulkOperations evaCVEInserts, BulkOperations dbsnpCVEInserts,
+                                               int numEVARSInserts, int numDbsnpRSInserts) {
+        try {
+            if (numEVARSInserts > 0) {
+                evaCVEInserts.execute();
+            }
+
+            if (numDbsnpRSInserts > 0) {
+                dbsnpCVEInserts.execute();
+            }
+        }
+        catch (DuplicateKeyException duplicateKeyException) {
+            MongoBulkWriteException writeException = ((MongoBulkWriteException) duplicateKeyException.getCause());
+            // Consider a scenario where we are back-propagating rs ID:
+            // RS1 corresponding to SS1 from ASM2 (remapped assembly) to ASM1 (original assembly)
+            // If the hash for back-propagated RS1 already exists in ASM1,
+            // it means that, for some reason, SS1 was not clustered with RS1 when ASM1 underwent clustering.
+            // It is better to flag such issues for later analysis.
+            extractUniqueHashesForDuplicateKeyError(writeException)
+                    .forEach(hash -> logger.error("Attempted to insert RS record with already existing hash " + hash +
+                                                         "during RS ID back-propagation! This could be symptomatic " +
+                                                         "of clustering issues with the original assembly "
+                                                         + this.originalAssembly + "."));
+        }
+    }
+
+    private ClusteredVariantEntity getSuitableRSFromRemappedSS(
+            Map<Long, List<SubmittedVariantEntity>> ssInRemappedAssemblyGroupedByID,
+            SubmittedVariantEntity submittedVariantEntity) {
+        // Currently if there is more than one entry for the SS accession in the remapped assembly,
+        // we choose the minimum RS ID as a hack since we don't have a way to map between the
+        // remapped SS and the original SS in such cases
+        // TODO: Re-visit during EVA-2612
+        ClusteredVariantEntity rsFromRemappedAssembly =
+                ssInRemappedAssemblyGroupedByID
+                        .get(submittedVariantEntity.getAccession())
+                        .stream()
+                        .max(Comparator.comparingLong(SubmittedVariantEntity::getClusteredVariantAccession))
+                        .map(clusteringWriter::toClusteredVariantEntity).get();
+
+        ClusteredVariantEntity newRSRecordForOriginalAssembly =
+                clusteringWriter.toClusteredVariantEntity(submittedVariantEntity);
+        // The above statement will only create an object with the null accession as in the original assembly
+        // The following is needed to update that accession to the back-propagated RS ID from the remapped assembly
+        newRSRecordForOriginalAssembly =
+                new ClusteredVariantEntity(rsFromRemappedAssembly.getAccession(),
+                                           newRSRecordForOriginalAssembly.getHashedMessage(),
+                                           newRSRecordForOriginalAssembly.getModel(),
+                                           newRSRecordForOriginalAssembly.getVersion());
+        return newRSRecordForOriginalAssembly;
+    }
+
+    private SubmittedVariantOperationEntity getUpdateOperation(SubmittedVariantEntity submittedVariantEntity,
+                                                               Long assignedRS) {
+        // Query to create the update operation history
+        SubmittedVariantOperationEntity updateOperation = new SubmittedVariantOperationEntity();
+        SubmittedVariantInactiveEntity inactiveEntity = new SubmittedVariantInactiveEntity(submittedVariantEntity);
+        updateOperation.fill(
+                EventType.UPDATED,
+                submittedVariantEntity.getAccession(),
+                null,
+                "Back-propagating rs" + assignedRS + " for submitted variant ss" +
+                        submittedVariantEntity.getAccession() + " after remapping to " + this.remappedAssembly + ".",
+                Collections.singletonList(inactiveEntity)
+        );
+        return updateOperation;
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
@@ -408,7 +408,7 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
         mongoTemplate.insert(rsSplitSVOEInsertEntries, SubmittedVariantOperationEntity.class);
     }
 
-    protected ClusteredVariantEntity toClusteredVariantEntity(SubmittedVariantEntity submittedVariantEntity) {
+    public ClusteredVariantEntity toClusteredVariantEntity(SubmittedVariantEntity submittedVariantEntity) {
         return new ClusteredVariantEntity(submittedVariantEntity.getClusteredVariantAccession(),
                 getClusteredVariantHash(submittedVariantEntity),
                 toClusteredVariant(submittedVariantEntity));

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
@@ -37,7 +37,6 @@ import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
 import uk.ac.ebi.eva.accession.core.model.ClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.ISubmittedVariant;
-import uk.ac.ebi.eva.accession.core.model.SubmittedVariant;
 import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantEntity;
 import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantOperationEntity;
 import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpSubmittedVariantEntity;
@@ -510,62 +509,12 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
                     Collections.singletonList(inactiveEntity)
             );
 
-            // Back-propagation logic
-            Query queryToFindSSInSourceAssembly = null;
-            SubmittedVariantOperationEntity backPropagationUpdateOperation = null;
-            if (submittedVariantEntity.getRemappedFrom() != null) {
-                // Query to back-propagate RS ID to the original SS (from where the current SS is remapped)
-                queryToFindSSInSourceAssembly =
-                        query(where("accession").is(submittedVariantEntity.getAccession()))
-                                .addCriteria(where("seq").is(submittedVariantEntity.getRemappedFrom()))
-                                .addCriteria(where("rs").exists(false));
-                // Query to record the update operation history with back-propagation
-                backPropagationUpdateOperation = new SubmittedVariantOperationEntity();
-                // Since we don't have the original source SS ID from which we remapped
-                // it can get quite expensive to query the source records for every original SS with just the accession
-                // without bulk-querying. Therefore, we are filling in fake data for the old SS entry in operations
-                // TODO: Find a more efficient way to do this!!
-                SubmittedVariant oldSS = new SubmittedVariant(submittedVariantEntity.getRemappedFrom(),
-                                                              submittedVariantEntity.getTaxonomyAccession(),
-                                                              submittedVariantEntity.getProjectAccession(),
-                                                              "contig-pre-remapping", -1L, "ref-pre-remapping",
-                                                              "alt-pre-remapping", null);
-                SubmittedVariantInactiveEntity inactiveEntityForBackPropagation =
-                        new SubmittedVariantInactiveEntity(
-                                new SubmittedVariantEntity(submittedVariantEntity.getAccession(),
-                                                           submittedHashingFunction.apply(oldSS),
-                                                           oldSS,
-                                                           submittedVariantEntity.getVersion()));
-                backPropagationUpdateOperation.fill(
-                        EventType.UPDATED,
-                        submittedVariantEntity.getAccession(),
-                        null,
-                        "Back-propagating rs" + rsid + " for submitted variant ss" +
-                                submittedVariantEntity.getAccession() + " after remapping to " +
-                                submittedVariantEntity.getReferenceSequenceAccession() + ".",
-                        Collections.singletonList(inactiveEntityForBackPropagation)
-                );
-            }
-
             if (isEvaSubmittedVariant(submittedVariantEntity)) {
                 bulkOperations.updateOne(updateRsQuery, updateRS);
-                if (submittedVariantEntity.getRemappedFrom() != null) {
-                    // Due to MongoDB technical limitations,
-                    // updateOne cannot be used when shard key "_id" is not part of the query
-                    // So, use updateMulti even though only one record will be updated
-                    bulkOperations.updateMulti(queryToFindSSInSourceAssembly, updateRS);
-                    bulkHistoryOperations.insert(backPropagationUpdateOperation);
-                    ++numUpdates;
-                }
                 bulkHistoryOperations.insert(updateOperation);
                 ++numUpdates;
             } else {
                 dbsnpBulkOperations.updateOne(updateRsQuery, updateRS);
-                if (submittedVariantEntity.getRemappedFrom() != null) {
-                    dbsnpBulkOperations.updateMulti(queryToFindSSInSourceAssembly, updateRS);
-                    dbsnpBulkHistoryOperations.insert(backPropagationUpdateOperation);
-                    ++numDbsnpUpdates;
-                }
                 dbsnpBulkHistoryOperations.insert(updateOperation);
                 ++numDbsnpUpdates;
             }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/ExtraneousRSReporter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/ExtraneousRSReporter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.io.qc;
+
+import com.mongodb.MongoBulkWriteException;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
+import uk.ac.ebi.eva.accession.clustering.batch.io.qc.QCMongoCollections.qcRSIdInSS;
+import uk.ac.ebi.eva.accession.core.model.eva.ClusteredVariantEntity;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+public class ExtraneousRSReporter implements ItemWriter<ClusteredVariantEntity> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExtraneousRSReporter.class);
+
+    private static final String IDAttribute = "_id";
+
+    private final String assemblyAccession;
+
+    private final MongoTemplate mongoTemplate;
+
+    public ExtraneousRSReporter(String assemblyAccession, MongoTemplate mongoTemplate) {
+        this.assemblyAccession = assemblyAccession;
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public void write(@Nonnull List<? extends ClusteredVariantEntity> clusteredVariantEntities)
+            throws MongoBulkWriteException, AccessionCouldNotBeGeneratedException {
+        reportExtraneousRS(clusteredVariantEntities);
+    }
+
+    private void reportExtraneousRS(List<? extends ClusteredVariantEntity> clusteredVariantEntities) {
+        String assemblyAccessionPrefix = QCMongoCollections.getAssemblyAccessionPrefix(this.assemblyAccession);
+        List<String> idsFromRSIDCollection = clusteredVariantEntities.stream().map(
+                entity -> assemblyAccessionPrefix + entity.getAccession()).distinct().collect(Collectors.toList());
+        Criteria[]  criteriaToLookupIDs =
+                idsFromRSIDCollection.stream().map(id -> where(IDAttribute).is(id)).toArray(Criteria[]::new);
+        if (criteriaToLookupIDs.length == 0) return;
+        Query queryToLookupIDs = new Query(new Criteria().orOperator(criteriaToLookupIDs));
+        List<String> idsInSSIDCollection = this.mongoTemplate.find(queryToLookupIDs, qcRSIdInSS.class)
+                .stream().map(qcRSIdInSS::getId).collect(Collectors.toList());
+
+        Arrays.stream(CollectionUtils.subtract(idsFromRSIDCollection, idsInSSIDCollection).toArray())
+                .map(Object::toString)
+                .forEach(extraneousRS ->
+                        logger.error("RS ID rs{} was not assigned to any SS in the assembly {}",
+                                extraneousRS.replace(assemblyAccessionPrefix, ""), this.assemblyAccession));
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/PendingMergeSplitReporter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/PendingMergeSplitReporter.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.io.qc;
+
+import com.mongodb.MongoBulkWriteException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.mongodb.core.BulkOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
+
+import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
+import uk.ac.ebi.eva.accession.clustering.batch.io.qc.QCMongoCollections.qcRSHashInSS;
+import uk.ac.ebi.eva.accession.clustering.batch.io.qc.QCMongoCollections.qcRSIdInSS;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+import static uk.ac.ebi.eva.accession.core.exceptions.MongoBulkWriteExceptionUtils.extractUniqueHashesForDuplicateKeyError;
+
+public class PendingMergeSplitReporter implements ItemWriter<SubmittedVariantEntity> {
+
+    private static final Logger logger = LoggerFactory.getLogger(PendingMergeSplitReporter.class);
+
+    private static final String IDAttribute = "_id";
+
+    private final String assemblyAccession;
+
+    private final ClusteringWriter clusteringWriter;
+
+    private final MongoTemplate mongoTemplate;
+
+    public PendingMergeSplitReporter(String assemblyAccession, ClusteringWriter clusteringWriter,
+                                     MongoTemplate mongoTemplate) {
+        this.assemblyAccession = assemblyAccession;
+        this.clusteringWriter = clusteringWriter;
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public void write(@Nonnull List<? extends SubmittedVariantEntity> submittedVariantEntities)
+            throws MongoBulkWriteException, AccessionCouldNotBeGeneratedException {
+        reportPendingSplitsAndMerges(submittedVariantEntities);
+    }
+
+    private void reportPendingSplitsAndMerges(List<? extends SubmittedVariantEntity> submittedVariantEntities) {
+        Map<String, Long> hashAndAssociatedRS = new HashMap<>();
+        Map<String, String> rsAndAssociatedHash = new HashMap<>();
+        String assemblyAccessionPrefix = QCMongoCollections.getAssemblyAccessionPrefix(this.assemblyAccession);
+        for (SubmittedVariantEntity submittedVariantEntity :submittedVariantEntities) {
+            Long rsID = submittedVariantEntity.getClusteredVariantAccession();
+            String rsHash = clusteringWriter.toClusteredVariantEntity(submittedVariantEntity).getHashedMessage();
+            reportMultipleRSWithSameHash(hashAndAssociatedRS, assemblyAccessionPrefix, rsID, rsHash);
+            hashAndAssociatedRS.put(assemblyAccessionPrefix + rsHash, rsID);
+            reportSameRSWithMultipleHashes(rsAndAssociatedHash, assemblyAccessionPrefix, rsID, rsHash);
+            rsAndAssociatedHash.put(assemblyAccessionPrefix + rsID, rsHash);
+        }
+
+        BulkOperations bulkHashInsert = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                qcRSHashInSS.class);
+        hashAndAssociatedRS.forEach((key, value) -> bulkHashInsert.insert(new qcRSHashInSS(key, value)));
+        BulkOperations bulkIDInsert = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                qcRSIdInSS.class);
+        rsAndAssociatedHash.forEach((key, value) -> bulkIDInsert.insert(new qcRSIdInSS(key, value)));
+
+        try {
+            bulkHashInsert.execute();
+        }
+        catch (DuplicateKeyException duplicateKeyException) {
+            MongoBulkWriteException writeException = ((MongoBulkWriteException) duplicateKeyException.getCause());
+            for (String hashWithAssemblyPrefix : extractUniqueHashesForDuplicateKeyError(writeException).collect(
+                    Collectors.toList())) {
+                qcRSHashInSS result = this.mongoTemplate.findOne(query(where(IDAttribute).is(hashWithAssemblyPrefix)),
+                                                                 qcRSHashInSS.class);
+                reportMultipleRSWithSameHash (hashAndAssociatedRS, assemblyAccessionPrefix, result.getRsID(),
+                                              hashWithAssemblyPrefix.replace(assemblyAccessionPrefix, ""));
+            };
+        }
+
+        try {
+            bulkIDInsert.execute();
+        }
+        catch (DuplicateKeyException duplicateKeyException) {
+            MongoBulkWriteException writeException = ((MongoBulkWriteException) duplicateKeyException.getCause());
+            for (String idWithAssemblyPrefix : extractUniqueHashesForDuplicateKeyError(writeException).collect(
+                    Collectors.toList())) {
+                qcRSIdInSS result = this.mongoTemplate.findOne(query(where(IDAttribute).is(idWithAssemblyPrefix)),
+                                                               qcRSIdInSS.class);
+                reportSameRSWithMultipleHashes(rsAndAssociatedHash, assemblyAccessionPrefix,
+                                               Long.parseLong(idWithAssemblyPrefix.replace(assemblyAccessionPrefix, "")),
+                                               result.getHash());
+            };
+        }
+    }
+
+    private void reportSameRSWithMultipleHashes(Map<String, String> rsAndAssociatedHash, String assemblyAccessionPrefix,
+                                                Long rsID, String rsHash) {
+        String previousHashWithTheSameRSID = rsAndAssociatedHash.get(assemblyAccessionPrefix + rsID);
+        if (Objects.nonNull(previousHashWithTheSameRSID) && !Objects.equals(previousHashWithTheSameRSID, rsHash)) {
+            logger.error("Same RS ID rs{} has multiple hashes {} and {}",
+                    rsID, previousHashWithTheSameRSID, rsHash);
+        }
+    }
+
+    private void reportMultipleRSWithSameHash(Map<String, Long> hashAndAssociatedRS, String assemblyAccessionPrefix,
+                                              Long rsID, String rsHash) {
+        Long previousRSIDWithTheSameHash = hashAndAssociatedRS.get(assemblyAccessionPrefix + rsHash);
+        if (Objects.nonNull(previousRSIDWithTheSameHash) && !Objects.equals(previousRSIDWithTheSameHash, rsID)) {
+            logger.error("Multiple RS IDs rs{} and rs{} have the same hash {}",
+                    previousRSIDWithTheSameHash, rsID, rsHash);
+        }
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/QCMongoCollections.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/QCMongoCollections.java
@@ -1,0 +1,61 @@
+package uk.ac.ebi.eva.accession.clustering.batch.io.qc;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+public class QCMongoCollections {
+
+    // remove dots and underscores in the assembly accession because extractUniqueHashesForDuplicateKeyError
+    // cannot detect anything other than alphanumeric characters
+    public final static String getAssemblyAccessionPrefix(String assemblyAccession) {
+      return assemblyAccession.replace(".", "").replace("_", "");
+    }
+
+    // QC Collection that collects all the RS hashes in the submitted variants for an assembly
+    @Document
+    public static class qcRSHashInSS {
+        // In the format <assembly>#<rs hash>#<rs ID>, optimizes lookup by hash
+        // GCA_000181335.4#FAB042ED1B2C6EC7DD2115EFEFD71EE8026CBB13
+        @Id
+        private final String id;
+
+        private final Long rsID;
+
+        public qcRSHashInSS(String id, Long rsID) {
+            this.id = id;
+            this.rsID = rsID;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Long getRsID() {
+            return rsID;
+        }
+    }
+
+    // QC Collection that collects all the RS IDs in the submitted variants for an assembly
+    @Document
+    public static class qcRSIdInSS {
+        // In the format <assembly>#<rs ID>#<rs hash>, optimizes lookup by ID
+        // GCA_000181335.4#785193025
+        @Id
+        private final String id;
+
+        private final String hash;
+
+        public qcRSIdInSS(String id, String hash) {
+            this.id = id;
+            this.hash = hash;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getHash() {
+            return hash;
+        }
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/RSReader.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/RSReader.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.io.qc;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.ClusteredVariantEntity;
+
+import javax.annotation.Nonnull;
+
+
+public class RSReader implements ItemStreamReader<ClusteredVariantEntity> {
+
+    private static final Logger logger = LoggerFactory.getLogger(RSReader.class);
+
+    private static final String ASSEMBLY_FIELD = "asm";
+
+    private final String assembly;
+
+    private MongoCursor<Document> evaCursor;
+
+    private MongoCursor<Document> dbsnpCursor;
+
+    private MongoConverter converter;
+
+    private final MongoTemplate mongoTemplate;
+
+    private final int chunkSize;
+
+    public RSReader(MongoTemplate mongoTemplate, String assembly, int chunkSize) {
+        this.mongoTemplate = mongoTemplate;
+        this.assembly = assembly;
+        this.chunkSize = chunkSize;
+    }
+
+    @Override
+    public ClusteredVariantEntity read() {
+        // Read from dbsnp collection first and subsequently EVA collection
+        Document nextElement = dbsnpCursor.hasNext() ? dbsnpCursor.next() :
+                (evaCursor.hasNext() ? evaCursor.next() : null);
+        return (nextElement != null) ? getClusteredVariantEntity(nextElement) : null;
+    }
+
+    private ClusteredVariantEntity getClusteredVariantEntity(Document clusteredVariants) {
+        return converter.read(ClusteredVariantEntity.class, new BasicDBObject(clusteredVariants));
+    }
+
+    @Override
+    public void open(@Nonnull ExecutionContext executionContext) throws ItemStreamException {
+        initializeReader();
+    }
+
+    public void initializeReader() {
+        Bson query = Filters.in(ASSEMBLY_FIELD, assembly);
+        logger.info("Issuing find: {}", query);
+
+        FindIterable<Document> clusteredVariantsDbsnp =
+                getClusteredVariants(query, DbsnpClusteredVariantEntity.class);
+        dbsnpCursor = clusteredVariantsDbsnp.iterator();
+        FindIterable<Document> clusteredVariantsEVA =
+                getClusteredVariants(query, ClusteredVariantEntity.class);
+        evaCursor = clusteredVariantsEVA.iterator();
+
+        converter = mongoTemplate.getConverter();
+    }
+
+    private FindIterable<Document> getClusteredVariants(Bson query, Class<?> entityClass) {
+        return mongoTemplate.getCollection(mongoTemplate.getCollectionName(entityClass))
+                            .find(query)
+                            .noCursorTimeout(true)
+                            .batchSize(chunkSize);
+    }
+
+    @Override
+    public void update(@Nonnull ExecutionContext executionContext) throws ItemStreamException {
+
+    }
+
+    @Override
+    public void close() throws ItemStreamException {
+        dbsnpCursor.close();
+        evaCursor.close();
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/SSReader.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/qc/SSReader.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.io.qc;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+
+import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpSubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+
+import javax.annotation.Nonnull;
+
+
+public class SSReader implements ItemStreamReader<SubmittedVariantEntity> {
+
+    private static final Logger logger = LoggerFactory.getLogger(SSReader.class);
+
+    private static final String ASSEMBLY_FIELD = "seq";
+
+    private final String assembly;
+
+    private MongoCursor<Document> evaCursor;
+
+    private MongoCursor<Document> dbsnpCursor;
+
+    private MongoConverter converter;
+
+    private final MongoTemplate mongoTemplate;
+
+    private final int chunkSize;
+
+    public SSReader(MongoTemplate mongoTemplate, String assembly, int chunkSize) {
+        this.mongoTemplate = mongoTemplate;
+        this.assembly = assembly;
+        this.chunkSize = chunkSize;
+    }
+
+    @Override
+    public SubmittedVariantEntity read() {
+        // Read from dbsnp collection first and subsequently EVA collection
+        Document nextElement = dbsnpCursor.hasNext() ? dbsnpCursor.next() :
+                (evaCursor.hasNext() ? evaCursor.next() : null);
+        return (nextElement != null) ? getSubmittedVariantEntity(nextElement) : null;
+    }
+
+    private SubmittedVariantEntity getSubmittedVariantEntity(Document submittedVariants) {
+        return converter.read(SubmittedVariantEntity.class, new BasicDBObject(submittedVariants));
+    }
+
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        initializeReader();
+    }
+
+    public void initializeReader() {
+        Bson query = Filters.in(ASSEMBLY_FIELD, assembly);
+        logger.info("Issuing find: {}", query);
+
+        FindIterable<Document> submittedVariantsDbsnp =
+                getSubmittedVariants(query, DbsnpSubmittedVariantEntity.class);
+        dbsnpCursor = submittedVariantsDbsnp.iterator();
+        FindIterable<Document> submittedVariantsEVA =
+                getSubmittedVariants(query, SubmittedVariantEntity.class);
+        evaCursor = submittedVariantsEVA.iterator();
+
+        converter = mongoTemplate.getConverter();
+    }
+
+    private FindIterable<Document> getSubmittedVariants(Bson query, Class<?> entityClass) {
+        return mongoTemplate.getCollection(mongoTemplate.getCollectionName(entityClass))
+                            .find(query)
+                            .noCursorTimeout(true)
+                            .batchSize(chunkSize);
+    }
+
+    @Override
+    public void update(@Nonnull ExecutionContext executionContext) throws ItemStreamException {
+
+    }
+
+    @Override
+    public void close() throws ItemStreamException {
+        dbsnpCursor.close();
+        evaCursor.close();
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/processors/qc/ReportUnclusteredSSProcessor.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/processors/qc/ReportUnclusteredSSProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.batch.processors.qc;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ItemProcessor;
+
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+
+import java.util.Objects;
+
+public class ReportUnclusteredSSProcessor implements ItemProcessor<SubmittedVariantEntity, SubmittedVariantEntity> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReportUnclusteredSSProcessor.class);
+
+    @Override
+    public SubmittedVariantEntity process(SubmittedVariantEntity submittedVariantEntity) {
+           if (submittedVariantEntity.isAssemblyMatch() && Objects.isNull(
+                   submittedVariantEntity.getClusteredVariantAccession())) {
+               logger.error("SS record {} in assembly {} was not clustered",
+                            submittedVariantEntity, submittedVariantEntity.getReferenceSequenceAccession());
+               return null;
+           }
+           return submittedVariantEntity;
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/BeanNames.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/BeanNames.java
@@ -33,6 +33,10 @@ public class BeanNames {
 
     public static final String RS_SPLIT_WRITER = "RS_SPLIT_WRITER";
 
+    public static final String BACK_PROPAGATED_RS_READER = "BACK_PROPAGATED_RS_READER";
+
+    public static final String BACK_PROPAGATED_RS_WRITER = "BACK_PROPAGATED_RS_WRITER";
+
     public static final String VARIANT_TO_SUBMITTED_VARIANT_ENTITY_PROCESSOR =
             "VARIANT_TO_SUBMITTED_VARIANT_ENTITY_PROCESSOR";
 
@@ -54,6 +58,8 @@ public class BeanNames {
 
     public static final String CLUSTERING_NON_CLUSTERED_VARIANTS_FROM_MONGO_STEP = "CLUSTERING_NON_CLUSTERED_VARIANTS_FROM_MONGO_STEP";
 
+    public static final String BACK_PROPAGATE_RS_STEP = "BACK_PROPAGATE_RS_STEP";
+
     public static final String CLUSTERING_FROM_VCF_JOB = "CLUSTERING_FROM_VCF_JOB";
 
     public static final String CLUSTERING_FROM_MONGO_JOB = "CLUSTERING_FROM_MONGO_JOB";
@@ -61,4 +67,6 @@ public class BeanNames {
     public static final String PROCESS_REMAPPED_VARIANTS_WITH_RS_JOB = "PROCESS_REMAPPED_VARIANTS_WITH_RS_JOB";
 
     public static final String CLUSTER_UNCLUSTERED_VARIANTS_JOB = "CLUSTER_UNCLUSTERED_VARIANTS_JOB";
+
+    public static final String BACK_PROPAGATE_RS_JOB = "BACK_PROPAGATE_RS_JOB";
 }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/BackPropagatedRSReaderConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/BackPropagatedRSReaderConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.configuration.batch.io;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringMongoReader;
+import uk.ac.ebi.eva.accession.clustering.configuration.InputParametersConfiguration;
+import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
+import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
+
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PROPAGATED_RS_READER;
+
+@Configuration
+@Import({MongoConfiguration.class, InputParametersConfiguration.class})
+public class BackPropagatedRSReaderConfiguration {
+
+    @Bean(BACK_PROPAGATED_RS_READER)
+    public ClusteringMongoReader backPropagatedRSReader(MongoTemplate mongoTemplate, InputParameters parameters) {
+        String remappedFromAssembly = parameters.getRemappedFrom();
+        if (remappedFromAssembly == null) {
+            throw new IllegalArgumentException("Assembly remapped from attribute must be provided!");
+        }
+        return new ClusteringMongoReader(mongoTemplate, remappedFromAssembly, parameters.getChunkSize(), false);
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/BackPropagatedRSWriterConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/BackPropagatedRSWriterConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.configuration.batch.io;
+
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import uk.ac.ebi.eva.accession.clustering.batch.io.BackPropagatedRSWriter;
+import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
+import uk.ac.ebi.eva.accession.clustering.batch.listeners.ClusteringCounts;
+import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
+import uk.ac.ebi.eva.accession.core.configuration.nonhuman.ClusteredVariantAccessioningConfiguration;
+import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
+import uk.ac.ebi.eva.accession.core.configuration.nonhuman.SubmittedVariantAccessioningConfiguration;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.service.nonhuman.SubmittedVariantAccessioningService;
+
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PROPAGATED_RS_WRITER;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERED_CLUSTERING_WRITER;
+
+@Configuration
+@Import({ClusteredVariantAccessioningConfiguration.class, SubmittedVariantAccessioningConfiguration.class,
+        ClusteringWriterConfiguration.class, MongoConfiguration.class})
+public class BackPropagatedRSWriterConfiguration {
+
+    @Bean(BACK_PROPAGATED_RS_WRITER)
+    public ItemWriter<SubmittedVariantEntity> backPropagatedRSWriter(
+            @Qualifier(CLUSTERED_CLUSTERING_WRITER) ClusteringWriter clusteringWriter,
+            MongoTemplate mongoTemplate, InputParameters parameters,
+            SubmittedVariantAccessioningService submittedVariantAccessioningService,
+            ClusteringCounts clusteringCounts) {
+        return new BackPropagatedRSWriter(parameters.getRemappedFrom(), parameters.getAssemblyAccession(),
+                                          clusteringWriter, submittedVariantAccessioningService, mongoTemplate,
+                                          clusteringCounts);
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/BackPropagateRSJobConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/BackPropagateRSJobConfiguration.java
@@ -30,7 +30,7 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PR
 @Configuration
 @EnableBatchProcessing
 public class BackPropagateRSJobConfiguration {
-    // Deal with remapped variants with an existing RS and create split or merge candidates as needed
+    // Deal with back-propagation of RS, that were assigned to SS in the remapped assembly, to the original assembly
     // Can be parallelized across multiple species
     @Bean(BACK_PROPAGATE_RS_JOB)
     public Job processRemappedVariantsWithRSJob(

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/BackPropagateRSJobConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/BackPropagateRSJobConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PROPAGATE_RS_JOB;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PROPAGATE_RS_STEP;
+
+@Configuration
+@EnableBatchProcessing
+public class BackPropagateRSJobConfiguration {
+    // Deal with remapped variants with an existing RS and create split or merge candidates as needed
+    // Can be parallelized across multiple species
+    @Bean(BACK_PROPAGATE_RS_JOB)
+    public Job processRemappedVariantsWithRSJob(
+            @Qualifier(BACK_PROPAGATE_RS_STEP) Step backPropagateRSStep,
+            JobBuilderFactory jobBuilderFactory) {
+        return jobBuilderFactory.get(BACK_PROPAGATE_RS_JOB)
+                                .incrementer(new RunIdIncrementer())
+                                .start(backPropagateRSStep)
+                                .build();
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromMongoJobConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringFromMongoJobConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PROPAGATE_RS_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_CLUSTERED_VARIANTS_FROM_MONGO_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_FROM_MONGO_JOB;
@@ -42,6 +43,7 @@ public class ClusteringFromMongoJobConfiguration {
             @Qualifier(PROCESS_RS_SPLIT_CANDIDATES_STEP) Step processRSSplitCandidatesStep,
             @Qualifier(CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES_STEP) Step clearRSMergeAndSplitCandidatesStep,
             @Qualifier(CLUSTERING_NON_CLUSTERED_VARIANTS_FROM_MONGO_STEP) Step clusteringNonClusteredVariantsFromMongoStep,
+            @Qualifier(BACK_PROPAGATE_RS_STEP) Step backPropagateRSStep,
             JobBuilderFactory jobBuilderFactory) {
         return jobBuilderFactory.get(CLUSTERING_FROM_MONGO_JOB)
                                 .incrementer(new RunIdIncrementer())
@@ -50,6 +52,7 @@ public class ClusteringFromMongoJobConfiguration {
                                 .next(processRSSplitCandidatesStep)
                                 .next(clearRSMergeAndSplitCandidatesStep)
                                 .next(clusteringNonClusteredVariantsFromMongoStep)
+                                .next(backPropagateRSStep)
                                 .build();
     }
 }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/qc/ClusteringQCJobConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/qc/ClusteringQCJobConfiguration.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs.qc;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
+import uk.ac.ebi.eva.accession.clustering.batch.io.qc.ExtraneousRSReporter;
+import uk.ac.ebi.eva.accession.clustering.batch.io.qc.PendingMergeSplitReporter;
+import uk.ac.ebi.eva.accession.clustering.batch.io.qc.RSReader;
+import uk.ac.ebi.eva.accession.clustering.batch.io.qc.SSReader;
+import uk.ac.ebi.eva.accession.clustering.batch.processors.qc.ReportUnclusteredSSProcessor;
+import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
+import uk.ac.ebi.eva.accession.core.model.eva.ClusteredVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERED_CLUSTERING_WRITER;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROGRESS_LISTENER;
+
+@Configuration
+@EnableBatchProcessing
+// Since this is a QC Job, the configuration is intentionally lightweight and all collected in one-place
+// to reduce overhead
+public class ClusteringQCJobConfiguration {
+
+    public static final String REPORT_UNCLUSTERED_SS_AND_PENDING_MERGES_AND_SPLITS_STEP = "REPORT_UNCLUSTERED_SS_AND_PENDING_MERGES_AND_SPLITS_STEP";
+    public static final String CLUSTERING_QC_JOB = "CLUSTERING_QC_JOB";
+    public static final String PENDING_MERGE_AND_SPLIT_REPORTER = "PENDING_MERGE_SPLIT_REPORTER";
+    public static final String REMAPPED_SS_READER = "QC_REMAPPED_SS_READER";
+    public static final String REPORT_UNCLUSTERED_SS_PROCESSOR = "REPORT_UNCLUSTERED_SS_PROCESSOR";
+    public static final String REMAPPED_RS_READER = "REMAPPED_RS_READER";
+    public static final String REPORT_EXTRANEOUS_RS_STEP = "REPORT_EXTRANEOUS_RS_STEP";
+    public static final String EXTRANEOUS_RS_REPORTER = "EXTRANEOUS_RS_REPORTER";
+
+    @Bean(REMAPPED_SS_READER)
+    public SSReader remappedSSReader(MongoTemplate mongoTemplate, InputParameters parameters) {
+        return new SSReader(mongoTemplate, parameters.getAssemblyAccession(), parameters.getChunkSize());
+    }
+
+    @Bean(REMAPPED_RS_READER)
+    public RSReader remappedRSReader(MongoTemplate mongoTemplate, InputParameters parameters) {
+        return new RSReader(mongoTemplate, parameters.getAssemblyAccession(), parameters.getChunkSize());
+    }
+
+    @Bean(REPORT_UNCLUSTERED_SS_PROCESSOR)
+    public ReportUnclusteredSSProcessor reportUnclusteredSSProcessor() {
+        return new ReportUnclusteredSSProcessor();
+    }
+
+    @Bean(PENDING_MERGE_AND_SPLIT_REPORTER)
+    public PendingMergeSplitReporter pendingMergeSplitReporter(
+            @Qualifier(CLUSTERED_CLUSTERING_WRITER) ClusteringWriter clusteringWriter,
+            InputParameters parameters,
+            MongoTemplate mongoTemplate) {
+        return new PendingMergeSplitReporter(parameters.getAssemblyAccession(), clusteringWriter, mongoTemplate);
+    }
+
+    @Bean(EXTRANEOUS_RS_REPORTER)
+    public ExtraneousRSReporter extraneousRSReporter(InputParameters parameters, MongoTemplate mongoTemplate) {
+        return new ExtraneousRSReporter(parameters.getAssemblyAccession(), mongoTemplate);
+    }
+
+    // QC step that reports unclustered SS and any pending merges/splits in the clustered assembly
+    @Bean(REPORT_UNCLUSTERED_SS_AND_PENDING_MERGES_AND_SPLITS_STEP)
+    public Step reportUnclusteredSSAndPendingMergeSplitStep(
+            @Qualifier(REMAPPED_SS_READER) ItemStreamReader<SubmittedVariantEntity> remappedSSReader,
+            @Qualifier(REPORT_UNCLUSTERED_SS_PROCESSOR)
+                    ItemProcessor<SubmittedVariantEntity, SubmittedVariantEntity> reportUnclusteredSSProcessor,
+            @Qualifier(PENDING_MERGE_AND_SPLIT_REPORTER)
+                    ItemWriter<SubmittedVariantEntity> pendingMergeSplitReporter,
+            @Qualifier(PROGRESS_LISTENER) StepExecutionListener progressListener,
+            StepBuilderFactory stepBuilderFactory,
+            SimpleCompletionPolicy chunkSizeCompletionPolicy) {
+        return stepBuilderFactory.get(REPORT_UNCLUSTERED_SS_AND_PENDING_MERGES_AND_SPLITS_STEP)
+                .<SubmittedVariantEntity, SubmittedVariantEntity>chunk(chunkSizeCompletionPolicy)
+                .reader(remappedSSReader)
+                .processor(reportUnclusteredSSProcessor)
+                .writer(pendingMergeSplitReporter)
+                .listener(progressListener)
+                .build();
+    }
+
+    // QC step that reports extraneous RS i.e., RS not assigned to any SS
+    @Bean(REPORT_EXTRANEOUS_RS_STEP)
+    public Step reportExtraneousRSStep(
+            @Qualifier(REMAPPED_RS_READER) ItemStreamReader<ClusteredVariantEntity> remappedRSReader,
+            @Qualifier(EXTRANEOUS_RS_REPORTER)
+                    ItemWriter<ClusteredVariantEntity> extraneousRSReporter,
+            @Qualifier(PROGRESS_LISTENER) StepExecutionListener progressListener,
+            StepBuilderFactory stepBuilderFactory,
+            SimpleCompletionPolicy chunkSizeCompletionPolicy) {
+        return stepBuilderFactory.get(REPORT_EXTRANEOUS_RS_STEP)
+                .<ClusteredVariantEntity, ClusteredVariantEntity>chunk(chunkSizeCompletionPolicy)
+                .reader(remappedRSReader)
+                .writer(extraneousRSReporter)
+                .listener(progressListener)
+                .build();
+    }
+
+    @Bean(CLUSTERING_QC_JOB)
+    public Job ClusteringQCJob(
+            @Qualifier(REPORT_UNCLUSTERED_SS_AND_PENDING_MERGES_AND_SPLITS_STEP)
+                    Step reportUnclusteredSSAndPendingMergeSplitStep,
+            @Qualifier(REPORT_EXTRANEOUS_RS_STEP)
+                    Step reportExtraneousRSStep,
+            JobBuilderFactory jobBuilderFactory) {
+        return jobBuilderFactory.get(CLUSTERING_QC_JOB)
+                .incrementer(new RunIdIncrementer())
+                .start(reportUnclusteredSSAndPendingMergeSplitStep)
+                .next(reportExtraneousRSStep)
+                .build();
+    }
+}

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringFromMongoStepConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringFromMongoStepConfiguration.java
@@ -31,6 +31,9 @@ import org.springframework.context.annotation.Configuration;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
 
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PROPAGATED_RS_READER;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PROPAGATED_RS_WRITER;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PROPAGATE_RS_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERED_VARIANTS_MONGO_READER;
@@ -144,6 +147,24 @@ public class ClusteringFromMongoStepConfiguration {
                 .writer(submittedVariantWriter)
                 .listener(progressListener)
                 .build();
+        return step;
+    }
+
+    @Bean(BACK_PROPAGATE_RS_STEP)
+    public Step backPropagateRSStep(
+            @Qualifier(BACK_PROPAGATED_RS_READER)
+                    ItemStreamReader<SubmittedVariantEntity> backPropagatedRSReader,
+            @Qualifier(BACK_PROPAGATED_RS_WRITER) ItemWriter<SubmittedVariantEntity> backPropagatedRSWriter,
+            @Qualifier(PROGRESS_LISTENER) StepExecutionListener progressListener,
+            StepBuilderFactory stepBuilderFactory,
+            SimpleCompletionPolicy chunkSizeCompletionPolicy) {
+        TaskletStep step = stepBuilderFactory.get(BACK_PROPAGATE_RS_STEP)
+                                             .<SubmittedVariantEntity, SubmittedVariantEntity>chunk(
+                                                     chunkSizeCompletionPolicy)
+                                             .reader(backPropagatedRSReader)
+                                             .writer(backPropagatedRSWriter)
+                                             .listener(progressListener)
+                                             .build();
         return step;
     }
 }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/parameters/InputParameters.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/parameters/InputParameters.java
@@ -22,6 +22,8 @@ public class InputParameters {
 
     private String vcf;
 
+    private String remappedFrom;
+
     private String projectAccession;
 
     private String assemblyAccession;
@@ -77,5 +79,13 @@ public class InputParameters {
                 .addString("vcf", vcf)
                 .addLong("chunkSize", (long) chunkSize, false)
                 .toJobParameters();
+    }
+
+    public String getRemappedFrom() {
+        return remappedFrom;
+    }
+
+    public void setRemappedFrom(String remappedFrom) {
+        this.remappedFrom = remappedFrom;
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringVariantJobConfigurationTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringVariantJobConfigurationTest.java
@@ -63,6 +63,7 @@ import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.BACK_PROPAGATE_RS_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_CLUSTERED_VARIANTS_FROM_MONGO_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_FROM_VCF_STEP;
@@ -147,6 +148,7 @@ public class ClusteringVariantJobConfigurationTest {
         expectedSteps.add(PROCESS_RS_SPLIT_CANDIDATES_STEP);
         expectedSteps.add(CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES_STEP);
         expectedSteps.add(CLUSTERING_NON_CLUSTERED_VARIANTS_FROM_MONGO_STEP);
+        expectedSteps.add(BACK_PROPAGATE_RS_STEP);
         assertStepsExecuted(expectedSteps, jobExecution);
         assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
     }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/test/configuration/BatchTestConfiguration.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/test/configuration/BatchTestConfiguration.java
@@ -27,11 +27,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.transaction.PlatformTransactionManager;
+
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.BackPropagatedRSReaderConfiguration;
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.BackPropagatedRSWriterConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.ClusteringMongoReaderConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.ClusteringWriterConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplitCandidatesReaderConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplitWriterConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.VcfReaderConfiguration;
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs.BackPropagateRSJobConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs.ClusterUnclusteredVariantsJobConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs.ClusteringFromMongoJobConfiguration;
 import uk.ac.ebi.eva.accession.clustering.configuration.batch.jobs.ClusteringFromVcfJobConfiguration;
@@ -54,6 +58,7 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTER
         ClusteringFromMongoJobConfiguration.class,
         ProcessRemappedVariantsWithRSJobConfiguration.class,
         ClusterUnclusteredVariantsJobConfiguration.class,
+        BackPropagateRSJobConfiguration.class,
         ClusteringFromVcfStepConfiguration.class,
         ClusteringFromMongoStepConfiguration.class,
         VcfReaderConfiguration.class,
@@ -62,6 +67,8 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTER
         ClusteringMongoReaderConfiguration.class,
         ClusteringVariantProcessorConfiguration.class,
         ClusteringWriterConfiguration.class,
+        BackPropagatedRSReaderConfiguration.class,
+        BackPropagatedRSWriterConfiguration.class,
         ListenersConfiguration.class,
         ClusteringCommandLineRunner.class,
         ChunkSizeCompletionPolicyConfiguration.class})

--- a/eva-accession-clustering/src/test/resources/clustering-issuance-test.properties
+++ b/eva-accession-clustering/src/test/resources/clustering-issuance-test.properties
@@ -1,6 +1,7 @@
 parameters.vcf=src/test/resources/input-files/vcf/aggregated_accessioned.vcf.gz
 parameters.projectAccession=projectId_1
 parameters.assemblyAccession=GCA_000000001.1
+parameters.remappedFrom=ASM1
 parameters.chunkSize=2
 
 eva.count-stats.url=http://localhost:8080

--- a/eva-accession-clustering/src/test/resources/clustering-pipeline-test.properties
+++ b/eva-accession-clustering/src/test/resources/clustering-pipeline-test.properties
@@ -1,6 +1,7 @@
 parameters.vcf=src/test/resources/input-files/vcf/aggregated_accessioned.vcf.gz
 parameters.projectAccession=projectId_1
 parameters.assemblyAccession=GCA_000000001.1
+parameters.remappedFrom=ASM1
 parameters.chunkSize=2
 
 eva.count-stats.url=http://localhost:8080

--- a/eva-accession-clustering/src/test/resources/clustering-writer-test.properties
+++ b/eva-accession-clustering/src/test/resources/clustering-writer-test.properties
@@ -1,6 +1,7 @@
 parameters.vcf=src/test/resources/input-files/vcf/aggregated_accessioned.vcf.gz
 parameters.projectAccession=projectId_1
 parameters.assemblyAccession=asm2
+parameters.remappedFrom=asm1
 parameters.chunkSize=2
 
 eva.count-stats.url=http://localhost:8080

--- a/eva-accession-clustering/src/test/resources/merge-split-test.properties
+++ b/eva-accession-clustering/src/test/resources/merge-split-test.properties
@@ -1,6 +1,7 @@
 parameters.vcf=src/test/resources/input-files/vcf/aggregated_accessioned.vcf.gz
 parameters.projectAccession=projectId_1
 parameters.assemblyAccession=GCA_000000001.1
+parameters.remappedFrom=ASM1
 parameters.chunkSize=2
 
 eva.count-stats.url=http://localhost:8080

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/repository/nonhuman/dbsnp/DbsnpSubmittedVariantAccessioningRepository.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/repository/nonhuman/dbsnp/DbsnpSubmittedVariantAccessioningRepository.java
@@ -29,4 +29,6 @@ public interface DbsnpSubmittedVariantAccessioningRepository extends
 
     List<DbsnpSubmittedVariantEntity> findByClusteredVariantAccessionIn(List<Long> clusteredVariantAccession);
 
+    List<DbsnpSubmittedVariantEntity> findByReferenceSequenceAccessionAndAccessionIn(String referenceSequenceAccession,
+                                                                                     List<Long> accession);
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/SubmittedVariantAccessioningService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/SubmittedVariantAccessioningService.java
@@ -214,4 +214,21 @@ public class SubmittedVariantAccessioningService implements AccessioningService<
             return accessioningServiceDbsnp.getLastInactive(accession);
         }
     }
+
+    public List<AccessionWrapper<ISubmittedVariant, String, Long>>
+    getAllActiveByAssemblyAndAccessionIn(String assembly, List<Long> accessionList) {
+        List<Long> evaAccessions = new ArrayList<>();
+        List<Long> dbsnpAccessions = new ArrayList<>();
+        for (Long accession : accessionList) {
+            if (accession >= accessioningMonotonicInitSs) {
+                evaAccessions.add(accession);
+            } else {
+                dbsnpAccessions.add(accession);
+            }
+        }
+        List<AccessionWrapper<ISubmittedVariant, String, Long>> result =
+                accessioningService.getAllActiveByAssemblyAndAccessionIn(assembly, evaAccessions);
+        result.addAll(accessioningServiceDbsnp.getAllActiveByAssemblyAndAccessionIn(assembly, dbsnpAccessions));
+        return result;
+    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/dbsnp/DbsnpSubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/dbsnp/DbsnpSubmittedVariantAccessioningDatabaseService.java
@@ -161,4 +161,11 @@ public class DbsnpSubmittedVariantAccessioningDatabaseService
         this.checkAccessionIsActive(entities, accession);
         return entities.stream().map(this::toModelWrapper).collect(Collectors.toList());
     }
+
+    public List<AccessionWrapper<ISubmittedVariant, String, Long>> getAllActiveByAssemblyAndAccessionIn
+            (String assembly, List<Long> accessionList) {
+        List<DbsnpSubmittedVariantEntity> entities = this.repository
+                .findByReferenceSequenceAccessionAndAccessionIn(assembly, accessionList);
+        return entities.stream().map(this::toModelWrapper).collect(Collectors.toList());
+    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/dbsnp/DbsnpSubmittedVariantMonotonicAccessioningService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/dbsnp/DbsnpSubmittedVariantMonotonicAccessioningService.java
@@ -60,4 +60,9 @@ public class DbsnpSubmittedVariantMonotonicAccessioningService
             throws AccessionMergedException, AccessionDoesNotExistException, AccessionDeprecatedException {
         return dbService.getAllByAccession(accession);
     }
+
+    public List<AccessionWrapper<ISubmittedVariant, String, Long>>
+    getAllActiveByAssemblyAndAccessionIn(String assembly, List<Long> accessionList) {
+        return dbService.getAllActiveByAssemblyAndAccessionIn(assembly, accessionList);
+    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/eva/SubmittedVariantAccessioningDatabaseService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/eva/SubmittedVariantAccessioningDatabaseService.java
@@ -108,4 +108,11 @@ public class SubmittedVariantAccessioningDatabaseService
             default:
         }
     }
+
+    public List<AccessionWrapper<ISubmittedVariant, String, Long>> getAllActiveByAssemblyAndAccessionIn
+            (String assembly, List<Long> accessionList) {
+        List<SubmittedVariantEntity> entities = this.repository
+                .findByReferenceSequenceAccessionAndAccessionIn(assembly, accessionList);
+        return entities.stream().map(this::toModelWrapper).collect(Collectors.toList());
+    }
 }

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/eva/SubmittedVariantMonotonicAccessioningService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/service/nonhuman/eva/SubmittedVariantMonotonicAccessioningService.java
@@ -54,4 +54,9 @@ public class SubmittedVariantMonotonicAccessioningService
             throws AccessionMergedException, AccessionDoesNotExistException, AccessionDeprecatedException {
         return dbService.getAllByAccession(accession);
     }
+
+    public List<AccessionWrapper<ISubmittedVariant, String, Long>>
+    getAllActiveByAssemblyAndAccessionIn(String assembly, List<Long> accessionList) {
+        return dbService.getAllActiveByAssemblyAndAccessionIn(assembly, accessionList);
+    }
 }


### PR DESCRIPTION
This PR deals with the following changes:

* When assigning RS to SS during splits, use hash-based updates instead of accession-based updates to avoid [infinite splitting scenario](https://docs.google.com/spreadsheets/d/1KQLVCUy-vqXKgkCDt2czX6kuMfsjfCc9uBsS19MZ6dY/edit#rangeid=1098774347) if clustering is re-run (in case of failures)
* Support multi-level merges 
* Extract back-propagation of RS IDs to its own job so that it can be run in parallel for multiple species
* Created a job to QC clustering