### PR TITLE
EVA-2991 - Add missing parameters for clustering

### DIFF
--- a/eva-accession-clustering-automation/clustering_automation/create_clustering_properties.py
+++ b/eva-accession-clustering-automation/clustering_automation/create_clustering_properties.py
@@ -57,6 +57,8 @@ parameters.remappedFrom=
 parameters.vcf={vcf}
 parameters.projectAccession={project}
 parameters.allowRetry={str(enable_retryable).lower()}
+parameters.projects=
+parameters.rsReportPath={assembly_accession}_rs_report.txt
 """)
     properties_file.write(clustering_properties)
 


### PR DESCRIPTION
When running clustering for all studies we still need the parameters to be filled in. 