### PR TITLE
EVA-2821 - Avoid accidental hash collision when creating original ASM SS records

### DIFF
--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/runner/ClusteringCommandLineRunnerTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/runner/ClusteringCommandLineRunnerTest.java
@@ -855,10 +855,12 @@ public class ClusteringCommandLineRunnerTest {
         List<SubmittedVariantEntity> variantsInRemappedAssembly =
                 Arrays.asList(evaSS1, dbsnpSS2, evaSS5, dbsnpSS7, evaSS8, evaSS9);
         for (SubmittedVariantEntity variantInRemappedAssembly: variantsInRemappedAssembly) {
+            // getStart is multiplied by 1000 so as to avoid accidental hash collision across the list of SS above
+            // due to the same start positions
             RSLocus rsLocusObj = new RSLocus(ASM1, variantInRemappedAssembly.getContig(),
-                                             variantInRemappedAssembly.getStart() + ThreadLocalRandom.current()
-                                                                                                     .nextLong(10),
-                                             VariantType.SNV);
+                    variantInRemappedAssembly.getStart()*1000
+                            + ThreadLocalRandom.current().nextLong(10),
+                    VariantType.SNV);
             ClusteredVariantEntity rsObj = createRS(variantInRemappedAssembly.getClusteredVariantAccession(),
                                                     rsLocusObj, false);
             createSS(variantInRemappedAssembly.getAccession(),


### PR DESCRIPTION
There was a [failed CI attempt](https://github.com/EBIvariation/eva-accession/actions/runs/2195431384/attempts/1) when merging the previous PR for this ticket. The failure was due to an accidental hash collision between evaSS1 and evaSS9 when creating original ASM records. This PR fixes that.