### PR TITLE
Merge and db name 

### DIFF
--- a/eva-accession-release-automation/run_release_in_embassy/merge_dbsnp_eva_release_files.py
+++ b/eva-accession-release-automation/run_release_in_embassy/merge_dbsnp_eva_release_files.py
@@ -118,7 +118,7 @@ def merge_dbsnp_eva_vcf_files(bgzip_path, bcftools_path, vcf_sort_script_path, a
             get_bgzip_and_index_commands(bgzip_path, bcftools_path, vcf_sort_script_path, [dbsnp_file, eva_file]))
         sorted_file_names = [name.replace("_unsorted", "") for name in [dbsnp_file, eva_file]]
         vcf_merge_commands.append(
-            "(({0} merge --no-version -O v {1}.gz {2}.gz | grep -v ^##) >> {3})".format(bcftools_path,
+            "(({0} merge --no-version -m none -O v {1}.gz {2}.gz | grep -v ^##) >> {3})".format(bcftools_path,
                                                                                         sorted_file_names[0],
                                                                                         sorted_file_names[1],
                                                                                         unsorted_release_file_path))

--- a/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
@@ -89,7 +89,7 @@ def get_unsorted_release_text_file_name(species_release_folder, assembly_accessi
 
 
 def get_release_db_name_in_tempmongo_instance(taxonomy_id, assembly_accession):
-    return "acc_" + str(taxonomy_id) + assembly_accession.replace('.', '_')
+    return "acc_" + str(taxonomy_id) + "_" + assembly_accession.replace('.', '_')
 
 
 def get_release_folder_name(taxonomy_id):

--- a/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
+++ b/eva-accession-release-automation/run_release_in_embassy/release_common_utils.py
@@ -88,8 +88,8 @@ def get_unsorted_release_text_file_name(species_release_folder, assembly_accessi
     return release_text_file_path.replace(filename, filename.replace(".txt", ".unsorted.txt"))
 
 
-def get_release_db_name_in_tempmongo_instance(taxonomy_id):
-    return "acc_" + str(taxonomy_id)
+def get_release_db_name_in_tempmongo_instance(taxonomy_id, assembly_accession):
+    return "acc_" + str(taxonomy_id) + assembly_accession.replace('.', '_')
 
 
 def get_release_folder_name(taxonomy_id):


### PR DESCRIPTION
- Ensure the final merge does not create multi allelic variant (request from Ensembl)
- Change the temp mongo database name to include the assembly to avoid overwriting the database when running per assembly process 