### PR TITLE
EVA-3026 - Move clustering counts script from EVA-2770 and EVA-2750 to release automation

### DIFF
--- a/eva-accession-release-automation/gather_clustering_counts/bash/count_rs_for_release.sh
+++ b/eva-accession-release-automation/gather_clustering_counts/bash/count_rs_for_release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+species_dir=$1
+idtype=$2
+species_name=$(basename "$species_dir")
+
+
+for ASSEMBLY_DIR in "${species_dir}"/GC*
+do
+    ASSEMBLY=$(basename "$ASSEMBLY_DIR")
+    zcat  "${species_dir}"/"$ASSEMBLY"/"${ASSEMBLY}"_"${idtype}"_ids_with_genbank.vcf.gz | grep -v '^#' | awk -v assembly="$ASSEMBLY" '{print $3" "assembly}'
+done | sort > tmp_"${species_name}"_"${idtype}"_rsid_sorted
+
+cat tmp_"${species_name}"_"${idtype}"_rsid_sorted \
+    | awk '{if (current_rsid != $1){for (a in assemblies){printf " %s",a} print ""; delete assemblies; current_rsid=$1 }; assemblies[$2]=1} END{for (a in assemblies){printf " %s",a}}'  \
+    | grep -v '^$' | sort | uniq -c | sort -nr > "${species_name}"_count_"${idtype}"_rsid.log
+
+rm  tmp_"${species_name}"_"${idtype}"_rsid_sorted

--- a/eva-accession-release-automation/gather_clustering_counts/bash/count_rs_for_release_for_txt.sh
+++ b/eva-accession-release-automation/gather_clustering_counts/bash/count_rs_for_release_for_txt.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+species_dir=$1
+idtype=$2
+species_name=$(basename "$species_dir")
+
+
+for ASSEMBLY_DIR in "${species_dir}"/GC*
+do
+    ASSEMBLY=$(basename "$ASSEMBLY_DIR")
+    zcat  "${species_dir}"/"$ASSEMBLY"/"${ASSEMBLY}"_"${idtype}"_ids.txt.gz | grep -v '^#' | awk -v assembly="$ASSEMBLY" '{print $1" "assembly}'
+done | sort > tmp_"${species_name}"_"${idtype}"_rsid_sorted
+
+cat tmp_"${species_name}"_"${idtype}"_rsid_sorted \
+    | awk '{if (current_rsid != $1){for (a in assemblies){printf " %s",a} print ""; delete assemblies; current_rsid=$1 }; assemblies[$2]=1} END{for (a in assemblies){printf " %s",a}}'  \
+    | grep -v '^$' | sort | uniq -c | sort -nr > "${species_name}"_count_"${idtype}"_rsid.log
+
+rm  tmp_"${species_name}"_"${idtype}"_rsid_sorted

--- a/eva-accession-release-automation/gather_clustering_counts/bash/count_rs_for_release_unmapped.sh
+++ b/eva-accession-release-automation/gather_clustering_counts/bash/count_rs_for_release_unmapped.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+species_dir=$1
+species_name=$(basename "$species_dir")
+
+zcat  "${species_dir}"/*_unmapped_ids.txt.gz  | grep -v '^#' | sort -u | wc -l > "${species_name}"_count_unmapped_rsid.log

--- a/eva-accession-release-automation/gather_clustering_counts/gather_clustering_counts_from_mongo.py
+++ b/eva-accession-release-automation/gather_clustering_counts/gather_clustering_counts_from_mongo.py
@@ -37,7 +37,7 @@ def get_assembly_info_and_date_ranges(all_log_files):
     ranges_per_assembly = defaultdict(dict)
     for log_file in all_log_files:
         logger.info('Parse log_dict file: ' + log_file)
-        scientific_name, taxid, assembly_accession, log_date = parse_log_file_path(log_file)
+        scientific_name, taxid, assembly_accession = parse_log_file_path(log_file)
         log_metric_date_range = parse_one_log(log_file)
 
         if assembly_accession not in ranges_per_assembly:
@@ -333,8 +333,7 @@ def parse_log_file_path(log_file_path):
     scientific_name_taxonomy_id, assembly_accession, file_name = log_file_path.split('/')[-3:]
     scientific_name = '_'.join(scientific_name_taxonomy_id.split('_')[:-1])
     taxid = scientific_name_taxonomy_id.split('_')[-1]
-    date = datetime.strptime(file_name.split('.')[0].split('_')[-1], '%Y%m%d%H%M%S')  # 20220112170519
-    return scientific_name, taxid, assembly_accession, date
+    return scientific_name, taxid, assembly_accession
 
 
 def parse_one_log(log_file):

--- a/eva-accession-release-automation/gather_clustering_counts/gather_clustering_counts_from_mongo.py
+++ b/eva-accession-release-automation/gather_clustering_counts/gather_clustering_counts_from_mongo.py
@@ -1,0 +1,378 @@
+import argparse
+import glob
+import os
+import psycopg2
+from collections import defaultdict
+from datetime import datetime
+
+from ebi_eva_common_pyutils.logger import logging_config
+from ebi_eva_common_pyutils.mongodb import MongoDatabase
+from ebi_eva_common_pyutils.config_utils import get_pg_metadata_uri_for_eva_profile
+from ebi_eva_common_pyutils.pg_utils import execute_query, get_all_results_for_query
+from gather_per_species_clustering_counts import assembly_table_name
+
+
+logger = logging_config.get_logger(__name__)
+logging_config.add_stdout_handler()
+
+
+def gather_count_from_mongo(clustering_dir, mongo_source, private_config_xml_file, release_version):
+    # Assume the directory structure:
+    # clustering_dir --> <scientific_name_taxonomy_id> --> <assembly_accession> --> cluster_<date>.log_dict
+
+    all_log_pattern = os.path.join(clustering_dir, '*', 'GCA_*', 'cluster_*.log')
+    all_log_files = glob.glob(all_log_pattern)
+    ranges_per_assembly = get_assembly_info_and_date_ranges(all_log_files)
+    metrics_per_assembly = get_metrics_per_assembly(mongo_source, ranges_per_assembly)
+    insert_counts_in_db(private_config_xml_file, metrics_per_assembly, ranges_per_assembly, release_version)
+
+
+def get_assembly_info_and_date_ranges(all_log_files):
+    """
+    Parse all the log files and retrieve assembly basic information (taxonomy, scientific name) and the date ranges
+    where all jobs and steps were run during the clustering process
+    """
+    ranges_per_assembly = defaultdict(dict)
+    for log_file in all_log_files:
+        logger.info('Parse log_dict file: ' + log_file)
+        scientific_name, taxid, assembly_accession, log_date = parse_log_file_path(log_file)
+        log_metric_date_range = parse_one_log(log_file)
+
+        if assembly_accession not in ranges_per_assembly:
+            ranges_per_assembly[assembly_accession] = defaultdict(dict)
+            ranges_per_assembly[assembly_accession]['metrics'] = defaultdict(dict)
+
+        # assembly info
+        ranges_per_assembly[assembly_accession]['taxid'] = taxid
+        ranges_per_assembly[assembly_accession]['scientific_name'] = scientific_name
+
+        # new_remapped_current_rs
+        if 'CLUSTERING_CLUSTERED_VARIANTS_FROM_MONGO_STEP' in log_metric_date_range:
+            ranges_per_assembly[assembly_accession]['metrics']['new_remapped_current_rs'][log_file] = {
+                'from': log_metric_date_range['CLUSTERING_CLUSTERED_VARIANTS_FROM_MONGO_STEP'],
+                'to': log_metric_date_range['CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES_STEP']
+                if "CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES_STEP" in log_metric_date_range
+                else log_metric_date_range["last_timestamp"]
+            }
+        # new_clustered_current_rs
+        if 'CLUSTERING_NON_CLUSTERED_VARIANTS_FROM_MONGO_STEP' in log_metric_date_range:
+            ranges_per_assembly[assembly_accession]['metrics']['new_clustered_current_rs'][log_file] = {
+                'from': log_metric_date_range['CLUSTERING_NON_CLUSTERED_VARIANTS_FROM_MONGO_STEP'],
+                'to': log_metric_date_range['CLUSTER_UNCLUSTERED_VARIANTS_JOB']["completed"]
+                if "completed" in log_metric_date_range['CLUSTER_UNCLUSTERED_VARIANTS_JOB']
+                else log_metric_date_range["last_timestamp"]
+            }
+        # merged_rs
+        if 'PROCESS_RS_MERGE_CANDIDATES_STEP' in log_metric_date_range:
+            ranges_per_assembly[assembly_accession]['metrics']['merged_rs'][log_file] = {
+                'from': log_metric_date_range['PROCESS_RS_MERGE_CANDIDATES_STEP'],
+                'to': log_metric_date_range['PROCESS_RS_SPLIT_CANDIDATES_STEP']
+                if "PROCESS_RS_SPLIT_CANDIDATES_STEP" in log_metric_date_range
+                else log_metric_date_range["last_timestamp"]
+            }
+        # split_rs
+        if 'PROCESS_RS_SPLIT_CANDIDATES_STEP' in log_metric_date_range:
+            ranges_per_assembly[assembly_accession]['metrics']['split_rs'][log_file] = {
+                'from': log_metric_date_range['PROCESS_RS_SPLIT_CANDIDATES_STEP'],
+                'to': log_metric_date_range['CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES_STEP']
+                if "CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES_STEP" in log_metric_date_range
+                else log_metric_date_range["last_timestamp"]
+            }
+        # new_ss_clustered
+        if 'CLUSTERING_NON_CLUSTERED_VARIANTS_FROM_MONGO_STEP' in log_metric_date_range:
+            ranges_per_assembly[assembly_accession]['metrics']['new_ss_clustered'][log_file] = {
+                'from': log_metric_date_range['CLUSTERING_NON_CLUSTERED_VARIANTS_FROM_MONGO_STEP'],
+                'to': log_metric_date_range['CLUSTER_UNCLUSTERED_VARIANTS_JOB']["completed"]
+                if "completed" in log_metric_date_range['CLUSTER_UNCLUSTERED_VARIANTS_JOB']
+                else log_metric_date_range["last_timestamp"]
+            }
+    return ranges_per_assembly
+
+
+def get_metrics_per_assembly(mongo_source, ranges_per_assembly):
+    """
+    Perform queries to mongodb to get counts based on the date ranges for the different metrics
+    """
+    metrics_per_assembly = defaultdict(dict)
+    for asm, asm_dict in ranges_per_assembly.items():
+        new_remapped_current_rs, new_clustered_current_rs, merged_rs, split_rs, new_ss_clustered = 0, 0, 0, 0, 0
+        for metric, log_dict in asm_dict['metrics'].items():
+            expressions = []
+            for log_name, query_range in log_dict.items():
+                expressions.append({"createdDate": {"$gt": query_range["from"], "$lt": query_range["to"]}})
+
+            date_range_filter = expressions
+            if metric == 'new_remapped_current_rs':
+                filter_criteria = {'asm': asm, '$or': date_range_filter}
+                new_remapped_current_rs = query_mongo(mongo_source, filter_criteria, metric)
+                logger.info(f'{metric} = {new_remapped_current_rs}')
+            elif metric == 'new_clustered_current_rs':
+                filter_criteria = {'asm': asm, '$or': date_range_filter}
+                new_clustered_current_rs = query_mongo(mongo_source, filter_criteria, metric)
+                logger.info(f'{metric} = {new_clustered_current_rs}')
+            elif metric == 'merged_rs':
+                filter_criteria = {'inactiveObjects.asm': asm, 'eventType': 'MERGED',
+                                   '$or': date_range_filter}
+                merged_rs = query_mongo(mongo_source, filter_criteria, metric)
+                logger.info(f'{metric} = {merged_rs}')
+            elif metric == 'split_rs':
+                filter_criteria = {'inactiveObjects.asm': asm, 'eventType': 'RS_SPLIT',
+                                   '$or': date_range_filter}
+                split_rs = query_mongo(mongo_source, filter_criteria, metric)
+                logger.info(f'{metric} = {split_rs}')
+            elif metric == 'new_ss_clustered':
+                filter_criteria = {'inactiveObjects.seq': asm, 'eventType': 'UPDATED',
+                                   '$or': date_range_filter}
+                new_ss_clustered = query_mongo(mongo_source, filter_criteria, metric)
+                logger.info(f'{metric} = {new_ss_clustered}')
+
+        metrics_per_assembly[asm]["assembly_accession"] = asm
+        metrics_per_assembly[asm]["new_remapped_current_rs"] = new_remapped_current_rs
+        metrics_per_assembly[asm]["new_clustered_current_rs"] = new_clustered_current_rs
+        metrics_per_assembly[asm]["merged_rs"] = merged_rs
+        metrics_per_assembly[asm]["split_rs"] = split_rs
+        metrics_per_assembly[asm]["new_ss_clustered"] = new_ss_clustered
+    return metrics_per_assembly
+
+
+def query_mongo(mongo_source, filter_criteria, metric):
+    total_count = 0
+    for collection_name in collections[metric]:
+        logger.info(f'Querying mongo: db.{collection_name}.countDocuments({filter_criteria})')
+        collection = mongo_source.mongo_handle[mongo_source.db_name][collection_name]
+        count = collection.count_documents(filter_criteria)
+        total_count += count
+        logger.info(f'{count}')
+    return total_count
+
+
+def insert_counts_in_db(private_config_xml_file, metrics_per_assembly, ranges_per_assembly, release_version):
+    with psycopg2.connect(get_pg_metadata_uri_for_eva_profile("production_processing", private_config_xml_file),
+                          user="evapro") \
+            as metadata_connection_handle:
+        for asm in metrics_per_assembly:
+            # get last release data for assembly
+            query_last_release = f"select * from {assembly_table_name} "\
+                             f"where assembly_accession = '{asm}' and release_version = {release_version}-1"
+            logger.info(query_last_release)
+            asm_last_release_data = get_all_results_for_query(metadata_connection_handle, query_last_release)
+
+            # insert data for current release
+            taxid = ranges_per_assembly[asm]['taxid']
+            scientific_name = ranges_per_assembly[asm]['scientific_name'].capitalize().replace('_', ' ')
+            folder = f"{ranges_per_assembly[asm]['scientific_name']}/{asm}"
+
+            new_remapped_current_rs = metrics_per_assembly[asm]['new_remapped_current_rs']
+
+            new_clustered_current_rs = metrics_per_assembly[asm]['new_clustered_current_rs']
+            new_current_rs = new_clustered_current_rs + new_remapped_current_rs
+
+            new_merged_rs = metrics_per_assembly[asm]['merged_rs']
+            new_split_rs = metrics_per_assembly[asm]['split_rs']
+            new_ss_clustered = metrics_per_assembly[asm]['new_ss_clustered']
+
+            insert_query = f"insert into {assembly_table_name} "\
+                           f"(taxonomy_id, scientific_name, assembly_accession, release_folder, release_version, " \
+                           f"current_rs, multi_mapped_rs, merged_rs, deprecated_rs, merged_deprecated_rs, " \
+                           f"new_current_rs, new_multi_mapped_rs, new_merged_rs, new_deprecated_rs, " \
+                           f"new_merged_deprecated_rs, new_ss_clustered, remapped_current_rs, " \
+                           f"new_remapped_current_rs, split_rs, new_split_rs, ss_clustered, clustered_current_rs," \
+                           f"new_clustered_current_rs) " \
+                           f"values ({taxid}, '{scientific_name}', '{asm}', '{folder}', {release_version}, " \
+
+            if asm_last_release_data:
+                prev_release_current_rs = asm_last_release_data[0][5]
+                prev_release_merged_rs = asm_last_release_data[0][7]
+                prev_release_multi_mapped_rs = asm_last_release_data[0][6]
+                prev_release_deprecated_rs = asm_last_release_data[0][8]
+                prev_release_merged_deprecated_rs = asm_last_release_data[0][9]
+
+                # get ss clustered
+                query_ss_clustered = f"select sum(new_ss_clustered) " \
+                                     f"from {assembly_table_name} " \
+                                     f"where assembly_accession = '{asm}'"
+                logger.info(query_ss_clustered)
+                ss_clustered_previous_releases = get_all_results_for_query(metadata_connection_handle,
+                                                                           query_ss_clustered)
+                total_ss_clustered_in_release = ss_clustered_previous_releases[0][0] + new_ss_clustered
+
+                # if assembly already existed -> add counts
+                total_current_rs_in_release = prev_release_current_rs + new_current_rs
+                total_merged_rs_in_release = prev_release_merged_rs + new_merged_rs
+                # current_rs in previous releases + newly clustered
+                total_clustered_current_rs_in_release = prev_release_current_rs + new_clustered_current_rs
+
+                insert_query_values = f"{total_current_rs_in_release}, " \
+                                      f"{prev_release_multi_mapped_rs}, " \
+                                      f"{total_merged_rs_in_release}, " \
+                                      f"{prev_release_deprecated_rs}, " \
+                                      f"{prev_release_merged_deprecated_rs}, " \
+                                      f"{new_current_rs}, " \
+                                      f"0, " \
+                                      f"{new_merged_rs}, " \
+                                      f"0, " \
+                                      f"0, " \
+                                      f"{new_ss_clustered}, " \
+                                      f"{new_remapped_current_rs}, " \
+                                      f"{new_remapped_current_rs}, " \
+                                      f"{new_split_rs}, " \
+                                      f"{new_split_rs}, " \
+                                      f"{total_ss_clustered_in_release}," \
+                                      f"{total_clustered_current_rs_in_release}," \
+                                      f"{new_clustered_current_rs})"
+            else:
+                # if new assembly
+                insert_query_values = f"{new_current_rs}, " \
+                                      f"0, " \
+                                      f"{new_merged_rs}, " \
+                                      f"0, " \
+                                      f"0, " \
+                                      f"{new_current_rs}, " \
+                                      f"0, " \
+                                      f"{new_merged_rs}, " \
+                                      f"0, " \
+                                      f"0, " \
+                                      f"{new_ss_clustered}, " \
+                                      f"{new_remapped_current_rs}, " \
+                                      f"{new_remapped_current_rs}, " \
+                                      f"{new_split_rs}, " \
+                                      f"{new_split_rs}, " \
+                                      f"{new_ss_clustered}," \
+                                      f"{new_clustered_current_rs}," \
+                                      f"{new_clustered_current_rs})"
+            insert_query = f"{insert_query} {insert_query_values}"
+            logger.info(insert_query)
+            execute_query(metadata_connection_handle, insert_query)
+
+        # get assemblies in from previous releases not in current release
+        assemblies_in_logs = ",".join(f"'{a}'" for a in ranges_per_assembly.keys())
+        query_missing_assemblies_stats = f"select * " \
+                                         f"from {assembly_table_name} " \
+                                         f"where release_version = {release_version}-1 " \
+                                         f"and assembly_accession not in ({assemblies_in_logs});"
+        logger.info(query_missing_assemblies_stats)
+        missing_assemblies_stats = get_all_results_for_query(metadata_connection_handle, query_missing_assemblies_stats)
+        for assembly_stats in missing_assemblies_stats:
+            taxonomy_id = assembly_stats[0]
+            scientific_name = assembly_stats[1]
+            assembly_accession = assembly_stats[2]
+            release_folder = assembly_stats[3]
+            current_rs = assembly_stats[5]
+            multi_mapped_rs = assembly_stats[6]
+            merged_rs = assembly_stats[7]
+            deprecated_rs = assembly_stats[8]
+            merged_deprecated_rs = assembly_stats[9]
+
+            # get ss clustered
+            query_ss_clustered = f"select sum(new_ss_clustered) " \
+                                 f"from {assembly_table_name} " \
+                                 f"where assembly_accession = '{assembly_accession}'"
+            logger.info(query_ss_clustered)
+            ss_clustered_previous_releases = get_all_results_for_query(metadata_connection_handle,
+                                                                       query_ss_clustered)
+            ss_clustered = ss_clustered_previous_releases[0][0]
+
+            insert_query = f"insert into {assembly_table_name} "\
+                           f"(taxonomy_id, scientific_name, assembly_accession, release_folder, release_version, " \
+                           f"current_rs, multi_mapped_rs, merged_rs, deprecated_rs, merged_deprecated_rs, " \
+                           f"new_current_rs, new_multi_mapped_rs, new_merged_rs, new_deprecated_rs, " \
+                           f"new_merged_deprecated_rs, new_ss_clustered, remapped_current_rs, " \
+                           f"new_remapped_current_rs, split_rs, new_split_rs, ss_clustered, clustered_current_rs, " \
+                           f"new_clustered_current_rs) " \
+                           f"values ({taxonomy_id}, '{scientific_name}', '{assembly_accession}', '{release_folder}', " \
+                           f"{release_version}, {current_rs}, {multi_mapped_rs}, {merged_rs}, {deprecated_rs}, " \
+                           f"{merged_deprecated_rs}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, {ss_clustered}, 0, 0);"
+            logger.info(insert_query)
+            execute_query(metadata_connection_handle, insert_query)
+
+
+collections = {
+    "new_remapped_current_rs": [
+        "clusteredVariantEntity",
+        "dbsnpClusteredVariantEntity"
+    ],
+    "new_clustered_current_rs": [
+        "clusteredVariantEntity"
+    ],
+    "merged_rs": [
+        "clusteredVariantOperationEntity",
+        "dbsnpClusteredVariantOperationEntity"
+    ],
+    "split_rs": [
+        "clusteredVariantOperationEntity",
+        "dbsnpClusteredVariantOperationEntity"
+    ],
+    "new_ss_clustered": [
+        "submittedVariantOperationEntity",
+        "dbsnpSubmittedVariantOperationEntity"
+    ]
+}
+
+
+def parse_log_file_path(log_file_path):
+    scientific_name_taxonomy_id, assembly_accession, file_name = log_file_path.split('/')[-3:]
+    scientific_name = '_'.join(scientific_name_taxonomy_id.split('_')[:-1])
+    taxid = scientific_name_taxonomy_id.split('_')[-1]
+    date = datetime.strptime(file_name.split('.')[0].split('_')[-1], '%Y%m%d%H%M%S')  # 20220112170519
+    return scientific_name, taxid, assembly_accession, date
+
+
+def parse_one_log(log_file):
+    # identify the clustering job/step
+    # identify the start end of run
+    # find the count lines and extract metrics
+    results = {}
+    with open(log_file) as open_file:
+        for line in open_file:
+            sp_line = line.strip().split()
+            if len(sp_line) < 8:
+                continue
+
+            # get last timestamp
+            try:
+                timestamp = datetime.strptime(f"{sp_line[0]}T{sp_line[1]}Z", '%Y-%m-%dT%H:%M:%S.%fZ')
+            except ValueError:
+                pass
+
+            # Jobs
+            if sp_line[7] == 'o.s.b.c.l.support.SimpleJobLauncher':
+                if sp_line[12] == "launched" or sp_line[12] == "completed":
+                    current_job = sp_line[11].rstrip(']').lstrip('[name=')
+                    job_status = sp_line[12]
+                    if current_job not in results:
+                        results[current_job] = {}
+                    if job_status not in results[current_job]:
+                        results[current_job][job_status] = {}
+                    results[current_job][job_status] = timestamp
+            # Steps
+            if sp_line[7] == 'o.s.batch.core.job.SimpleStepHandler':
+                current_step = sp_line[11].rstrip(']').lstrip('[')
+                if current_step not in results:
+                    results[current_step] = {}
+                results[current_step] = timestamp
+
+    results["last_timestamp"] = timestamp
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Parse all the clustering logs to get date ranges and query mongo to get metrics counts')
+    parser.add_argument("--clustering-root-path", type=str,
+                        help="base directory where all the clustering was run.", required=True)
+    parser.add_argument("--mongo-source-uri",
+                        help="Mongo Source URI (ex: mongodb://user:@mongos-source-host:27017/admin)", required=True)
+    parser.add_argument("--mongo-source-secrets-file",
+                        help="Full path to the Mongo Source secrets file (ex: /path/to/mongo/source/secret)",
+                        required=True)
+    parser.add_argument('--private-config-xml-file', help='Path to the file containing the ', required=True)
+    parser.add_argument("--release-version", type=int, help="current release version", required=True)
+
+    args = parser.parse_args()
+    mongo_source = MongoDatabase(uri=args.mongo_source_uri, secrets_file=args.mongo_source_secrets_file,
+                                 db_name="eva_accession_sharded")
+    gather_count_from_mongo(args.clustering_root_path, mongo_source, args.private_config_xml_file, args.release_version)
+
+
+if __name__ == '__main__':
+    main()

--- a/eva-accession-release-automation/gather_clustering_counts/gather_clustering_counts_from_mongo.py
+++ b/eva-accession-release-automation/gather_clustering_counts/gather_clustering_counts_from_mongo.py
@@ -338,6 +338,7 @@ def parse_remapping_log_file_path(log_file_path):
 
 
 def parse_log_file_path(log_file_path):
+    # See https://github.com/EBIvariation/eva-tools/blob/9bed9547c73d35a475d06bf6fff58b1bb6af2140/variant-remapping-automation/remapping_process.nf#L245
     remapping_log_file_pattern = re.compile("^(GCA_.*)+_to_(GCA_.*)+_clustering.log$")
     if remapping_log_file_pattern.match(os.path.basename(log_file_path)):
         return parse_remapping_log_file_path(log_file_path)

--- a/eva-accession-release-automation/gather_clustering_counts/gather_clustering_counts_from_mongo.py
+++ b/eva-accession-release-automation/gather_clustering_counts/gather_clustering_counts_from_mongo.py
@@ -15,7 +15,7 @@ from gather_clustering_counts.gather_per_species_clustering_counts import assemb
 
 logger = logging_config.get_logger(__name__)
 logging_config.add_stdout_handler()
-taxonomy_scientific_name_map = defaultdict(dict)
+taxonomy_scientific_name_map = {}
 
 
 def gather_count_from_mongo(clustering_dir, remapping_dir, mongo_source, private_config_xml_file, release_version):

--- a/eva-accession-release-automation/gather_clustering_counts/gather_per_species_clustering_counts.py
+++ b/eva-accession-release-automation/gather_clustering_counts/gather_per_species_clustering_counts.py
@@ -1,0 +1,143 @@
+import argparse
+import os
+
+from ebi_eva_common_pyutils.logger import logging_config
+from ebi_eva_common_pyutils.metadata_utils import get_metadata_connection_handle
+from ebi_eva_common_pyutils.command_utils import run_command_with_output
+from ebi_eva_common_pyutils.pg_utils import get_all_results_for_query, execute_query
+
+logger = logging_config.get_logger(__name__)
+logging_config.add_stdout_handler()
+
+shell_script_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'bash')
+
+species_table_name = 'eva_stats.release_rs_statistics_per_species'
+assembly_table_name = 'eva_stats.release_rs_statistics_per_assembly'
+tracker_table_name = 'eva_progress_tracker.clustering_release_tracker'
+
+id_to_column = {
+    'current': 'current_rs',
+    'multimap': 'multi_mapped_rs',
+    'merged': 'merged_rs',
+    'deprecated': 'deprecated_rs',
+    'merged_deprecated': 'merged_deprecated_rs',
+    'unmapped': 'unmapped_rs'
+}
+
+
+def write_counts_to_table(private_config_xml_file, counts):
+    all_columns = counts[0].keys()
+    all_values = [f"({','.join(str(species_counts[c]) for c in all_columns)})" for species_counts in counts]
+    insert_query = f"insert into {species_table_name} " \
+                   f"({','.join(all_columns)}) " \
+                   f"values {','.join(all_values)}"
+    with get_metadata_connection_handle('production_processing', private_config_xml_file) as db_conn:
+        execute_query(db_conn, insert_query)
+
+
+def get_new_ss_clustered(private_config_xml_file, release_version, taxonomy_id):
+    query = f"select new_ss_clustered from {assembly_table_name} " \
+            f"where release_version={release_version} " \
+            f"and taxonomy_id={taxonomy_id} " \
+            f"and new_ss_clustered > 0"
+    with get_metadata_connection_handle('production_processing', private_config_xml_file) as db_conn:
+        results = get_all_results_for_query(db_conn, query)
+    if len(results) > 1:
+        raise ValueError(f'Should have exactly one assembly for taxonomy {taxonomy_id} with new clustered ss, '
+                         f'instead found {len(results)}')
+    elif len(results) == 0:
+        logger.warning(f'No assemblies found with new clustered ss for taxonomy {taxonomy_id}')
+        return 0
+    return results[0][0]
+
+
+def get_last_release_metric(private_config_xml_file, release_version, taxonomy_id, column_name):
+    query = f"select {column_name} from {species_table_name} " \
+            f"where release_version={release_version-1} " \
+            f"and taxonomy_id={taxonomy_id}"
+    with get_metadata_connection_handle('production_processing', private_config_xml_file) as db_conn:
+        results = get_all_results_for_query(db_conn, query)
+    # If this is a new species for this release, won't find anything, so just return 0
+    if len(results) < 1:
+        return 0
+    return results[0][0]
+
+
+def get_taxonomy_and_scientific_name(private_config_xml_file, release_version, species_folder):
+    query = f"select taxonomy, scientific_name from {tracker_table_name} " \
+            f"where release_version={release_version} " \
+            f"and release_folder_name='{species_folder}' " \
+            f"and should_be_released"
+    with get_metadata_connection_handle('production_processing', private_config_xml_file) as db_conn:
+        results = get_all_results_for_query(db_conn, query)
+    if len(results) < 1:
+        logger.warning(f'Failed to get scientific name and taxonomy for {species_folder}')
+        return None, None
+    return results[0][0], results[0][1]
+
+
+def run_count_script(script_name, species_dir, metric_id):
+    log_file = f'{os.path.basename(species_dir)}_count_{metric_id}_rsid.log'
+    if not os.path.exists(log_file):
+        run_command_with_output(
+            f'Run {script_name}',
+            f'{os.path.join(shell_script_dir, script_name)} {species_dir} {metric_id}'
+        )
+    return log_file
+
+
+def gather_counts(private_config_xml_file, release_version, release_dir):
+    results = []
+    for species_dir in os.listdir(release_dir):
+        full_species_dir = os.path.join(release_dir, species_dir)
+
+        # Get data from other tables
+        taxid, sci_name = get_taxonomy_and_scientific_name(private_config_xml_file, release_version, species_dir)
+        if not taxid or not sci_name:
+            continue
+        new_ss_clustered = get_new_ss_clustered(private_config_xml_file, release_version, taxid)
+        per_species_results = {
+            'taxonomy_id': taxid,
+            'scientific_name': f"'{sci_name}'",
+            'release_folder': f"'{species_dir}'",
+            'release_version': release_version,
+            'new_ss_clustered': new_ss_clustered
+        }
+
+        # Get metrics from release files
+        for metric_id in id_to_column.keys():
+            if metric_id in {'current', 'merged', 'multimap'}:
+                output_log = run_count_script('count_rs_for_release.sh', full_species_dir, metric_id)
+            elif metric_id in {'deprecated', 'merged_deprecated'}:
+                output_log = run_count_script('count_rs_for_release_for_txt.sh', full_species_dir, metric_id)
+            else:
+                output_log = run_count_script('count_rs_for_release_unmapped.sh', full_species_dir, metric_id)
+
+            with open(output_log) as f:
+                total = sum(int(line.strip().split(' ')[0]) for line in f)
+            per_species_results[id_to_column[metric_id]] = total
+
+            # Include diff with previous release
+            last_release_total = get_last_release_metric(private_config_xml_file, release_version, taxid,
+                                                         id_to_column[metric_id])
+            per_species_results[f'new_{id_to_column[metric_id]}'] = max(0, total-last_release_total)
+
+        results.append(per_species_results)
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Parse all the release output to get RS statistics per species')
+    parser.add_argument("--release-root-path", type=str,
+                        help="base directory where all the release was run.", required=True)
+    parser.add_argument("--private-config-xml-file", help="ex: /path/to/eva-maven-settings.xml", required=True)
+    parser.add_argument("--release-version", type=int, help="current release version", required=True)
+
+    args = parser.parse_args()
+    counts = gather_counts(args.private_config_xml_file, args.release_version, args.release_root_path)
+    write_counts_to_table(args.private_config_xml_file, counts)
+
+
+if __name__ == '__main__':
+    main()

--- a/eva-accession-release-automation/gather_clustering_counts/requirements.txt
+++ b/eva-accession-release-automation/gather_clustering_counts/requirements.txt
@@ -1,0 +1,1 @@
+ebi_eva_common_pyutils

--- a/eva-accession-release-automation/publish_release_to_ftp/publish_release_files_to_ftp.py
+++ b/eva-accession-release-automation/publish_release_to_ftp/publish_release_files_to_ftp.py
@@ -97,7 +97,7 @@ def get_release_file_list_for_assembly(release_assembly_info):
     for example, see here, ftp://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_1/by_assembly/GCA_000001515.4/)
     """
     assembly_accession = release_assembly_info["assembly_accession"]
-    vcf_files = ["{0}_{1}.vcf.gz".format(assembly_accession, category) for category in release_vcf_file_categories]
+    vcf_files = ["{0}_{1}_with_genbank.vcf.gz".format(assembly_accession, category) for category in release_vcf_file_categories]
     text_files = ["{0}_{1}.txt.gz".format(assembly_accession, category) for category in release_text_file_categories]
     csi_files = ["{0}.csi".format(filename) for filename in vcf_files]
     release_file_list = vcf_files + text_files + csi_files + ["README_rs_ids_counts.txt"]


### PR DESCRIPTION
Scripts differences below
- count_rs_for_release.sh - [diff](https://www.diffchecker.com/OZVebcoC)
- count_rs_release_for_txt.sh - [diff](https://www.diffchecker.com/4SX2lHEk)
- count_rs_for_release_unmapped.sh - [diff](https://www.diffchecker.com/V4X70POd)
- gather_clustering_counts_from_mongo.py - [diff](https://www.diffchecker.com/wQ0aP21n)
- gather_per_species_clustering_counts.py - [diff](https://www.diffchecker.com/kGbNiu4F)
