### PR TITLE
EVA-2652 - Fix release pipeline issues

### DIFF
--- a/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
+++ b/eva-accession-release-automation/run_release_in_embassy/create_release_properties_file.py
@@ -68,9 +68,11 @@ def create_release_properties_file_for_assembly(private_config_xml_file, profile
                                                              species_release_folder)
     properties_string = """
         spring.batch.job.names=ACCESSION_RELEASE_JOB
+        parameters.accessionedVcf=
         parameters.assemblyAccession={assembly_accession}
         parameters.assemblyReportUrl={report_path}
         parameters.chunkSize=1000
+        parameters.contigNaming=SEQUENCE_NAME
         parameters.fasta={fasta_path}
         parameters.forceRestart=true
         parameters.outputFolder={output_folder}

--- a/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
@@ -53,8 +53,8 @@ def close_mongo_port_to_tempmongo(port_forwarding_process_id):
 
 
 def get_bgzip_bcftools_index_commands_for_file(bgzip_path, bcftools_path, file):
-    commands = ["rm -f {0}.gz".format(file), "({0} --csi {1} > {1}.gz)".format(bgzip_path, file),
-                "({0} -cf {1}.gz)".format(bcftools_path, file)]
+    commands = ["rm -f {0}.gz".format(file), "({0} -cf {1} > {1}.gz)".format(bgzip_path, file),
+                "({0} index --csi {1}.gz)".format(bcftools_path, file)]
     return commands
 
 

--- a/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/batch/io/VariantMongoAggregationReader.java
+++ b/eva-accession-release/src/main/java/uk/ac/ebi/eva/accession/release/batch/io/VariantMongoAggregationReader.java
@@ -66,6 +66,8 @@ public abstract class VariantMongoAggregationReader implements ItemStreamReader<
 
     protected static final String REFERENCE_ASSEMBLY_FIELD = "asm";
 
+    protected static final String REFERENCE_ASSEMBLY_FIELD_IN_SUBMITTED_COLLECTIONS = "seq";
+
     protected static final String STUDY_FIELD = "study";
 
     protected static final String CONTIG_FIELD = "contig";

--- a/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/batch/io/active/AccessionedVariantMongoReaderTest.java
+++ b/eva-accession-release/src/test/java/uk/ac/ebi/eva/accession/release/batch/io/active/AccessionedVariantMongoReaderTest.java
@@ -36,7 +36,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
-import uk.ac.ebi.eva.accession.release.batch.io.active.AccessionedVariantMongoReader;
 import uk.ac.ebi.eva.accession.release.collectionNames.DbsnpCollectionNames;
 import uk.ac.ebi.eva.accession.release.test.configuration.MongoTestConfiguration;
 import uk.ac.ebi.eva.accession.release.test.rule.FixSpringMongoDbRule;
@@ -414,5 +413,17 @@ public class AccessionedVariantMongoReaderTest {
 
         assertTrue(isVariantPresent(allVariants, "CM001642.1", 7356604L, "",
                                     "AGAGCTATGATCTTCGGAAGGAGAAGGAGAAGGAAAAGATTCATGACGTCCAC"));
+    }
+
+    /*
+    For a given SS ID ss1 and release assembly ASM2, if ss1 has entries in both ASM1 and ASM2,
+    ensure that the variant list only uses the ss1 entry in ASM1
+     */
+    @Test
+    public void ensureOnlySSInReleaseAssemblyIsUsed() throws Exception {
+        Variant variantInTwoAssemblies = readIntoList().stream().filter(e -> e.getIds().contains("rs8181"))
+                                                       .findFirst().get();
+        // Ensure that only one SS entry is available in the variant that was read
+        assertEquals(1, variantInTwoAssemblies.getSourceEntries().size());
     }
 }

--- a/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
+++ b/eva-accession-release/src/test/resources/test-data/dbsnpSubmittedVariantEntity.json
@@ -33,6 +33,20 @@
       )
     },
     {
+      "_id": "81901D6C149D283D8E00859E8BADC1C89750CCCD",
+      "seq": "GCA_000409795.1",
+      "tax": 60711,
+      "study": "PRJEB7923",
+      "contig": "CM001954.1",
+      "start": NumberLong(151),
+      "ref": "",
+      "alt": "T",
+      "rs": NumberLong(8181),
+      "accession": NumberLong(8283),
+      "version": 1,
+      "createdDate": ISODate("2016-05-05T13:43:00Z")
+    },
+    {
       "_id": "81901D6C149D283D8E00859E8BADC1C89750F111",
       "seq": "GCA_000409795.2",
       "tax": 60711,


### PR DESCRIPTION
This PR accomplishes two things:

* Ensure that [only the SS corresponding to the release assembly](https://github.com/EBIvariation/eva-accession/pull/309/commits/9d8295dc153cf6ff759b86a80b74be89b939a152) is chosen by the release pipeline
* Fix a [few issues in automation](https://github.com/EBIvariation/eva-accession/pull/309/commits/28f65b9829cbc5519dd8a8430419cf9405e929a2) that prevent release pipeline from running