### PR TITLE
EVA-2823 - Update scripts to use production_processing profile

### DIFF
--- a/eva-accession-clustering-automation/clustering_automation/cluster_from_mongo.py
+++ b/eva-accession-clustering-automation/clustering_automation/cluster_from_mongo.py
@@ -112,7 +112,7 @@ def cluster_multiple_from_mongo(taxonomy_id, common_clustering_properties_file, 
     clustering_tracking_table = common_properties["clustering-release-tracker"]
     release_version = common_properties["release-version"]
     clustering_folder = common_properties['clustering-folder']
-    with get_metadata_connection_handle("production", common_properties["private-config-xml-file"]) as metadata_connection_handle:
+    with get_metadata_connection_handle("production_processing", common_properties["private-config-xml-file"]) as metadata_connection_handle:
         assembly_list, scientific_name = get_assemblies_and_scientific_name_from_taxonomy(taxonomy_id, metadata_connection_handle, clustering_tracking_table, release_version)
         pipeline, output_directory = generate_linear_pipeline(taxonomy_id, scientific_name, assembly_list, common_properties, memory, instance, enable_retryable)
         pipeline.run_pipeline(

--- a/eva-accession-clustering-automation/clustering_automation/update_clustering_status.py
+++ b/eva-accession-clustering-automation/clustering_automation/update_clustering_status.py
@@ -35,7 +35,7 @@ def set_clustering_status(private_config_xml_file, clustering_tracking_table, as
         update_status_query += f", clustering_end='{now}'"
     update_status_query += (f" WHERE assembly_accession='{assembly}' AND taxonomy='{tax_id}' "
                             f"AND release_version={release_version}")
-    with get_metadata_connection_handle("production", private_config_xml_file) as metadata_connection_handle:
+    with get_metadata_connection_handle("production_processing", private_config_xml_file) as metadata_connection_handle:
         execute_query(metadata_connection_handle, update_status_query)
 
 

--- a/eva-accession-release-automation/include_mapping_weight_from_dbsnp/add_mapping_weight_attribute.py
+++ b/eva-accession-release-automation/include_mapping_weight_from_dbsnp/add_mapping_weight_attribute.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 def import_mapping_weight_attribute_for_dbsnp_species(private_config_xml_file, metadata_connection_handle,
                                                       dbsnp_species_taxonomy):
     metadata_params = metadata_connection_handle.get_dsn_parameters()
-    mongo_params = parse_uri(get_mongo_uri_for_eva_profile("production", private_config_xml_file))
+    mongo_params = parse_uri(get_mongo_uri_for_eva_profile("production_processing", private_config_xml_file))
     # nodelist is in format: [(host1,port1), (host2,port2)]. Just choose one.
     # Mongo is smart enough to fallback to secondaries automatically.
     mongo_host = mongo_params["nodelist"][0][0]
@@ -44,7 +44,7 @@ def import_mapping_weight_attribute_for_dbsnp_species(private_config_xml_file, m
 
 def add_mapping_weight_attribute_for_dbsnp_species(private_config_xml_file, dbsnp_species_name):
     try:
-        with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("production", private_config_xml_file),
+        with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("production_processing", private_config_xml_file),
                               user="evapro") as metadata_connection_handle:
             dbsnp_species_taxonomy = int(dbsnp_species_name.split("_")[-1])
             import_mapping_weight_attribute_for_dbsnp_species(private_config_xml_file, metadata_connection_handle,

--- a/eva-accession-release-automation/include_mapping_weight_from_dbsnp/export_all_multimap_snps_from_dbsnp_dumps.py
+++ b/eva-accession-release-automation/include_mapping_weight_from_dbsnp/export_all_multimap_snps_from_dbsnp_dumps.py
@@ -42,7 +42,7 @@ def get_assemblies_with_multimap_snps_for_species(metadata_connection_handle):
 
 def export_all_multimap_snps_from_dbsnp_dumps(private_config_xml_file):
     result_file = "all_multimap_snp_ids_from_dbsnp_dumps.txt"
-    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("production", private_config_xml_file), user="evapro") \
+    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("production_processing", private_config_xml_file), user="evapro") \
         as metadata_connection_handle:
         assembly_GCA_accession_map = get_assemblies_with_multimap_snps_for_species(metadata_connection_handle)
         for species_info in get_species_info(metadata_connection_handle):

--- a/eva-accession-release-automation/include_mapping_weight_from_dbsnp/validate_mapping_weight_addition_to_mongo.py
+++ b/eva-accession-release-automation/include_mapping_weight_from_dbsnp/validate_mapping_weight_addition_to_mongo.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 def get_multimap_snps_from_mongo(private_config_xml_file, collection_to_validate):
     #  Dirty hack: since mongoexport does not allow switching databases
     #  replace admin in the URI with the database name and relegate admin to authSource
-    production_mongo_uri = get_mongo_uri_for_eva_profile("production", private_config_xml_file) \
+    production_mongo_uri = get_mongo_uri_for_eva_profile("production_processing", private_config_xml_file) \
         .replace("/admin", "/eva_accession_sharded?authSource=admin")
     output_file = collection_to_validate + "_multimap_snp_ids.txt"
     accession_attribute = collection_attribute_paths[collection_to_validate]["rs_accession_attribute_name"].replace(
@@ -63,7 +63,7 @@ def are_all_unprocessed_multimap_snps_absent_in_mongo(private_config_xml_file, c
                                                       unprocessed_multimap_snps_in_dbsnp_file):
     chunk_size = 2000
     num_entries_looked_up = 0
-    with MongoClient(get_mongo_uri_for_eva_profile("production", private_config_xml_file)) as mongo_handle:
+    with MongoClient(get_mongo_uri_for_eva_profile("production_processing", private_config_xml_file)) as mongo_handle:
         with open(unprocessed_multimap_snps_in_dbsnp_file) as unprocessed_snps_in_dbsnp_file_handle:
             while True:
                 snps_to_lookup_in_mongo = defaultdict(list)

--- a/eva-accession-release-automation/publish_release_to_ftp/publish_release_files_to_ftp.py
+++ b/eva-accession-release-automation/publish_release_to_ftp/publish_release_files_to_ftp.py
@@ -308,9 +308,9 @@ def publish_release_files_to_ftp(common_release_properties_file, taxonomy_id):
     # Release README, known issues etc.,
     publish_release_top_level_files_to_ftp(release_properties)
 
-    metadata_password = get_properties_from_xml_file("production",
+    metadata_password = get_properties_from_xml_file("production_processing",
                                                      release_properties.private_config_xml_file)["eva.evapro.password"]
-    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("production",
+    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("production_processing",
                                                               release_properties.private_config_xml_file),
                           user="evapro", password=metadata_password) as metadata_connection_handle:
         assemblies_to_process = get_release_assemblies_info_for_taxonomy(taxonomy_id, release_properties,


### PR DESCRIPTION
Updating the changes made in this [commit](https://github.com/EBIvariation/eva-accession/commit/c6ade0a9e40acefae09e347b2180b720c116a99b) per [Nitin's suggestion](https://docs.google.com/document/d/1kisKFmtCg9rCGFOlb7gqf4j1GgHIGBcmhSVaRJGQPvw/edit?disco=AAAAaAzdBTA) to use production_processing profile.