### PR TITLE
EVA-3124 - Log discards in remapping writer

### DIFF
--- a/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/listeners/RemappingIngestionProgressListener.java
+++ b/eva-remapping-ingest/src/main/java/uk/ac/ebi/eva/remapping/ingest/batch/listeners/RemappingIngestionProgressListener.java
@@ -41,11 +41,13 @@ public class RemappingIngestionProgressListener extends GenericProgressListener<
 
         String stepName = stepExecution.getStepName();
         long numTotalItemsRead = stepExecution.getReadCount();
-        logger.info("Step {} finished: Items (remapped ss) read = {}, ss ingested = {}, ss skipped (duplicate) = {}",
+        logger.info("Step {} finished: Items (remapped ss) read = {}, ss ingested = {}, ss skipped (duplicate) = {}," +
+                            " ss discarded from db = {}",
                     stepName,
                     numTotalItemsRead,
                     remappingIngestCounts.getRemappedVariantsIngested(),
-                    remappingIngestCounts.getRemappedVariantsSkipped());
+                    remappingIngestCounts.getRemappedVariantsSkipped(),
+                    remappingIngestCounts.getRemappedVariantsDiscarded());
         return status;
     }
 }


### PR DESCRIPTION
Added a couple tests to exemplify some slightly weird deduplication behaviour in the writer.  I believe it's actually correct and only applies to a situation where there are existing duplicate SS anyway, but combined with the lack of discard logging I think it could account for the counting discrepancy in the original ticket.  (I'll also create a new ticket for QC so we can continue to monitor the situation...)