### PR TITLE
EVA-2647 - Address RS back-propagation issues

### DIFF
--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
@@ -219,7 +219,7 @@ public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity
             Map<Long, List<SubmittedVariantEntity>> ssInRemappedAssemblyGroupedByID,
             SubmittedVariantEntity submittedVariantEntity) {
         // Currently if there is more than one entry for the SS accession in the remapped assembly,
-        // we choose the minimum RS ID as a hack since we don't have a way to map between the
+        // we choose the maximum RS ID as a hack since we don't have a way to map between the
         // remapped SS and the original SS in such cases
         // TODO: Re-visit during EVA-2612
         ClusteredVariantEntity rsFromRemappedAssembly =

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
@@ -15,16 +15,17 @@
  */
 package uk.ac.ebi.eva.accession.clustering.batch.io;
 
-import com.mongodb.DuplicateKeyException;
 import com.mongodb.MongoBulkWriteException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
+import uk.ac.ebi.ampt2d.commons.accession.core.models.AccessionWrapper;
 import uk.ac.ebi.ampt2d.commons.accession.core.models.EventType;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.AccessionedDocument;
 import uk.ac.ebi.eva.accession.clustering.metric.ClusteringMetric;
@@ -35,10 +36,12 @@ import uk.ac.ebi.eva.accession.core.model.eva.ClusteredVariantEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantInactiveEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
+import uk.ac.ebi.eva.accession.core.service.nonhuman.ClusteredVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.service.nonhuman.SubmittedVariantAccessioningService;
 import uk.ac.ebi.eva.metrics.metric.MetricCompute;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -60,6 +63,8 @@ public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity
 
     private final ClusteringWriter clusteringWriter;
 
+    private final ClusteredVariantAccessioningService clusteredVariantAccessioningService;
+
     private final SubmittedVariantAccessioningService submittedVariantAccessioningService;
 
     private static final String ID_ATTRIBUTE = "_id";
@@ -71,12 +76,14 @@ public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity
     private final MetricCompute metricCompute;
 
     public BackPropagatedRSWriter(String originalAssembly, String remappedAssembly, ClusteringWriter clusteringWriter,
+                                  ClusteredVariantAccessioningService clusteredVariantAccessioningService,
                                   SubmittedVariantAccessioningService submittedVariantAccessioningService,
                                   MongoTemplate mongoTemplate,
                                   MetricCompute metricCompute) {
         this.originalAssembly = originalAssembly;
         this.remappedAssembly = remappedAssembly;
         this.clusteringWriter = clusteringWriter;
+        this.clusteredVariantAccessioningService = clusteredVariantAccessioningService;
         this.submittedVariantAccessioningService = submittedVariantAccessioningService;
         this.mongoTemplate = mongoTemplate;
         this.metricCompute = metricCompute;
@@ -96,6 +103,12 @@ public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity
                         // Don't bring such variants in for clustering again.
                         .filter(SubmittedVariantEntity::isAllelesMatch)
                         .map(AccessionedDocument::getAccession).collect(Collectors.toList());
+
+        // There may be some unclustered SS left behind which could potentially be assigned
+        // an existing RS in the current assembly
+        Map<SubmittedVariantEntity, ClusteredVariantEntity> ssWithSuitableRSInCurrentAssembly =
+                getRSPresentInCurrentAssembly(submittedVariantEntitiesInOriginalAssemblyWithNoRS);
+
         Map<Long, List<SubmittedVariantEntity>> ssInRemappedAssemblyGroupedByID =
                 submittedVariantAccessioningService
                         .getAllActiveByAssemblyAndAccessionIn(remappedAssembly, ssIDsToLookupInRemappedAssembly)
@@ -105,14 +118,33 @@ public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity
                                                                   entity.getVersion()))
                         .filter(entity -> Objects.nonNull(entity.getClusteredVariantAccession()))
                         .collect(Collectors.groupingBy(SubmittedVariantEntity::getAccession));
-        backPropagateRS(submittedVariantEntitiesInOriginalAssemblyWithNoRS, ssInRemappedAssemblyGroupedByID);
+        assignRSToSS(submittedVariantEntitiesInOriginalAssemblyWithNoRS, ssWithSuitableRSInCurrentAssembly,
+                     ssInRemappedAssemblyGroupedByID);
     }
 
-    /*
-      @see <a href="https://docs.google.com/spreadsheets/d/1KQLVCUy-vqXKgkCDt2czX6kuMfsjfCc9uBsS19MZ6dY/edit#rangeid=717877299"/>
-     */
-    private void backPropagateRS(
+    private Map<SubmittedVariantEntity, ClusteredVariantEntity> getRSPresentInCurrentAssembly(
+            List<? extends SubmittedVariantEntity> submittedVariantEntitiesInOriginalAssemblyWithNoRS) {
+        Map<SubmittedVariantEntity, ClusteredVariantEntity> ssAndAssociatedCVE =
+                submittedVariantEntitiesInOriginalAssemblyWithNoRS
+                        .stream()
+                        .collect(Collectors.toMap(ss -> ss, clusteringWriter::toClusteredVariantEntity));
+        Map<String, ClusteredVariantEntity> rsPresentInCurrentAssembly =
+                clusteredVariantAccessioningService
+                        .get(new ArrayList<>(ssAndAssociatedCVE.values()))
+                        .stream().collect(Collectors.toMap(AccessionWrapper::getHash,
+                                                           e -> new ClusteredVariantEntity(e.getAccession(),
+                                                                                           e.getHash(), e.getData(),
+                                                                                           e.getVersion())));
+        return ssAndAssociatedCVE.entrySet().stream()
+                                 .filter(e -> rsPresentInCurrentAssembly.containsKey(e.getValue().getHashedMessage()))
+                                 .collect(Collectors.toMap(Map.Entry::getKey,
+                                                           e -> rsPresentInCurrentAssembly
+                                                                   .get(e.getValue().getHashedMessage())));
+    }
+
+    private void assignRSToSS(
             @Nonnull List<? extends SubmittedVariantEntity> submittedVariantEntitiesInOriginalAssemblyWithNoRS,
+            Map<SubmittedVariantEntity, ClusteredVariantEntity> ssWithSuitableRSInCurrentAssembly,
             Map<Long, List<SubmittedVariantEntity>> ssInRemappedAssemblyGroupedByID) {
 
         // Inserts to create RS record for back-propagated RS in the original assembly
@@ -140,8 +172,24 @@ public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity
         int numDbsnpRSInserts = 0;
 
         for (SubmittedVariantEntity submittedVariantEntity: submittedVariantEntitiesInOriginalAssemblyWithNoRS) {
-            Long ssIDToAssignRS = submittedVariantEntity.getAccession();
-            if (ssInRemappedAssemblyGroupedByID.containsKey(ssIDToAssignRS)) {
+            Long ssIDToBeClustered = submittedVariantEntity.getAccession();
+            Long rsToAssign = null;
+            ClusteredVariantEntity newRSRecordForOriginalAssembly = null;
+
+            if (ssWithSuitableRSInCurrentAssembly.containsKey(submittedVariantEntity)) {
+                rsToAssign = ssWithSuitableRSInCurrentAssembly.get(submittedVariantEntity).getAccession();
+            }
+            /*
+                Back-propagate RS from the remapped assembly if no suitable RS found in the current assembly
+                @see <a href="https://docs.google.com/spreadsheets/d/1KQLVCUy-vqXKgkCDt2czX6kuMfsjfCc9uBsS19MZ6dY/edit#rangeid=717877299"/>
+            */
+            else if (ssInRemappedAssemblyGroupedByID.containsKey(ssIDToBeClustered)) {
+                newRSRecordForOriginalAssembly =
+                        getSuitableRSFromRemappedSS(ssInRemappedAssemblyGroupedByID, submittedVariantEntity);
+                rsToAssign = newRSRecordForOriginalAssembly.getAccession();
+            }
+
+            if (Objects.nonNull(rsToAssign)) {
                 BulkOperations bulkSVEUpdates, bulkSVOEInserts, bulkCVEInserts;
                 if (clusteringWriter.isEvaSubmittedVariant(submittedVariantEntity)) {
                     bulkSVEUpdates = evaSVEUpdates;
@@ -152,19 +200,19 @@ public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity
                     bulkSVOEInserts = dbsnpSVOEInserts;
                     numDbsnpRSAssignments += 1;
                 }
-                ClusteredVariantEntity newRSRecordForOriginalAssembly =
-                        getSuitableRSFromRemappedSS(ssInRemappedAssemblyGroupedByID, submittedVariantEntity);
-                Long rsToAssign = newRSRecordForOriginalAssembly.getAccession();
 
-                if (clusteringWriter.getClusteredVariantCollection(rsToAssign).equals(ClusteredVariantEntity.class)) {
-                    bulkCVEInserts = evaCVEInserts;
-                    numEVARSInserts += 1;
-                } else {
-                    bulkCVEInserts = dbsnpCVEInserts;
-                    numDbsnpRSInserts += 1;
+                if (Objects.nonNull(newRSRecordForOriginalAssembly)) {
+                    if (clusteringWriter.getClusteredVariantCollection(rsToAssign).equals(
+                            ClusteredVariantEntity.class)) {
+                        bulkCVEInserts = evaCVEInserts;
+                        numEVARSInserts += 1;
+                    } else {
+                        bulkCVEInserts = dbsnpCVEInserts;
+                        numDbsnpRSInserts += 1;
+                    }
+                    bulkCVEInserts.insert(newRSRecordForOriginalAssembly);
+                    metricCompute.addCount(ClusteringMetric.CLUSTERED_VARIANTS_CREATED, 1);
                 }
-                bulkCVEInserts.insert(newRSRecordForOriginalAssembly);
-                metricCompute.addCount(ClusteringMetric.CLUSTERED_VARIANTS_CREATED, 1);
 
                 Query queryToLookUpSSHash = query(where(ID_ATTRIBUTE).is(submittedVariantEntity.getHashedMessage()));
                 Update updateRSInOriginalAssembly = Update.update(RS_ATTRIBUTE, rsToAssign);

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
@@ -256,7 +256,7 @@ public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity
             // it means that, for some reason, SS1 was not clustered with RS1 when ASM1 underwent clustering.
             // It is better to flag such issues for later analysis.
             extractUniqueHashesForDuplicateKeyError(writeException)
-                    .forEach(hash -> logger.error("Attempted to insert RS record with already existing hash " + hash +
+                    .forEach(hash -> logger.warn("Attempted to insert RS record with already existing hash " + hash +
                                                          "during RS ID back-propagation! This could be symptomatic " +
                                                          "of clustering issues with the original assembly "
                                                          + this.originalAssembly + "."));

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/BackPropagatedRSWriter.java
@@ -256,7 +256,7 @@ public class BackPropagatedRSWriter implements ItemWriter<SubmittedVariantEntity
             // it means that, for some reason, SS1 was not clustered with RS1 when ASM1 underwent clustering.
             // It is better to flag such issues for later analysis.
             extractUniqueHashesForDuplicateKeyError(writeException)
-                    .forEach(hash -> logger.warn("Attempted to insert RS record with already existing hash " + hash +
+                    .forEach(hash -> logger.error("Attempted to insert RS record with already existing hash " + hash +
                                                          "during RS ID back-propagation! This could be symptomatic " +
                                                          "of clustering issues with the original assembly "
                                                          + this.originalAssembly + "."));

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/BackPropagatedRSWriterConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/BackPropagatedRSWriterConfiguration.java
@@ -29,6 +29,7 @@ import uk.ac.ebi.eva.accession.core.configuration.nonhuman.ClusteredVariantAcces
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.SubmittedVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.service.nonhuman.ClusteredVariantAccessioningService;
 import uk.ac.ebi.eva.accession.core.service.nonhuman.SubmittedVariantAccessioningService;
 import uk.ac.ebi.eva.metrics.metric.MetricCompute;
 
@@ -44,10 +45,11 @@ public class BackPropagatedRSWriterConfiguration {
     public ItemWriter<SubmittedVariantEntity> backPropagatedRSWriter(
             @Qualifier(CLUSTERED_CLUSTERING_WRITER) ClusteringWriter clusteringWriter,
             MongoTemplate mongoTemplate, InputParameters parameters,
+            ClusteredVariantAccessioningService clusteredVariantAccessioningService,
             SubmittedVariantAccessioningService submittedVariantAccessioningService,
             MetricCompute metricCompute) {
         return new BackPropagatedRSWriter(parameters.getRemappedFrom(), parameters.getAssemblyAccession(),
-                clusteringWriter, submittedVariantAccessioningService, mongoTemplate,
-                metricCompute);
+                                          clusteringWriter, clusteredVariantAccessioningService,
+                                          submittedVariantAccessioningService, mongoTemplate, metricCompute);
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
@@ -197,8 +197,8 @@ public class ReuseAccessionClusteringWriterTest {
         this.clusterVariants(Collections.singletonList(sveNonClustered));
         assertEquals(2, mongoTemplate.count(new Query(), ClusteredVariantEntity.class));
 
-        // Two RS - one reused for clustering the non-clustered variant sveNonClustered in the remapped assembly
-        // and another for back-propagating that new RS to the original assembly
+        // Two RS - one reused (but not created) for clustering the non-clustered variant sveNonClustered in the remapped assembly
+        // and another back-propagated RS created for the original assembly
         assertClusteringCounts(metricCompute, 1, 0, 0, 0, 2, 0, 2);
     }
 


### PR DESCRIPTION
This PR is layered on top of [another PR](https://github.com/EBIvariation/eva-accession/pull/308). Therefore use [this link](https://github.com/sundarvenkata-EBI/eva-accession/compare/fix/overlapping_merges...sundarvenkata-EBI:fix/address_backprop_issues?expand=1) to view the actual differences.

This PR accomplishes the following:

* Address review comments regarding back-propagation from April and Tim. Links to the original review comments are provided inline in the PR.
* Update back-propagation writer to use back-propagation from the remapped assembly only if there is no suitable RS in the current assembly. See scenario [here](https://docs.google.com/spreadsheets/d/1KQLVCUy-vqXKgkCDt2czX6kuMfsjfCc9uBsS19MZ6dY/edit#rangeid=1618907977).