### PR TITLE
EVA-2937 - Detect duplicates when ingesting remapped variants

### DIFF
--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/exceptions/MongoBulkWriteExceptionUtils.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/exceptions/MongoBulkWriteExceptionUtils.java
@@ -30,8 +30,8 @@ public class MongoBulkWriteExceptionUtils {
 
     private static final String DUPLICATE_KEY_ERROR_MESSAGE_GROUP_NAME = "IDKEY";
 
-    private static final String DUPLICATE_KEY_ERROR_MESSAGE_REGEX = "index:\\s.*\\{\\s?\\:\\s?\"(?<"
-            + DUPLICATE_KEY_ERROR_MESSAGE_GROUP_NAME + ">[a-zA-Z0-9]+)\"\\s?\\}";
+    private static final String DUPLICATE_KEY_ERROR_MESSAGE_REGEX = "index:\\s.*\\{\\s?.*\\:\\s?\"(?<"
+            + DUPLICATE_KEY_ERROR_MESSAGE_GROUP_NAME + ">[a-zA-Z0-9_.]+)\"\\s?\\}";
 
     private static final Pattern DUPLICATE_KEY_PATTERN = Pattern.compile(DUPLICATE_KEY_ERROR_MESSAGE_REGEX);
 

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/SubmittedVariantEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/SubmittedVariantEntity.java
@@ -352,7 +352,8 @@ public class SubmittedVariantEntity extends AccessionedDocument<ISubmittedVarian
     @Override
     public String toString() {
         return "SubmittedVariantEntity{" +
-                "referenceSequenceAccession='" + referenceSequenceAccession + '\'' +
+                "accession=" + getAccession() +
+                ", referenceSequenceAccession='" + referenceSequenceAccession + '\'' +
                 ", taxonomyAccession=" + taxonomyAccession +
                 ", projectAccession='" + projectAccession + '\'' +
                 ", contig='" + contig + '\'' +

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/SubmittedVariantOperationEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/SubmittedVariantOperationEntity.java
@@ -22,6 +22,7 @@ import uk.ac.ebi.ampt2d.commons.accession.persistence.mongodb.document.EventDocu
 import uk.ac.ebi.eva.accession.core.model.ISubmittedVariant;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Document
 public class SubmittedVariantOperationEntity extends EventDocument<ISubmittedVariant, Long,
@@ -31,6 +32,27 @@ public class SubmittedVariantOperationEntity extends EventDocument<ISubmittedVar
         super();
         //Set the created date to assure is is assigned when performing bulk operations
         setCreatedDate(LocalDateTime.now());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SubmittedVariantOperationEntity that = (SubmittedVariantOperationEntity) o;
+        return Objects.equals(this.getId(), that.getId()) &&
+                Objects.equals(this.getEventType(), that.getEventType()) &&
+                Objects.equals(this.getAccession(), that.getAccession()) &&
+                Objects.equals(this.getMergedInto(), that.getMergedInto()) &&
+                Objects.equals(this.getSplitInto(), that.getSplitInto()) &&
+                Objects.equals(this.getReason(), that.getReason()) &&
+                Objects.equals(this.getCreatedDate(), that.getCreatedDate()) &&
+                Objects.equals(this.getInactiveObjects(), that.getInactiveObjects());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getId(), this.getEventType(), this.getAccession(), this.getMergedInto(),
+                            this.getSplitInto(),this.getReason(), this.getCreatedDate(), this.getInactiveObjects());
     }
 
     @Override

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/SubmittedVariantOperationEntity.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/model/eva/SubmittedVariantOperationEntity.java
@@ -52,7 +52,7 @@ public class SubmittedVariantOperationEntity extends EventDocument<ISubmittedVar
     @Override
     public int hashCode() {
         return Objects.hash(this.getId(), this.getEventType(), this.getAccession(), this.getMergedInto(),
-                            this.getSplitInto(),this.getReason(), this.getCreatedDate(), this.getInactiveObjects());
+                            this.getSplitInto(), this.getReason(), this.getCreatedDate(), this.getInactiveObjects());
     }
 
     @Override

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriter.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriter.java
@@ -96,12 +96,6 @@ public class RemappedSubmittedVariantsWriter implements ItemWriter<SubmittedVari
                                                               SubmittedVariantEntity.class,
                                                               collection);
         // Deal with discards before inserts, to avoid DuplicateKeyExceptions
-        if (svesToDiscard.size() > 0) {
-            bulkOperations.remove(query(where("_id").in(
-                    svesToDiscard.stream().map(SubmittedVariantEntity::getHashedMessage)
-                                 .collect(Collectors.toSet()))));
-            bulkOperations.execute();
-        }
         if (discardOperations.size() > 0) {
             try {
                 BulkOperations svoeBulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
@@ -124,6 +118,12 @@ public class RemappedSubmittedVariantsWriter implements ItemWriter<SubmittedVari
                 remappingIngestCounts.addRemappedVariantsDiscarded(bulkWriteResult.getInsertedCount());
                 remappingIngestCounts.addRemappedVariantsSkipped(duplicatesSkipped.size());
             }
+        }
+        if (svesToDiscard.size() > 0) {
+            bulkOperations.remove(query(where("_id").in(
+                    svesToDiscard.stream().map(SubmittedVariantEntity::getHashedMessage)
+                                 .collect(Collectors.toSet()))));
+            bulkOperations.execute();
         }
 
         if (svesToInsert.size() > 0) {

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriter.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriter.java
@@ -23,13 +23,27 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.ac.ebi.ampt2d.commons.accession.core.models.EventType;
 
 import uk.ac.ebi.eva.accession.core.exceptions.MongoBulkWriteExceptionUtils;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantInactiveEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
+import uk.ac.ebi.eva.remapping.ingest.batch.io.SubmittedVariantDiscardPolicy.DiscardPriority;
+import uk.ac.ebi.eva.remapping.ingest.batch.io.SubmittedVariantDiscardPolicy.SubmittedVariantDiscardDeterminants;
 import uk.ac.ebi.eva.remapping.ingest.batch.listeners.RemappingIngestCounts;
-import uk.ac.ebi.eva.remapping.ingest.configuration.BeanNames;
+import uk.ac.ebi.eva.remapping.ingest.configuration.CollectionNames;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
 
 public class RemappedSubmittedVariantsWriter implements ItemWriter<SubmittedVariantEntity> {
 
@@ -37,38 +51,156 @@ public class RemappedSubmittedVariantsWriter implements ItemWriter<SubmittedVari
 
     private MongoTemplate mongoTemplate;
 
+    private String assemblyAccession;
+
     private String collection;
+
+    private String operationCollection;
 
     private RemappingIngestCounts remappingIngestCounts;
 
-    public RemappedSubmittedVariantsWriter(MongoTemplate mongoTemplate, String collection,
+    public RemappedSubmittedVariantsWriter(MongoTemplate mongoTemplate, String assemblyAccession, String collection,
                                            RemappingIngestCounts remappingIngestCounts) {
         this.mongoTemplate = mongoTemplate;
+        this.assemblyAccession = assemblyAccession;
         this.collection = collection;
+        this.operationCollection = collection.equals(CollectionNames.SUBMITTED_VARIANT_ENTITY) ?
+                CollectionNames.SUBMITTED_VARIANT_OPERATION_ENTITY : CollectionNames.DBSNP_SUBMITTED_VARIANT_OPERATION_ENTITY;
         this.remappingIngestCounts = remappingIngestCounts;
     }
 
     @Override
     public void write(List<? extends SubmittedVariantEntity> submittedVariantsRemapped) {
+        // We do this to avoid tedious generic type signatures in the method calls
+        List<SubmittedVariantEntity> svesToInsert = new ArrayList<>(submittedVariantsRemapped);
+
         try {
+            // Resolve potential duplicate SS IDs
+            Map<Long, List<SubmittedVariantEntity>> duplicateCandidates = getDuplicateSs(svesToInsert);
+            List<SubmittedVariantEntity> svesToDiscard = resolveDuplicates(duplicateCandidates, svesToInsert);
+            List<SubmittedVariantOperationEntity> discardOperations = getDiscardOperations(svesToDiscard);
+
             BulkOperations bulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
                                                                   SubmittedVariantEntity.class,
                                                                   collection);
-            bulkOperations.insert(submittedVariantsRemapped);
+            BulkOperations svoeBulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                                                                      SubmittedVariantEntity.class,
+                                                                      operationCollection);
+
+            // TODO think about ordering of these statements & idempotency
+            bulkOperations.insert(svesToInsert);
+            if (svesToDiscard.size() > 0) {
+                bulkOperations.remove(query(where("_id").in(
+                        svesToDiscard.stream().map(SubmittedVariantEntity::getHashedMessage)
+                                     .collect(Collectors.toSet()))));
+                svoeBulkOperations.insert(discardOperations);
+            }
             BulkWriteResult bulkWriteResult = bulkOperations.execute();
+            BulkWriteResult operationWriteResult = svoeBulkOperations.execute();
+
+            // TODO counts.... ?
             remappingIngestCounts.addRemappedVariantsIngested(bulkWriteResult.getInsertedCount());
         } catch (DuplicateKeyException exception) {
-            logger.warn(exception.toString());
-
             MongoBulkWriteException writeException = ((MongoBulkWriteException) exception.getCause());
             BulkWriteResult bulkWriteResult = writeException.getWriteResult();
 
+            // Log the actual submitted variants we failed to insert due to DuplicateKeyException
+            Set<String> duplicateHashesSkipped = MongoBulkWriteExceptionUtils
+                    .extractUniqueHashesForDuplicateKeyError(writeException).collect(Collectors.toSet());
+            List<SubmittedVariantEntity> duplicateSvesSkipped = svesToInsert
+                    .stream()
+                    .filter(sve -> duplicateHashesSkipped.contains(sve.getHashedMessage()))
+                    .collect(Collectors.toList());
+            logger.info("Failed to insert due to duplicate key exception: " + duplicateSvesSkipped);
+
             int ingested = bulkWriteResult.getInsertedCount();
             remappingIngestCounts.addRemappedVariantsIngested(ingested);
-
-            long duplicatesSkipped = MongoBulkWriteExceptionUtils
-                    .extractUniqueHashesForDuplicateKeyError(writeException).count();
-            remappingIngestCounts.addRemappedVariantsSkipped(duplicatesSkipped);
+            remappingIngestCounts.addRemappedVariantsSkipped(duplicateSvesSkipped.size());
         }
+    }
+
+    private Map<Long, List<SubmittedVariantEntity>> getDuplicateSs(List<SubmittedVariantEntity> sves) {
+        Map<Long, List<SubmittedVariantEntity>> svesGroupedBySs = new HashMap<>();
+
+        // Collect potential duplicates from the current batch
+        addToSsMap(sves, svesGroupedBySs);
+
+        // Find duplicate SS already in the database
+        List<SubmittedVariantEntity> svesWithSameAccession = mongoTemplate.find(
+                query(where("seq").is(assemblyAccession).and("accession").in(svesGroupedBySs.keySet())),
+                SubmittedVariantEntity.class, collection);
+        if (!svesWithSameAccession.isEmpty()) {
+            addToSsMap(svesWithSameAccession, svesGroupedBySs);
+        }
+
+        return svesGroupedBySs
+                .entrySet()
+                .stream()
+                .filter(candidateEntry -> candidateEntry.getValue().size() > 1)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private void addToSsMap(List<SubmittedVariantEntity> sves, Map<Long, List<SubmittedVariantEntity>> ssMap) {
+        for (SubmittedVariantEntity sve : sves) {
+            ssMap.putIfAbsent(sve.getAccession(), Collections.emptyList());
+            ssMap.get(sve.getAccession()).add(sve);
+        }
+    }
+
+    private List<SubmittedVariantEntity> resolveDuplicates(
+            Map<Long, List<SubmittedVariantEntity>> svesGroupedBySs, List<SubmittedVariantEntity> svesToInsert) {
+        List<SubmittedVariantEntity> svesToDiscard = new ArrayList<>();
+        List<SubmittedVariantEntity> svesToNotInsert = new ArrayList<>();
+
+        // TODO provision for same hash - need to keep the one in DB already if present, to ensure idempotency
+        //  and also not creating superfluous discard operations.
+
+        for (Map.Entry<Long, List<SubmittedVariantEntity>> ssAndSve: svesGroupedBySs.entrySet()) {
+            List<SubmittedVariantEntity> duplicates = ssAndSve.getValue();
+            // Ensure we only keep one out of the list of duplicates for this SS.
+            SubmittedVariantEntity currentKept = duplicates.get(0);
+            for (int i = 1; i < duplicates.size(); i++) {
+                SubmittedVariantEntity other = duplicates.get(i);
+                DiscardPriority priority = SubmittedVariantDiscardPolicy.prioritise(
+                        new SubmittedVariantDiscardDeterminants(currentKept,
+                                                                currentKept.getAccession(),
+                                                                currentKept.getRemappedFrom(),
+                                                                currentKept.getCreatedDate()),  // TODO this needs to be the created date in the source assembly!!
+                        new SubmittedVariantDiscardDeterminants(other,
+                                                                other.getAccession(),
+                                                                other.getRemappedFrom(),
+                                                                other.getCreatedDate()));
+                currentKept = priority.sveToKeep;
+            }
+            // Discard everything that's not currentKept
+            for (SubmittedVariantEntity sve : duplicates) {
+                if (sve.equals(currentKept)) continue;
+                // If the SVE to discard isn't one we were trying to insert, add it to the list of SVEs to remove from
+                // the database; these will also generate a discard operation.
+                // Otherwise just remove it from the list to insert; these will only be logged.
+                if (!svesToInsert.remove(sve)) {
+                    svesToDiscard.add(sve);
+                } else {
+                    svesToNotInsert.add(sve);
+                }
+            }
+
+        }
+        if (svesToNotInsert.size() > 0) {
+            logger.info("Not inserting because SS ID already exists in assembly: " + svesToNotInsert);
+        }
+        return svesToDiscard;
+    }
+
+    private List<SubmittedVariantOperationEntity> getDiscardOperations(List<SubmittedVariantEntity> svesToDiscard) {
+        return svesToDiscard.stream().map(
+                sve -> {
+                    SubmittedVariantOperationEntity svoe = new SubmittedVariantOperationEntity();
+                    svoe.fill(EventType.DEPRECATED,  // TODO new event type!
+                              sve.getAccession(),
+                              "Submitted variant discarded due to duplicate SS IDs in assembly",
+                              Collections.singletonList(new SubmittedVariantInactiveEntity(sve)));
+                    return svoe;
+                }).collect(Collectors.toList());
     }
 }

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriter.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriter.java
@@ -182,8 +182,12 @@ public class RemappedSubmittedVariantsWriter implements ItemWriter<SubmittedVari
                     currentKept = priority.sveToKeep.getSve();
                 } catch (IllegalArgumentException exception) {
                     // This is an issue to be investigated but needn't block processing as these SVEs are
-                    // indistinguishable, so we log the error (these should be removed earlier in any case).
+                    // indistinguishable, so we log the error and keep whichever is not in the insert list.
                     logger.warn(exception.toString());
+                    if (svesToInsert.contains(currentKept) && !svesToInsert.contains(other)) {
+                        currentKept = other;
+                        currentDeterminants = otherDeterminants;
+                    }
                 }
             }
             // Discard everything that's not currentKept

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriter.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriter.java
@@ -17,6 +17,8 @@ package uk.ac.ebi.eva.remapping.ingest.batch.io;
 
 import com.mongodb.MongoBulkWriteException;
 import com.mongodb.bulk.BulkWriteResult;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemWriter;
@@ -36,11 +38,12 @@ import uk.ac.ebi.eva.remapping.ingest.configuration.CollectionNames;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -75,118 +78,161 @@ public class RemappedSubmittedVariantsWriter implements ItemWriter<SubmittedVari
     public void write(List<? extends SubmittedVariantEntity> submittedVariantsRemapped) {
         // We do this to avoid tedious generic type signatures in the method calls
         List<SubmittedVariantEntity> svesToInsert = new ArrayList<>(submittedVariantsRemapped);
-        List<SubmittedVariantEntity> svesToDiscard = new ArrayList<>();
 
         // Resolve duplicate hashes and accessions before inserting; note that hash resolution must happen first.
-        resolveDuplicateHashes(svesToInsert);
-        resolveDuplicateAccessions(svesToInsert, svesToDiscard);
-        List<SubmittedVariantOperationEntity> discardOperations = getDiscardOperations(svesToDiscard);
+        ImmutablePair<List<SubmittedVariantEntity>, List<SubmittedVariantOperationEntity>> duplicateHashDiscards =
+                resolveDuplicateHashes(svesToInsert);
+        ImmutablePair<List<SubmittedVariantEntity>, List<SubmittedVariantOperationEntity>> duplicateAccessionDiscards =
+                resolveDuplicateAccessions(svesToInsert);
+
+        List<SubmittedVariantEntity> svesToDiscard = Stream.concat(duplicateHashDiscards.getLeft().stream(),
+                                                                    duplicateAccessionDiscards.getLeft().stream())
+                                                            .collect(Collectors.toList());
+        List<SubmittedVariantOperationEntity> discardOperations = Stream.concat(duplicateHashDiscards.getRight().stream(),
+                                                                                duplicateAccessionDiscards.getRight().stream())
+                                                                        .collect(Collectors.toList());
 
         BulkOperations bulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
                                                               SubmittedVariantEntity.class,
                                                               collection);
-        if (svesToInsert.size() > 0) {
-            bulkOperations.insert(svesToInsert);
-        }
+        // Deal with discards before inserts, to avoid DuplicateKeyExceptions
         if (svesToDiscard.size() > 0) {
             bulkOperations.remove(query(where("_id").in(
                     svesToDiscard.stream().map(SubmittedVariantEntity::getHashedMessage)
                                  .collect(Collectors.toSet()))));
-            BulkOperations svoeBulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
-                                                                      SubmittedVariantOperationEntity.class,
-                                                                      operationCollection);
-            svoeBulkOperations.insert(discardOperations);
-            svoeBulkOperations.execute();
+            bulkOperations.execute();
         }
-        if (svesToInsert.size() > 0 || svesToDiscard.size() > 0) {
-            BulkWriteResult bulkWriteResult = bulkOperations.execute();
-            remappingIngestCounts.addRemappedVariantsIngested(bulkWriteResult.getInsertedCount());
-            remappingIngestCounts.addRemappedVariantsDiscarded(bulkWriteResult.getDeletedCount());
-        }
-    }
+        if (discardOperations.size() > 0) {
+            try {
+                BulkOperations svoeBulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED,
+                                                                          SubmittedVariantOperationEntity.class,
+                                                                          operationCollection);
+                svoeBulkOperations.insert(discardOperations);
+                BulkWriteResult bulkWriteResult = svoeBulkOperations.execute();
+                remappingIngestCounts.addRemappedVariantsDiscarded(bulkWriteResult.getInsertedCount());
 
-    private void resolveDuplicateHashes(List<SubmittedVariantEntity> svesToInsert) {
-        Map<String, List<SubmittedVariantEntity>> svesGroupedByHash = getDuplicateHashes(svesToInsert);
-        List<SubmittedVariantEntity> svesToNotInsert = new ArrayList<>();
+            } catch (DuplicateKeyException exception) {
+                // As we check for hash collisions in submitted variants, we should only get duplicate keys from
+                // trying to insert an identical DISCARD operation, which should only happen when resuming or rerunning.
+                MongoBulkWriteException writeException = ((MongoBulkWriteException) exception.getCause());
+                BulkWriteResult bulkWriteResult = writeException.getWriteResult();
 
-        // This method should not discard anything from DB, only not insert new variants.
-        // These will only be logged and will not generate operations.
-        List<SubmittedVariantEntity> duplicates = flattenValues(svesGroupedByHash);
-        for (SubmittedVariantEntity sve : duplicates) {
-            if (svesToInsert.remove(sve)) {
-                svesToNotInsert.add(sve);
+                List<String> duplicatesSkipped = MongoBulkWriteExceptionUtils
+                        .extractUniqueHashesForDuplicateKeyError(writeException).collect(Collectors.toList());
+                logger.warn("Duplicate key exception when inserting DISCARD operations: " + duplicatesSkipped);
+
+                remappingIngestCounts.addRemappedVariantsDiscarded(bulkWriteResult.getInsertedCount());
+                remappingIngestCounts.addRemappedVariantsSkipped(duplicatesSkipped.size());
             }
         }
 
-        if (svesToNotInsert.size() > 0) {
-            logger.info("Not inserting due to duplicate hashes: " + svesToNotInsert);
-            remappingIngestCounts.addRemappedVariantsSkipped(svesToNotInsert.size());
+        if (svesToInsert.size() > 0) {
+            bulkOperations.insert(svesToInsert);
+            BulkWriteResult bulkWriteResult = bulkOperations.execute();
+            remappingIngestCounts.addRemappedVariantsIngested(bulkWriteResult.getInsertedCount());
         }
     }
 
-    private Map<String, List<SubmittedVariantEntity>> getDuplicateHashes(List<SubmittedVariantEntity> sves) {
-        List<String> hashes = sves.stream().map(SubmittedVariantEntity::getHashedMessage).collect(Collectors.toList());
-
-        // Find duplicate hashes already in db
-        List<SubmittedVariantEntity> svesWithSameHash = mongoTemplate.find(query(where("_id").in(hashes)),
-                                                                           SubmittedVariantEntity.class, collection);
-
-        Map<String, List<SubmittedVariantEntity>> svesGroupedByHash =
-                Stream.concat(sves.stream(), svesWithSameHash.stream())
-                      .collect(Collectors.groupingBy(SubmittedVariantEntity::getHashedMessage));
-
-        return filterForDuplicates(svesGroupedByHash);
+    private ImmutablePair<List<SubmittedVariantEntity>, List<SubmittedVariantOperationEntity>> resolveDuplicateHashes(
+            List<SubmittedVariantEntity> svesToInsert) {
+        Map<String, List<SubmittedVariantEntity>> svesGroupedByHash = getDuplicateHashes(svesToInsert);
+        return resolveDuplicates(svesToInsert, svesGroupedByHash,
+                                 "Submitted variant discarded due to duplicate hash");
     }
 
-    private void resolveDuplicateAccessions(List<SubmittedVariantEntity> svesToInsert,
-                                            List<SubmittedVariantEntity> svesToDiscard) {
+    private ImmutablePair<List<SubmittedVariantEntity>, List<SubmittedVariantOperationEntity>> resolveDuplicateAccessions(
+            List<SubmittedVariantEntity> svesToInsert) {
         Map<Long, List<SubmittedVariantEntity>> svesGroupedByAccession = getDuplicateAccessions(svesToInsert);
-        List<SubmittedVariantEntity> svesToNotInsert = new ArrayList<>();
+        return resolveDuplicates(svesToInsert, svesGroupedByAccession,
+                                 "Submitted variant discarded due to duplicate SS IDs in assembly");
+    }
 
-        List<SubmittedVariantEntity> duplicateSves = flattenValues(svesGroupedByAccession);
-        Map<String, LocalDateTime> createdDateByHash = getAllCreatedDateFromSource(duplicateSves);
+    private <T>ImmutablePair<List<SubmittedVariantEntity>, List<SubmittedVariantOperationEntity>> resolveDuplicates(
+            List<SubmittedVariantEntity> svesToInsert,
+            Map<T, List<SubmittedVariantEntity>> svesGroupedByKey,
+            String discardMessage) {
+        List<SubmittedVariantEntity> svesToDiscard = new ArrayList<>();
+        List<SubmittedVariantOperationEntity> discardOperations = new ArrayList<>();
 
-        for (Map.Entry<Long, List<SubmittedVariantEntity>> ssAndSve: svesGroupedByAccession.entrySet()) {
-            List<SubmittedVariantEntity> duplicates = ssAndSve.getValue();
+        List<SubmittedVariantEntity> duplicateSves = flattenValues(svesGroupedByKey);
+        Map<ImmutableTriple<String, Long, String>, LocalDateTime> createdDateMap =
+                getAllCreatedDateFromSource(duplicateSves);
+
+        for (Map.Entry<T, List<SubmittedVariantEntity>> keyAndSve: svesGroupedByKey.entrySet()) {
+            List<SubmittedVariantEntity> duplicates = keyAndSve.getValue();
             // Ensure we only keep one out of the list of duplicates for this SS.
             SubmittedVariantEntity currentKept = duplicates.get(0);
             SubmittedVariantDiscardDeterminants currentDeterminants = new SubmittedVariantDiscardDeterminants(
                     currentKept,
                     currentKept.getAccession(),
                     currentKept.getRemappedFrom(),
-                    createdDateByHash.get(currentKept.getHashedMessage()));
+                    createdDateMap.get(getKeyForCreatedDate(currentKept)));
             for (int i = 1; i < duplicates.size(); i++) {
                 SubmittedVariantEntity other = duplicates.get(i);
-                DiscardPriority priority = SubmittedVariantDiscardPolicy.prioritise(
-                        currentDeterminants,
-                        new SubmittedVariantDiscardDeterminants(other,
-                                                                other.getAccession(),
-                                                                other.getRemappedFrom(),
-                                                                createdDateByHash.get(other.getHashedMessage())));
-                currentDeterminants = priority.sveToKeep;
-                currentKept = priority.sveToKeep.getSve();
+                SubmittedVariantDiscardDeterminants otherDeterminants = new SubmittedVariantDiscardDeterminants(
+                        other,
+                        other.getAccession(),
+                        other.getRemappedFrom(),
+                        createdDateMap.get(getKeyForCreatedDate(other)));
+                try {
+                    DiscardPriority priority = SubmittedVariantDiscardPolicy.prioritise(currentDeterminants,
+                                                                                        otherDeterminants);
+
+                    currentDeterminants = priority.sveToKeep;
+                    currentKept = priority.sveToKeep.getSve();
+                } catch (IllegalArgumentException exception) {
+                    // This is an issue to be investigated but needn't block processing as these SVEs are
+                    // indistinguishable, so we log the error (these should be removed earlier in any case).
+                    logger.warn(exception.toString());
+                }
             }
             // Discard everything that's not currentKept
             for (SubmittedVariantEntity sve : duplicates) {
                 if (sve.equals(currentKept)) continue;
                 // If the SVE to discard isn't one we were trying to insert, add it to the list of SVEs to remove from
-                // the database; these will also generate a discard operation.
-                // Otherwise just remove it from the list to insert; these will only be logged.
+                // the database; otherwise just remove it from the list to insert.
                 if (!svesToInsert.remove(sve)) {
                     svesToDiscard.add(sve);
-                } else {
-                    svesToNotInsert.add(sve);
                 }
+                // Either way create a discard operation
+                discardOperations.add(getDiscardOperationWithMessage(sve, discardMessage));
             }
         }
-        if (svesToNotInsert.size() > 0) {
-            logger.info("Not inserting because SS ID already exists in assembly: " + svesToNotInsert);
-            remappingIngestCounts.addRemappedVariantsSkipped(svesToNotInsert.size());
-        }
+        return new ImmutablePair<>(svesToDiscard, discardOperations);
     }
 
-    private Map<Long, List<SubmittedVariantEntity>> getDuplicateAccessions(List<SubmittedVariantEntity> sves) {
-        List<Long> accessions = sves.stream().map(SubmittedVariantEntity::getAccession).collect(Collectors.toList());
+    private Map<String, List<SubmittedVariantEntity>> getDuplicateHashes(List<SubmittedVariantEntity> svesToInsert) {
+        List<String> hashes = svesToInsert.stream()
+                                          .map(SubmittedVariantEntity::getHashedMessage)
+                                          .collect(Collectors.toList());
+
+        // Find duplicate hashes already in db
+        List<SubmittedVariantEntity> svesWithSameHash = mongoTemplate.find(query(where("_id").in(hashes)),
+                                                                           SubmittedVariantEntity.class, collection);
+
+        // Get the subset of these that are actually identical and remove them immediately from svesToInsert
+        // These are counted as skips rather than discards.
+        Map<Integer, List<SubmittedVariantEntity>> duplicateSve = filterForDuplicates(
+                Stream.concat(svesToInsert.stream(), svesWithSameHash.stream())
+                      .collect(Collectors.groupingBy(SubmittedVariantEntity::hashCode)));
+        for (List<SubmittedVariantEntity> dups : duplicateSve.values()) {
+            if (svesToInsert.remove(dups.get(0))) {
+                remappingIngestCounts.addRemappedVariantsSkipped(1);
+            }
+        }
+
+        // Get the remaining duplicate hashes
+        Map<String, List<SubmittedVariantEntity>> svesGroupedByHash =
+                Stream.concat(svesToInsert.stream(), svesWithSameHash.stream())
+                      .collect(Collectors.groupingBy(SubmittedVariantEntity::getHashedMessage));
+
+        return filterForDuplicates(svesGroupedByHash);
+    }
+
+    private Map<Long, List<SubmittedVariantEntity>> getDuplicateAccessions(List<SubmittedVariantEntity> svesToInsert) {
+        List<Long> accessions = svesToInsert.stream()
+                                            .map(SubmittedVariantEntity::getAccession)
+                                            .collect(Collectors.toList());
 
         // Find duplicate SS already in the database
         List<SubmittedVariantEntity> svesWithSameAccession = mongoTemplate.find(
@@ -194,17 +240,21 @@ public class RemappedSubmittedVariantsWriter implements ItemWriter<SubmittedVari
                 SubmittedVariantEntity.class, collection);
 
         Map<Long, List<SubmittedVariantEntity>> svesGroupedBySs =
-                Stream.concat(sves.stream(), svesWithSameAccession.stream())
+                Stream.concat(svesToInsert.stream(), svesWithSameAccession.stream())
                       .collect(Collectors.groupingBy(SubmittedVariantEntity::getAccession));
 
         return filterForDuplicates(svesGroupedBySs);
     }
 
-    private Map<String, LocalDateTime> getAllCreatedDateFromSource(List<SubmittedVariantEntity> duplicateSves) {
-        // By default use the target SVE's created date
-        Map<String, LocalDateTime> targetHashToSourceCreatedDate = duplicateSves
-                .stream().collect(Collectors.toMap(SubmittedVariantEntity::getHashedMessage,
-                                                   SubmittedVariantEntity::getCreatedDate));
+    private Map<ImmutableTriple<String, Long, String>, LocalDateTime> getAllCreatedDateFromSource(
+            List<SubmittedVariantEntity> duplicateSves) {
+        // By default use the target SVE's created date.
+        // Keyed on (accession, hash, remappedFrom) triplet as that's the only way we can reliably distinguish
+        // duplicates in all cases. If there's a duplicate triple almost certainly the createdDates are the same.
+        Map<ImmutableTriple<String, Long, String>, LocalDateTime> targetToSourceCreatedDate = duplicateSves
+                .stream().collect(Collectors.toMap(this::getKeyForCreatedDate,
+                                                   SubmittedVariantEntity::getCreatedDate,
+                                                   (cd1, cd2) -> Collections.min(Arrays.asList(cd1, cd2))));
 
         Map<String, List<SubmittedVariantEntity>> svesBySourceAssembly = duplicateSves
                 .stream().collect(Collectors.groupingBy(
@@ -232,37 +282,47 @@ public class RemappedSubmittedVariantsWriter implements ItemWriter<SubmittedVari
 
             for (SubmittedVariantEntity sve : svesRemappedFromAsm) {
                 List<SubmittedVariantEntity> sourceSves = sourceSvesByAccession.get(sve.getAccession());
-                targetHashToSourceCreatedDate.put(sve.getHashedMessage(), getCreatedDateFromSource(sve, sourceSves));
+                targetToSourceCreatedDate.put(getKeyForCreatedDate(sve), getCreatedDateFromSource(sve, sourceSves));
             }
         }
 
-        return targetHashToSourceCreatedDate;
+        return targetToSourceCreatedDate;
+    }
+
+    private ImmutableTriple<String, Long, String> getKeyForCreatedDate(SubmittedVariantEntity sve) {
+        return new ImmutableTriple<>(sve.getHashedMessage(), sve.getAccession(), sve.getRemappedFrom());
     }
 
     private LocalDateTime getCreatedDateFromSource(SubmittedVariantEntity targetSve,
                                                    List<SubmittedVariantEntity> sourceSves) {
-        // If we can't find the exact source SVE for any reason, use the created date of the remapped SVE
+        // If we can't find the source SVE, use the created date of the remapped SVE
         if (Objects.isNull(sourceSves) || sourceSves.isEmpty()) {
-            logger.warn("No SS " + targetSve.getAccession() + " found in source assembly " + targetSve.getRemappedFrom());
+            logger.warn("No SS " + targetSve.getAccession() + " found in source assembly "
+                                + targetSve.getRemappedFrom());
             return targetSve.getCreatedDate();
         }
+        // If we find multiple SS in the source, return the min created date
         if (sourceSves.size() > 1) {
-            logger.warn("Duplicate SS " + targetSve.getAccession() + " found in assembly " + targetSve.getRemappedFrom());
-            return targetSve.getCreatedDate();
+            logger.warn("Duplicate SS " + targetSve.getAccession() + " found in source assembly "
+                                + targetSve.getRemappedFrom());
+            return Collections.min(sourceSves, Comparator.comparing(SubmittedVariantEntity::getCreatedDate))
+                              .getCreatedDate();
         }
         return sourceSves.get(0).getCreatedDate();
     }
 
-    private List<SubmittedVariantOperationEntity> getDiscardOperations(List<SubmittedVariantEntity> svesToDiscard) {
-        return svesToDiscard.stream().map(
-                sve -> {
-                    SubmittedVariantOperationEntity svoe = new SubmittedVariantOperationEntity();
-                    svoe.fill(EventType.DISCARDED,
-                              sve.getAccession(),
-                              "Submitted variant discarded due to duplicate SS IDs in assembly",
-                              Collections.singletonList(new SubmittedVariantInactiveEntity(sve)));
-                    return svoe;
-                }).collect(Collectors.toList());
+    private SubmittedVariantOperationEntity getDiscardOperationWithMessage(SubmittedVariantEntity sve, String message) {
+        String svoeId = String.format("DISCARD_SS_%s_HASH_%s_SOURCE_%s",
+                                      sve.getAccession(),
+                                      sve.getHashedMessage(),
+                                      sve.getRemappedFrom());
+        SubmittedVariantOperationEntity svoe = new SubmittedVariantOperationEntity();
+        svoe.fill(EventType.DISCARDED,
+                  sve.getAccession(),
+                  message,
+                  Collections.singletonList(new SubmittedVariantInactiveEntity(sve)));
+        svoe.setId(svoeId);
+        return svoe;
     }
 
     private <T, S>Map<T, List<S>> filterForDuplicates(Map<T, List<S>> map) {

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/SubmittedVariantDiscardPolicy.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/SubmittedVariantDiscardPolicy.java
@@ -45,6 +45,7 @@ public class SubmittedVariantDiscardPolicy {
         public SubmittedVariantEntity getSve() {
             return sve;
         }
+
         public Long getSsId() {
             return ssId;
         }
@@ -60,10 +61,11 @@ public class SubmittedVariantDiscardPolicy {
     }
 
     public static class DiscardPriority {
-        public final SubmittedVariantEntity sveToKeep;
-        public final SubmittedVariantEntity sveToDiscard;
+        public final SubmittedVariantDiscardDeterminants sveToKeep;
+        public final SubmittedVariantDiscardDeterminants sveToDiscard;
 
-        public DiscardPriority(SubmittedVariantEntity sveToKeep, SubmittedVariantEntity sveToDiscard) {
+        public DiscardPriority(SubmittedVariantDiscardDeterminants sveToKeep,
+                               SubmittedVariantDiscardDeterminants sveToDiscard) {
             this.sveToKeep = sveToKeep;
             this.sveToDiscard = sveToDiscard;
         }
@@ -81,15 +83,15 @@ public class SubmittedVariantDiscardPolicy {
         }
 
         if (firstSve.getRemappedFrom() == null && secondSve.getRemappedFrom() != null) {
-            return new DiscardPriority(firstSve.getSve(), secondSve.getSve());
+            return new DiscardPriority(firstSve, secondSve);
         }
         if (firstSve.getRemappedFrom() != null && secondSve.getRemappedFrom() == null) {
-            return new DiscardPriority(secondSve.getSve(), firstSve.getSve());
+            return new DiscardPriority(secondSve, firstSve);
         }
         if (firstSve.getCreatedDate().isBefore(secondSve.getCreatedDate())) {
-            return new DiscardPriority(firstSve.getSve(), secondSve.getSve());
+            return new DiscardPriority(firstSve, secondSve);
         }
-        return new DiscardPriority(secondSve.getSve(), firstSve.getSve());
+        return new DiscardPriority(secondSve, firstSve);
     }
 
 }

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/SubmittedVariantDiscardPolicy.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/io/SubmittedVariantDiscardPolicy.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.remapping.ingest.batch.io;
+
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+
+import java.time.LocalDateTime;
+
+/**
+ * This class represents the policy for choosing which SVE to discard when the SS ID is duplicated.
+ */
+public class SubmittedVariantDiscardPolicy {
+
+    public static class SubmittedVariantDiscardDeterminants {
+
+        private final SubmittedVariantEntity sve;
+
+        private final Long ssId;
+
+        private final String remappedFrom;
+
+        private final LocalDateTime createdDate;
+
+        public SubmittedVariantDiscardDeterminants(SubmittedVariantEntity sve, Long ssId, String remappedFrom,
+                                                   LocalDateTime createdDate) {
+            this.sve = sve;
+            this.ssId = ssId;
+            this.remappedFrom = remappedFrom;
+            this.createdDate = createdDate;
+        }
+
+        public SubmittedVariantEntity getSve() {
+            return sve;
+        }
+        public Long getSsId() {
+            return ssId;
+        }
+
+        public String getRemappedFrom() {
+            return remappedFrom;
+        }
+
+        public LocalDateTime getCreatedDate() {
+            return createdDate;
+        }
+
+    }
+
+    public static class DiscardPriority {
+        public final SubmittedVariantEntity sveToKeep;
+        public final SubmittedVariantEntity sveToDiscard;
+
+        public DiscardPriority(SubmittedVariantEntity sveToKeep, SubmittedVariantEntity sveToDiscard) {
+            this.sveToKeep = sveToKeep;
+            this.sveToDiscard = sveToDiscard;
+        }
+    }
+
+    /**
+     * Keep the submitted variant without remappedFrom attribute, or earliest createdDate as tie-breaker.
+     */
+    public static DiscardPriority prioritise(SubmittedVariantDiscardDeterminants firstSve,
+                                             SubmittedVariantDiscardDeterminants secondSve) {
+        // Discard is only valid for variants sharing the same SS
+        if (!firstSve.getSsId().equals(secondSve.getSsId())) {
+            throw new IllegalArgumentException("Submitted variant discard is not valid for two different SS: "
+                                                       + firstSve.getSsId() + " and " + secondSve.getSsId());
+        }
+
+        if (firstSve.getRemappedFrom() == null && secondSve.getRemappedFrom() != null) {
+            return new DiscardPriority(firstSve.getSve(), secondSve.getSve());
+        }
+        if (firstSve.getRemappedFrom() != null && secondSve.getRemappedFrom() == null) {
+            return new DiscardPriority(secondSve.getSve(), firstSve.getSve());
+        }
+        if (firstSve.getCreatedDate().isBefore(secondSve.getCreatedDate())) {
+            return new DiscardPriority(firstSve.getSve(), secondSve.getSve());
+        }
+        return new DiscardPriority(secondSve.getSve(), firstSve.getSve());
+    }
+
+}

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/listeners/RemappingIngestCounts.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/listeners/RemappingIngestCounts.java
@@ -24,6 +24,10 @@ public class RemappingIngestCounts {
     private long remappedVariantsDiscarded;
 
     public RemappingIngestCounts() {
+        resetCounts();
+    }
+
+    public void resetCounts() {
         this.remappedVariantsIngested = 0;
         this.remappedVariantsSkipped = 0;
         this.remappedVariantsDiscarded = 0;

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/listeners/RemappingIngestCounts.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/listeners/RemappingIngestCounts.java
@@ -21,9 +21,12 @@ public class RemappingIngestCounts {
 
     private long remappedVariantsSkipped;
 
+    private long remappedVariantsDiscarded;
+
     public RemappingIngestCounts() {
         this.remappedVariantsIngested = 0;
         this.remappedVariantsSkipped = 0;
+        this.remappedVariantsDiscarded = 0;
     }
 
     public long getRemappedVariantsIngested() {
@@ -40,5 +43,13 @@ public class RemappingIngestCounts {
 
     public void addRemappedVariantsSkipped(long remappedVariantsSkipped) {
         this.remappedVariantsSkipped += remappedVariantsSkipped;
+    }
+
+    public long getRemappedVariantsDiscarded() {
+        return remappedVariantsDiscarded;
+    }
+
+    public void addRemappedVariantsDiscarded(long remappedVariantsDiscarded) {
+        this.remappedVariantsDiscarded += remappedVariantsDiscarded;
     }
 }

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/processors/VariantToSubmittedVariantEntityRemappedProcessor.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/processors/VariantToSubmittedVariantEntityRemappedProcessor.java
@@ -78,7 +78,7 @@ public class VariantToSubmittedVariantEntityRemappedProcessor implements ItemPro
                 throw new IllegalArgumentException("RS id is not in the correct format: " + rsIdTxt);
             }
         } else {
-            logger.warn("Variant {} does not have an RS ID associated: {}", variant.getMainId(), variant);
+            logger.debug("Variant {} does not have an RS ID associated: {}", variant.getMainId(), variant);
         }
 
         SubmittedVariant submittedVariant = new SubmittedVariant(assemblyAccession, taxonomyAccession, projectAccession,

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/configuration/BeanNames.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/configuration/BeanNames.java
@@ -17,10 +17,6 @@ package uk.ac.ebi.eva.remapping.ingest.configuration;
 
 public class BeanNames {
 
-    public static final String SUBMITTED_VARIANT_ENTITY = "submittedVariantEntity";
-
-    public static final String DBSNP_SUBMITTED_VARIANT_ENTITY = "dbsnpSubmittedVariantEntity";
-
     public static final String VCF_READER = "VCF_READER";
 
     public static final String COMPOSITE_VARIANT_PROCESSOR = "COMPOSITE_VARIANT_PROCESSOR";

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/configuration/CollectionNames.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/configuration/CollectionNames.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.remapping.ingest.configuration;
+
+public class CollectionNames {
+
+    public static final String SUBMITTED_VARIANT_ENTITY = "submittedVariantEntity";
+
+    public static final String DBSNP_SUBMITTED_VARIANT_ENTITY = "dbsnpSubmittedVariantEntity";
+
+    public static final String SUBMITTED_VARIANT_OPERATION_ENTITY = "submittedVariantOperationEntity";
+
+    public static final String DBSNP_SUBMITTED_VARIANT_OPERATION_ENTITY = "dbsnpSubmittedVariantOperationEntity";
+
+}

--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/configuration/batch/io/IngestRemappedSubmittedVariantsWriterConfiguration.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/configuration/batch/io/IngestRemappedSubmittedVariantsWriterConfiguration.java
@@ -24,6 +24,7 @@ import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
 import uk.ac.ebi.eva.remapping.ingest.batch.io.RemappedSubmittedVariantsWriter;
 import uk.ac.ebi.eva.remapping.ingest.batch.listeners.RemappingIngestCounts;
 import uk.ac.ebi.eva.remapping.ingest.configuration.BeanNames;
+import uk.ac.ebi.eva.remapping.ingest.configuration.CollectionNames;
 import uk.ac.ebi.eva.remapping.ingest.parameters.InputParameters;
 
 @Configuration
@@ -34,17 +35,17 @@ public class IngestRemappedSubmittedVariantsWriterConfiguration {
     public RemappedSubmittedVariantsWriter remappedSubmittedVariantsWriter(MongoTemplate mongoTemplate,
                                                                            InputParameters inputParameters,
                                                                            RemappingIngestCounts remappingIngestCounts){
-        return new RemappedSubmittedVariantsWriter(mongoTemplate, getCollection(inputParameters.getLoadTo()),
-                                                   remappingIngestCounts);
+        return new RemappedSubmittedVariantsWriter(mongoTemplate, inputParameters.getAssemblyAccession(),
+                                                   getCollection(inputParameters.getLoadTo()), remappingIngestCounts);
     }
 
     private String getCollection(String loadTo) {
         if (loadTo == null) {
             throw new IllegalArgumentException("Please provide the target collection (EVA or DBSNP)");
         }else if (loadTo.toUpperCase().equals("EVA")) {
-            return BeanNames.SUBMITTED_VARIANT_ENTITY;
+            return CollectionNames.SUBMITTED_VARIANT_ENTITY;
         } else if (loadTo.toUpperCase().equals("DBSNP")) {
-            return BeanNames.DBSNP_SUBMITTED_VARIANT_ENTITY;
+            return CollectionNames.DBSNP_SUBMITTED_VARIANT_ENTITY;
         }
         throw new IllegalArgumentException("loadTo parameter should be either EVA or DBSNP");
     }

--- a/eva-remapping-ingest/src/test/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriterTest.java
+++ b/eva-remapping-ingest/src/test/java/uk/ac/ebi/eva/remapping/ingest/batch/io/RemappedSubmittedVariantsWriterTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2022 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.ebi.eva.remapping.ingest.batch.io;
+
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbConfigurationBuilder;
+import com.lordofthejars.nosqlunit.mongodb.MongoDbRule;
+import com.mongodb.MongoClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction;
+
+import uk.ac.ebi.eva.accession.core.model.ISubmittedVariant;
+import uk.ac.ebi.eva.accession.core.model.SubmittedVariant;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
+import uk.ac.ebi.eva.accession.core.summary.SubmittedVariantSummaryFunction;
+import uk.ac.ebi.eva.remapping.ingest.batch.listeners.RemappingIngestCounts;
+import uk.ac.ebi.eva.remapping.ingest.test.configuration.BatchTestConfiguration;
+import uk.ac.ebi.eva.remapping.ingest.test.rule.FixSpringMongoDbRule;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static uk.ac.ebi.eva.remapping.ingest.configuration.BeanNames.REMAPPED_SUBMITTED_VARIANTS_WRITER;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {BatchTestConfiguration.class})
+@TestPropertySource("classpath:ingest-remapped-variants.properties")
+@UsingDataSet(locations = {"/test-data/submittedVariantEntity.json"})
+public class RemappedSubmittedVariantsWriterTest {
+
+    private static final String TEST_DB = "test-ingest-remapping";
+
+    @Autowired
+    private MongoClient mongoClient;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    @Qualifier(REMAPPED_SUBMITTED_VARIANTS_WRITER)
+    private RemappedSubmittedVariantsWriter writer;
+
+    private Function<ISubmittedVariant, String> hashingFunction;
+
+    //Required by nosql-unit
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Rule
+    public MongoDbRule mongoDbRule = new FixSpringMongoDbRule(
+            MongoDbConfigurationBuilder.mongoDb().databaseName(TEST_DB).build());
+
+    @Autowired
+    private RemappingIngestCounts remappingIngestCounts;
+
+    @Before
+    public void setUp() {
+        hashingFunction = new SubmittedVariantSummaryFunction().andThen(new SHA1HashingFunction());
+    }
+
+    @After
+    public void tearDown() {
+        mongoClient.dropDatabase(TEST_DB);
+        remappingIngestCounts.resetCounts();
+    }
+
+    private SubmittedVariantEntity createSve(Long accession, long start, String ref, String alt,
+                                             LocalDateTime createdDate, String remappedFrom) {
+        SubmittedVariant model = new SubmittedVariant("GCA_000000002.1", 1000, "projectId_1", "CM000002.1",
+                                                      start, ref, alt, 3000000002L);
+        String hash = hashingFunction.apply(model);
+        SubmittedVariantEntity sve = new SubmittedVariantEntity(accession, hash, model, 1);
+        sve.setCreatedDate(createdDate);
+        sve.setRemappedFrom(remappedFrom);
+        return sve;
+    }
+
+    private void assertRemappingIngestCounts(int ingested, int skipped, int discarded) {
+        assertEquals(ingested, remappingIngestCounts.getRemappedVariantsIngested());
+        assertEquals(skipped, remappingIngestCounts.getRemappedVariantsSkipped());
+        assertEquals(discarded, remappingIngestCounts.getRemappedVariantsDiscarded());
+    }
+
+    @Test
+    public void testDoesNotWriteNewDuplicates_removeFromInput() {
+        List<SubmittedVariantEntity> svesToWrite = Collections.singletonList(
+                createSve(5000000002L, 2100, "C", "T", LocalDateTime.now(), "GCA_000000001.1"));
+        writer.write(svesToWrite);
+        assertRemappingIngestCounts(0, 1, 0);
+    }
+
+    @Test
+    public void testDoesNotWriteNewDuplicates_removeFromDatabase() {
+        List<SubmittedVariantEntity> svesToWrite = Collections.singletonList(
+                createSve(5000000002L, 2100, "C", "T", LocalDateTime.now(), null));
+        writer.write(svesToWrite);
+        assertRemappingIngestCounts(1, 0, 1);
+    }
+
+    @Test
+    public void testDeduplicatesInput() {
+        List<SubmittedVariantEntity> svesToWrite = Arrays.asList(
+                createSve(5000000003L, 2100, "C", "T", LocalDateTime.now(), "GCA_000000001.1"),
+                createSve(5000000003L, 2100, "A", "T", LocalDateTime.now(), "GCA_000000001.3"));
+        writer.write(svesToWrite);
+        assertRemappingIngestCounts(1, 1, 0);
+    }
+
+    @Test
+    public void testIdempotentWrites() {
+        List<SubmittedVariantEntity> svesToWrite = Collections.singletonList(
+                createSve(5000000002L, 2100, "C", "T", LocalDateTime.now(), null));
+        writer.write(svesToWrite);
+        assertRemappingIngestCounts(1, 0, 1);
+
+        Set<SubmittedVariantEntity> sveAfterFirstWrite = new HashSet<>(
+                mongoTemplate.findAll(SubmittedVariantEntity.class));
+        Set<SubmittedVariantOperationEntity> svoeAfterFirstWrite = new HashSet<>(
+                mongoTemplate.findAll(SubmittedVariantOperationEntity.class));
+
+        remappingIngestCounts.resetCounts();
+        writer.write(svesToWrite);
+        assertRemappingIngestCounts(0, 1, 0);
+
+        Set<SubmittedVariantEntity> sveAfterSecondWrite = new HashSet<>(
+                mongoTemplate.findAll(SubmittedVariantEntity.class));
+        Set<SubmittedVariantOperationEntity> svoeAfterSecondWrite = new HashSet<>(
+                mongoTemplate.findAll(SubmittedVariantOperationEntity.class));
+
+        assertEquals(sveAfterFirstWrite, sveAfterSecondWrite);
+        assertEquals(svoeAfterFirstWrite, svoeAfterSecondWrite);
+    }
+
+}

--- a/eva-remapping-ingest/src/test/java/uk/ac/ebi/eva/remapping/ingest/configuration/batch/jobs/IngestRemappedVariantsFromVcfJobConfigurationTest.java
+++ b/eva-remapping-ingest/src/test/java/uk/ac/ebi/eva/remapping/ingest/configuration/batch/jobs/IngestRemappedVariantsFromVcfJobConfigurationTest.java
@@ -107,6 +107,6 @@ public class IngestRemappedVariantsFromVcfJobConfigurationTest {
                                                     .filter(x -> x.getRemappingId() != null &&
                                                             x.getRemappingId().equals(remappingId))
                                                     .count();
-        assertEquals(4, variantsWithMetatada);
+        assertEquals(3, variantsWithMetatada);
     }
 }

--- a/eva-remapping-ingest/src/test/java/uk/ac/ebi/eva/remapping/ingest/configuration/batch/steps/IngestRemappedFromVcfStepConfigurationTest.java
+++ b/eva-remapping-ingest/src/test/java/uk/ac/ebi/eva/remapping/ingest/configuration/batch/steps/IngestRemappedFromVcfStepConfigurationTest.java
@@ -99,13 +99,13 @@ public class IngestRemappedFromVcfStepConfigurationTest {
         Assert.assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 
         //Documents in the database after the ingestion
-        assertEquals(11, mongoTemplate.getCollection(SUBMITTED_VARIANT_COLLECTION).countDocuments());
+        assertEquals(10, mongoTemplate.getCollection(SUBMITTED_VARIANT_COLLECTION).countDocuments());
 
         Query remappedVariantsQuery = new Query(Criteria.where("remappedFrom").is(REMAPPED_FROM));
         List<SubmittedVariantEntity> remappedVariants = mongoTemplate.find(remappedVariantsQuery,
                                                                            SubmittedVariantEntity.class);
 
-        assertEquals(6, remappedVariants.size());
+        assertEquals(5, remappedVariants.size());
 
         //Variant ss5000000000: Remapped only once
         assertEquals(2, getVariantCountBySsId(5000000000L));
@@ -120,8 +120,8 @@ public class IngestRemappedFromVcfStepConfigurationTest {
         assertEquals(2, getVariantCountBySsId(5000000001L));
 
         //Variant ss5000000002: Remapped twice to a different location
-        //Insert both remapped variants
-        assertEquals(3, getVariantCountBySsId(5000000002L));
+        //Skip the duplicate variant as they have the same accession
+        assertEquals(2, getVariantCountBySsId(5000000002L));
 
         //Variant ss5000000002: Remapped only once, belongs to a different project and have a different taxonomy
         assertEquals(2, getVariantCountBySsId(5000000003L));

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.13</junit.version>
         <variation-commons-version>0.8.0</variation-commons-version>
-        <accession-commons-version>0.7.9-SNAPSHOT</accession-commons-version>
+        <accession-commons-version>0.7.9</accession-commons-version>
     </properties>
 
     <parent>


### PR DESCRIPTION
Detect and resolve both duplicate hashes and duplicate SS in an assembly before ingesting remapped submitted variants.