### PR TITLE
EVA-3267 - Explicitly name RestTemplate beans

### DIFF
--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/listeners/ListenersConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/listeners/ListenersConfiguration.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.eva.accession.clustering.configuration.batch.listeners;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +24,8 @@ public class ListenersConfiguration {
     }
 
     @Bean
-    public MetricCompute getClusteringMetricCompute(CountServiceParameters countServiceParameters, RestTemplate restTemplate,
+    public MetricCompute getClusteringMetricCompute(CountServiceParameters countServiceParameters,
+                                                    @Qualifier("COUNT_STATS_REST_TEMPLATE") RestTemplate restTemplate,
                                                     InputParameters inputParameters) {
         return new ClusteringMetricCompute(countServiceParameters, restTemplate, inputParameters.getAssemblyAccession(),
                                            inputParameters.getProjects());

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/SSSplitWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/SSSplitWriterTest.java
@@ -117,6 +117,7 @@ public class SSSplitWriterTest {
     private MockRestServiceServer mockServer;
 
     @Autowired
+    @Qualifier("COUNT_STATS_REST_TEMPLATE")
     private RestTemplate restTemplate;
 
     private final String URL_PATH_SAVE_COUNT = "/v1/bulk/count";

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringVariantJobConfigurationTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringVariantJobConfigurationTest.java
@@ -113,6 +113,7 @@ public class ClusteringVariantJobConfigurationTest {
     private CountServiceParameters countServiceParameters;
 
     @Autowired
+    @Qualifier("COUNT_STATS_REST_TEMPLATE")
     private RestTemplate restTemplate;
 
     private final String URL_PATH_SAVE_COUNT = "/v1/bulk/count";

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringVariantStepConfigurationTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/steps/ClusteringVariantStepConfigurationTest.java
@@ -115,6 +115,7 @@ public class ClusteringVariantStepConfigurationTest {
     private CountServiceParameters countServiceParameters;
 
     @Autowired
+    @Qualifier("COUNT_STATS_REST_TEMPLATE")
     private RestTemplate restTemplate;
 
     private final String URL_PATH_SAVE_COUNT = "/v1/bulk/count";

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/runner/ClusteringCommandLineRunnerTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/runner/ClusteringCommandLineRunnerTest.java
@@ -276,6 +276,7 @@ public class ClusteringCommandLineRunnerTest {
     private CountServiceParameters countServiceParameters;
 
     @Autowired
+    @Qualifier("COUNT_STATS_REST_TEMPLATE")
     private RestTemplate restTemplate;
 
     private final String URL_PATH_SAVE_COUNT = "/v1/bulk/count";

--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/ContigAliasConfiguration.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/ContigAliasConfiguration.java
@@ -17,6 +17,7 @@
  */
 package uk.ac.ebi.eva.accession.core.configuration;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +29,7 @@ import uk.ac.ebi.eva.accession.core.contigalias.ContigAliasService;
 @Configuration
 public class ContigAliasConfiguration {
 
-    @Bean
+    @Bean(name="CONTIG_ALIAS_REST_TEMPLATE")
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }
@@ -40,7 +41,7 @@ public class ContigAliasConfiguration {
     }
 
     @Bean
-    public ContigAliasService contigAliasService(RestTemplate restTemplate,
+    public ContigAliasService contigAliasService(@Qualifier("CONTIG_ALIAS_REST_TEMPLATE") RestTemplate restTemplate,
                                                  ContigAliasInputParameters contigAliasInputParameters) {
         return new ContigAliasService(restTemplate, contigAliasInputParameters.getUrl());
     }

--- a/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/configuration/batch/listeners/ListenerConfiguration.java
+++ b/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/configuration/batch/listeners/ListenerConfiguration.java
@@ -16,6 +16,7 @@
 package uk.ac.ebi.eva.accession.deprecate.configuration.batch.listeners;
 
 import org.springframework.batch.core.listener.StepListenerSupport;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -46,7 +47,8 @@ public class ListenerConfiguration {
 
     @Bean
     public MetricCompute getClusteringMetricCompute(CountServiceParameters countServiceParameters,
-                                                    RestTemplate restTemplate, InputParameters inputParameters) {
+                                                    @Qualifier("COUNT_STATS_REST_TEMPLATE") RestTemplate restTemplate,
+                                                    InputParameters inputParameters) {
         return new ClusteringMetricCompute(countServiceParameters, restTemplate,
                                            inputParameters.getAssemblyAccession(),
                                            Collections.singletonList(inputParameters.getProjectAccession()));

--- a/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/batch/listeners/ListenersConfiguration.java
+++ b/eva-accession-pipeline/src/main/java/uk/ac/ebi/eva/accession/pipeline/configuration/batch/listeners/ListenersConfiguration.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.eva.accession.pipeline.configuration.batch.listeners;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +23,8 @@ public class ListenersConfiguration {
     }
 
     @Bean
-    public MetricCompute getClusteringMetricCompute(CountServiceParameters countServiceParameters, RestTemplate restTemplate,
+    public MetricCompute getClusteringMetricCompute(CountServiceParameters countServiceParameters,
+                                                    @Qualifier("COUNT_STATS_REST_TEMPLATE") RestTemplate restTemplate,
                                                     InputParameters inputParameters) {
         return new AccessioningMetricCompute(countServiceParameters, restTemplate, inputParameters.getAssemblyAccession(),
                 inputParameters.getProjectAccession());

--- a/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/runner/EvaAccessionJobLauncherCommandLineRunnerTest.java
+++ b/eva-accession-pipeline/src/test/java/uk/ac/ebi/eva/accession/pipeline/runner/EvaAccessionJobLauncherCommandLineRunnerTest.java
@@ -30,6 +30,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.test.JobRepositoryTestUtils;
 import org.springframework.batch.test.context.SpringBatchTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
@@ -102,6 +103,7 @@ public class EvaAccessionJobLauncherCommandLineRunnerTest {
     private CountServiceParameters countServiceParameters;
 
     @Autowired
+    @Qualifier("COUNT_STATS_REST_TEMPLATE")
     private RestTemplate restTemplate;
 
     private final String URL_PATH_SAVE_COUNT = "/v1/bulk/count";

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
             <dependency>
                 <groupId>uk.ac.ebi.eva</groupId>
                 <artifactId>eva-metrics</artifactId>
-                <version>0.0.3</version>
+                <version>0.0.4-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>


### PR DESCRIPTION
RestTemplate bean [for contig-alias introduced as part of EVA-3228](https://github.com/EBIvariation/eva-accession/blob/a027ce0ccb4765e509ef175c38c450837e70c73d/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/configuration/ContigAliasConfiguration.java#L32) was chosen sporadically by Spring for autowiring [here](https://github.com/EBIvariation/eva-accession/blob/a027ce0ccb4765e509ef175c38c450837e70c73d/eva-accession-deprecate/src/main/java/uk/ac/ebi/eva/accession/deprecate/configuration/batch/listeners/ListenerConfiguration.java#L49) instead of the [RestTemplate with authentication](https://github.com/EBIvariation/eva-metrics/blob/eb0809edb57da83cad662d0e89504c53ff6b75fb/src/main/java/uk/ac/ebi/eva/metrics/configuration/MetricConfiguration.java#L20) meant for count-stats. This caused count-stats metrics persistence functionality to fail because it involves a PUT request that requires authentication. The newly introduced RestTemplate bean does not have authentication possibly because we are not performing any authenticated contig-alias tasks. This PR and [this PR in eva-metrics](https://github.com/EBIvariation/eva-metrics/pull/4) explicitly disambugate these beans by naming them.