### PR TITLE
EVA-3164 - Low-hanging optimizations for clustering

### DIFF
--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
@@ -357,7 +357,6 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
                 submittedVariantOperationEntity = new SubmittedVariantOperationEntity();
                 submittedVariantOperationEntity.fill(EventType.RS_MERGE_CANDIDATES, accessionInDB,
                         "RS mismatch with " + accessionInDB, inactiveObjects);
-                submittedVariantOperationEntity.setId("RSMC_" + this.assembly + "_" + variantHash);
                 mergeCandidateSVOE.put(variantHash, submittedVariantOperationEntity);
             }
             updateMergeCandidateSVOE.put(variantHash, submittedVariantOperationEntity);
@@ -391,7 +390,6 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
                                                                                         .collect(Collectors.toList());
                 submittedVariantOperationEntity.fill(EventType.RS_SPLIT_CANDIDATES, variantAccession,
                         "Hash mismatch with " + variantAccession, inactiveEntities);
-                submittedVariantOperationEntity.setId("RSSC_" + this.assembly + "_" + variantAccession);
                 rsSplitCandidateSVOE.put(variantAccession, submittedVariantOperationEntity);
             }
             updateRsSplitCandidateSVOE.put(variantAccession, submittedVariantOperationEntity);
@@ -425,6 +423,8 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
         for (Map.Entry<String, SubmittedVariantOperationEntity> entry : mergeSVOE.entrySet()) {
             SubmittedVariantOperationEntity svoe = entry.getValue();
             if(Objects.isNull(svoe.getId())){
+                svoe.setId("RSMC_" + this.assembly + "_" +
+                                   this.getClusteredVariantHash(svoe.getInactiveObjects().get(0)));
                 mergeSVOEInsertEntries.add(svoe);
                 continue;
             }
@@ -442,6 +442,8 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
             Long accession = entry.getKey();
             SubmittedVariantOperationEntity svoe = entry.getValue();
             if(Objects.isNull(svoe.getId())){
+                svoe.setId("RSSC_" + this.assembly + "_" +
+                                   svoe.getInactiveObjects().get(0).getClusteredVariantAccession());
                 rsSplitSVOEInsertEntries.add(svoe);
                 continue;
             }

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/ClusteringWriter.java
@@ -357,7 +357,7 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
                 submittedVariantOperationEntity = new SubmittedVariantOperationEntity();
                 submittedVariantOperationEntity.fill(EventType.RS_MERGE_CANDIDATES, accessionInDB,
                         "RS mismatch with " + accessionInDB, inactiveObjects);
-
+                submittedVariantOperationEntity.setId("RSMC_" + this.assembly + "_" + variantHash);
                 mergeCandidateSVOE.put(variantHash, submittedVariantOperationEntity);
             }
             updateMergeCandidateSVOE.put(variantHash, submittedVariantOperationEntity);
@@ -391,7 +391,7 @@ public class ClusteringWriter implements ItemWriter<SubmittedVariantEntity> {
                                                                                         .collect(Collectors.toList());
                 submittedVariantOperationEntity.fill(EventType.RS_SPLIT_CANDIDATES, variantAccession,
                         "Hash mismatch with " + variantAccession, inactiveEntities);
-
+                submittedVariantOperationEntity.setId("RSSC_" + this.assembly + "_" + variantAccession);
                 rsSplitCandidateSVOE.put(variantAccession, submittedVariantOperationEntity);
             }
             updateRsSplitCandidateSVOE.put(variantAccession, submittedVariantOperationEntity);

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriter.java
@@ -138,10 +138,6 @@ public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity
             this.currentlyProcessingOperationIndex = i;
             writeRSMerge(allMergeCandidateOperations.get(i));
         }
-        List<String> allCandidateIds = allMergeCandidateOperations.stream().map(EventDocument::getId)
-                .collect(Collectors.toList());
-        this.mongoTemplate.findAllAndRemove(query(where("_id").in(allCandidateIds)),
-                SubmittedVariantOperationEntity.class);
     }
 
     private void populateOperationsIndex

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriter.java
@@ -429,7 +429,7 @@ public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity
                 newSplitCandidateRecord.fill(EventType.RS_SPLIT_CANDIDATES, lowestSS,
                         "Hash mismatch with " + prioritised.accessionToKeep,
                         ssClusteredUnderTargetRS);
-                newSplitCandidateRecord.setId("RSSC_" + this.assemblyAccession + "_" + prioritised.accessionToKeep);
+                newSplitCandidateRecord.setId(ClusteringWriter.getSplitCandidateId(newSplitCandidateRecord));
                 mongoTemplate.insert(Collections.singletonList(newSplitCandidateRecord),
                         SubmittedVariantOperationEntity.class);
                 metricCompute.addCount(ClusteringMetric.CLUSTERED_VARIANTS_RS_SPLIT, 1);

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriter.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGeneratedException;
@@ -64,8 +65,8 @@ import java.util.stream.Collectors;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
 import static org.springframework.data.mongodb.core.query.Update.update;
-import static uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplitCandidatesReaderConfiguration.getMergeCandidatesQuery;
-import static uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplitCandidatesReaderConfiguration.getSplitCandidatesQuery;
+import static uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplitCandidatesReaderConfiguration.getMergeCandidatesCriteria;
+import static uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplitCandidatesReaderConfiguration.getSplitCandidatesCriteria;
 
 public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity> {
 
@@ -137,6 +138,10 @@ public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity
             this.currentlyProcessingOperationIndex = i;
             writeRSMerge(allMergeCandidateOperations.get(i));
         }
+        List<String> allCandidateIds = allMergeCandidateOperations.stream().map(EventDocument::getId)
+                .collect(Collectors.toList());
+        this.mongoTemplate.findAllAndRemove(query(where("_id").in(allCandidateIds)),
+                SubmittedVariantOperationEntity.class);
     }
 
     private void populateOperationsIndex
@@ -318,10 +323,11 @@ public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity
     }
 
     private void updateOperationsInDB(ClusteredVariantMergingPolicy.Priority prioritised,
-                           SubmittedVariantOperationEntity currentMergeOperation) {
-        Query queryForMergeCandidatesInvolvingMergee = getMergeCandidatesQuery(this.assemblyAccession)
-                .addCriteria(where(ID_ATTRIBUTE).ne(currentMergeOperation.getId()))
-                .addCriteria(where(RS_KEY_IN_OPERATIONS_COLLECTION).is(prioritised.accessionToBeMerged));
+                                      SubmittedVariantOperationEntity currentMergeOperation) {
+        Query queryForMergeCandidatesInvolvingMergee = query(new Criteria().andOperator(
+                getMergeCandidatesCriteria(this.assemblyAccession),
+                where(ID_ATTRIBUTE).ne(currentMergeOperation.getId()),
+                where(RS_KEY_IN_OPERATIONS_COLLECTION).is(prioritised.accessionToBeMerged)));
         List<SubmittedVariantOperationEntity> operationsInDBInvolvingMergee =
                 mongoTemplate.find(queryForMergeCandidatesInvolvingMergee, SubmittedVariantOperationEntity.class);
         for (SubmittedVariantOperationEntity operation: operationsInDBInvolvingMergee) {
@@ -357,9 +363,10 @@ public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity
                 SubmittedVariantOperationEntity updatedOperation =
                         new SubmittedVariantOperationEntity();
                 updatedOperation.fill(operation.getEventType(), operation.getAccession(), operation.getReason(),
-                                      inactiveEntities);
+                        inactiveEntities);
+                updatedOperation.setId(operation.getId());
                 allMergeCandidateOperations.set(operationWithIndex.operationIndex, updatedOperation);
-            }            
+            }
         }
     }
 
@@ -374,10 +381,12 @@ public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity
     }
 
     private void updateSplitCandidates(ClusteredVariantMergingPolicy.Priority prioritised) {
-        Query queryForSplitCandidatesInvolvingTargetRS = getSplitCandidatesQuery(this.assemblyAccession)
-                .addCriteria(where(RS_KEY_IN_OPERATIONS_COLLECTION).is(prioritised.accessionToKeep));
-        Query queryForSplitCandidatesInvolvingMergee = getSplitCandidatesQuery(this.assemblyAccession)
-                .addCriteria(where(RS_KEY_IN_OPERATIONS_COLLECTION).is(prioritised.accessionToBeMerged));
+        Query queryForSplitCandidatesInvolvingTargetRS = query(getSplitCandidatesCriteria(this.assemblyAccession)
+                                                                       .and(RS_KEY_IN_OPERATIONS_COLLECTION)
+                                                                       .is(prioritised.accessionToKeep));
+        Query queryForSplitCandidatesInvolvingMergee = query(getSplitCandidatesCriteria(this.assemblyAccession)
+                                                                     .and(RS_KEY_IN_OPERATIONS_COLLECTION)
+                                                                     .is(prioritised.accessionToBeMerged));
         // Since the mergee has been merged into the target RS,
         // the split candidates record for mergee are no longer valid - so, delete them!
         mongoTemplate.remove(queryForSplitCandidatesInvolvingMergee, SubmittedVariantOperationEntity.class);
@@ -422,8 +431,9 @@ public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity
                 // TODO: Refactor to use common fill method for split candidates generation
                 // to avoid duplicating reason text and call semantics
                 newSplitCandidateRecord.fill(EventType.RS_SPLIT_CANDIDATES, lowestSS,
-                                             "Hash mismatch with " + prioritised.accessionToKeep,
-                                             ssClusteredUnderTargetRS);
+                        "Hash mismatch with " + prioritised.accessionToKeep,
+                        ssClusteredUnderTargetRS);
+                newSplitCandidateRecord.setId("RSSC_" + this.assemblyAccession + "_" + prioritised.accessionToKeep);
                 mongoTemplate.insert(Collections.singletonList(newSplitCandidateRecord),
                         SubmittedVariantOperationEntity.class);
                 metricCompute.addCount(ClusteringMetric.CLUSTERED_VARIANTS_RS_SPLIT, 1);
@@ -446,10 +456,11 @@ public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity
                         where(REFERENCE_ASSEMBLY_FIELD_IN_SUBMITTED_VARIANT_COLLECTION).is(this.assemblyAccession));
         List<? extends SubmittedVariantEntity> svToUpdate =
                 mongoTemplate.find(querySubmitted, submittedVariantCollection);
+        List<String> svToUpdateIds = svToUpdate.stream().map(AccessionedDocument::getId).collect(Collectors.toList());
 
         Update update = new Update();
         update.set(RS_KEY, prioritised.accessionToKeep);
-        mongoTemplate.updateMulti(querySubmitted, update, submittedVariantCollection);
+        mongoTemplate.updateMulti(query(where("_id").in(svToUpdateIds)), update, submittedVariantCollection);
         metricCompute.addCount(ClusteringMetric.SUBMITTED_VARIANTS_UPDATED_RS, svToUpdate.size());
 
         List<SubmittedVariantOperationEntity> operations =

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/RSMergeAndSplitCandidatesReaderConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/RSMergeAndSplitCandidatesReaderConfiguration.java
@@ -30,6 +30,7 @@ import uk.ac.ebi.eva.accession.clustering.configuration.InputParametersConfigura
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
 
 import java.util.Arrays;
@@ -55,12 +56,18 @@ public class RSMergeAndSplitCandidatesReaderConfiguration {
 
     public static final EventType MERGE_CANDIDATES_EVENT_TYPE = EventType.RS_MERGE_CANDIDATES;
 
+    public static final String MERGE_CANDIDATE_ID_PREFIX = "RSMC";
+
+    public static final String SPLIT_CANDIDATE_ID_PREFIX = "RSSC";
+
     public static Criteria getSplitCandidatesCriteria(String assemblyAccession) {
-        return where(DBCollection.ID_FIELD_NAME).regex("^RSSC_" + assemblyAccession + "_.*");
+        return where(DBCollection.ID_FIELD_NAME).regex("^" + SPLIT_CANDIDATE_ID_PREFIX + "_"
+                                                               + assemblyAccession + "_.*");
     }
 
     public static Criteria getMergeCandidatesCriteria(String assemblyAccession) {
-        return where(DBCollection.ID_FIELD_NAME).regex("^RSMC_" + assemblyAccession + "_.*");
+        return where(DBCollection.ID_FIELD_NAME).regex("^" + MERGE_CANDIDATE_ID_PREFIX + "_"
+                                                               + assemblyAccession + "_.*");
     }
 
     @Bean(RS_SPLIT_CANDIDATES_READER)

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/RSMergeAndSplitCandidatesReaderConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/RSMergeAndSplitCandidatesReaderConfiguration.java
@@ -15,27 +15,29 @@
  */
 package uk.ac.ebi.eva.accession.clustering.configuration.batch.io;
 
+import com.mongodb.DBCollection;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.batch.item.data.MongoItemReader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Meta;
 import org.springframework.data.mongodb.core.query.Query;
 
 import uk.ac.ebi.ampt2d.commons.accession.core.models.EventType;
 import uk.ac.ebi.eva.accession.clustering.configuration.InputParametersConfiguration;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
+import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLEAR_RS_MERGE_AND_SPLIT_CANDIDATES;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.RS_MERGE_CANDIDATES_READER;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.RS_SPLIT_CANDIDATES_READER;
@@ -48,53 +50,51 @@ public class RSMergeAndSplitCandidatesReaderConfiguration {
 
     public static final String ASSEMBLY_FIELD = "inactiveObjects.seq";
 
-    private static final String SORT_FIELD = "accession";
-
     public static final String EVENT_TYPE_FIELD = "eventType";
 
     public static final EventType SPLIT_CANDIDATES_EVENT_TYPE = EventType.RS_SPLIT_CANDIDATES;
 
     public static final EventType MERGE_CANDIDATES_EVENT_TYPE = EventType.RS_MERGE_CANDIDATES;
 
-    public static Query getSplitCandidatesQuery(String assemblyAccession) {
-        return Query.query(where(ASSEMBLY_FIELD).is(assemblyAccession))
-                    .addCriteria(where(EVENT_TYPE_FIELD).is(SPLIT_CANDIDATES_EVENT_TYPE.toString()));
+    public static Criteria getSplitCandidatesCriteria(String assemblyAccession) {
+        return where(DBCollection.ID_FIELD_NAME).regex("^RSSC_" + assemblyAccession + "_.*");
     }
 
-    public static Query getMergeCandidatesQuery(String assemblyAccession) {
-        return Query.query(where(ASSEMBLY_FIELD).is(assemblyAccession))
-                    .addCriteria(where(EVENT_TYPE_FIELD).is(MERGE_CANDIDATES_EVENT_TYPE.toString()));
+    public static Criteria getMergeCandidatesCriteria(String assemblyAccession) {
+        return where(DBCollection.ID_FIELD_NAME).regex("^RSMC_" + assemblyAccession + "_.*");
     }
 
     @Bean(RS_SPLIT_CANDIDATES_READER)
     public ItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader(MongoTemplate mongoTemplate,
                                                                                InputParameters parameters) {
-        MongoItemReader<SubmittedVariantOperationEntity> mongoItemReader = new MongoItemReader<>();
+        MongoDbCursorItemReader<SubmittedVariantOperationEntity> mongoItemReader = new MongoDbCursorItemReader<>();
         mongoItemReader.setTemplate(mongoTemplate);
         mongoItemReader.setTargetType(SubmittedVariantOperationEntity.class);
         mongoItemReader.setCollection(SUBMITTED_VARIANT_OPERATIONS_COLLECTION);
 
         //See https://docs.google.com/spreadsheets/d/1KQLVCUy-vqXKgkCDt2czX6kuMfsjfCc9uBsS19MZ6dY/#rangeid=1213746442
-        Query query = getSplitCandidatesQuery(parameters.getAssemblyAccession());
+        Meta meta = new Meta();
+        meta.addFlag(Meta.CursorOption.NO_TIMEOUT);
+        Query query = query(getSplitCandidatesCriteria(parameters.getAssemblyAccession()));
+        query.setMeta(meta);
         mongoItemReader.setQuery(query);
-        mongoItemReader.setPageSize(parameters.getChunkSize());
-        mongoItemReader.setSort(Collections.singletonMap(SORT_FIELD, Sort.Direction.ASC));
         return mongoItemReader;
     }
 
     @Bean(RS_MERGE_CANDIDATES_READER)
     public ItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader(MongoTemplate mongoTemplate,
                                                                                InputParameters parameters) {
-        MongoItemReader<SubmittedVariantOperationEntity> mongoItemReader = new MongoItemReader<>();
+        MongoDbCursorItemReader<SubmittedVariantOperationEntity> mongoItemReader = new MongoDbCursorItemReader<>();
         mongoItemReader.setTemplate(mongoTemplate);
         mongoItemReader.setTargetType(SubmittedVariantOperationEntity.class);
         mongoItemReader.setCollection(SUBMITTED_VARIANT_OPERATIONS_COLLECTION);
 
         //See https://docs.google.com/spreadsheets/d/1KQLVCUy-vqXKgkCDt2czX6kuMfsjfCc9uBsS19MZ6dY/#rangeid=1213746442
-        Query query = getMergeCandidatesQuery(parameters.getAssemblyAccession());
+        Meta meta = new Meta();
+        meta.addFlag(Meta.CursorOption.NO_TIMEOUT);
+        Query query = query(getMergeCandidatesCriteria(parameters.getAssemblyAccession()));
+        query.setMeta(meta);
         mongoItemReader.setQuery(query);
-        mongoItemReader.setPageSize(parameters.getChunkSize());
-        mongoItemReader.setSort(Collections.singletonMap(SORT_FIELD, Sort.Direction.ASC));
         return mongoItemReader;
     }
 
@@ -114,7 +114,7 @@ public class RSMergeAndSplitCandidatesReaderConfiguration {
         @Override
         public void write(List items) throws Exception {
             Query queryToRemoveMergeAndSplitCandidates =
-                    Query.query(where(ASSEMBLY_FIELD).is(parameters.getAssemblyAccession()))
+                    query(where(ASSEMBLY_FIELD).is(parameters.getAssemblyAccession()))
                          .addCriteria(where(EVENT_TYPE_FIELD).in(
                                  Arrays.asList(MERGE_CANDIDATES_EVENT_TYPE.toString(),
                                                SPLIT_CANDIDATES_EVENT_TYPE.toString()))

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/RSMergeAndSplitCandidatesReaderConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/io/RSMergeAndSplitCandidatesReaderConfiguration.java
@@ -16,7 +16,6 @@
 package uk.ac.ebi.eva.accession.clustering.configuration.batch.io;
 
 import com.mongodb.DBCollection;
-import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -65,8 +64,9 @@ public class RSMergeAndSplitCandidatesReaderConfiguration {
     }
 
     @Bean(RS_SPLIT_CANDIDATES_READER)
-    public ItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader(MongoTemplate mongoTemplate,
-                                                                               InputParameters parameters) {
+    public MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader(MongoTemplate mongoTemplate,
+                                                                                            InputParameters parameters)
+    {
         MongoDbCursorItemReader<SubmittedVariantOperationEntity> mongoItemReader = new MongoDbCursorItemReader<>();
         mongoItemReader.setTemplate(mongoTemplate);
         mongoItemReader.setTargetType(SubmittedVariantOperationEntity.class);
@@ -82,8 +82,9 @@ public class RSMergeAndSplitCandidatesReaderConfiguration {
     }
 
     @Bean(RS_MERGE_CANDIDATES_READER)
-    public ItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader(MongoTemplate mongoTemplate,
-                                                                               InputParameters parameters) {
+    public MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader(MongoTemplate mongoTemplate,
+                                                                                            InputParameters parameters)
+    {
         MongoDbCursorItemReader<SubmittedVariantOperationEntity> mongoItemReader = new MongoDbCursorItemReader<>();
         mongoItemReader.setTemplate(mongoTemplate);
         mongoItemReader.setTargetType(SubmittedVariantOperationEntity.class);

--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ProcessRemappedVariantsWithRSJobConfiguration.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ProcessRemappedVariantsWithRSJobConfiguration.java
@@ -26,6 +26,8 @@ import org.springframework.context.annotation.Configuration;
 
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_CLUSTERED_VARIANTS_FROM_MONGO_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROCESS_REMAPPED_VARIANTS_WITH_RS_JOB;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROCESS_RS_MERGE_CANDIDATES_STEP;
+import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROCESS_RS_SPLIT_CANDIDATES_STEP;
 
 @Configuration
 @EnableBatchProcessing
@@ -40,5 +42,17 @@ public class ProcessRemappedVariantsWithRSJobConfiguration {
                                 .incrementer(new RunIdIncrementer())
                                 .start(clusteringClusteredVariantsFromMongoStep)
                                 .build();
+    }
+
+    @Bean("MERGE_SPLIT_RESOLUTION_JOB")
+    public Job processMergeSplitResolutionJob(
+            @Qualifier(PROCESS_RS_MERGE_CANDIDATES_STEP) Step processRSMergeCandidatesStep,
+            @Qualifier(PROCESS_RS_SPLIT_CANDIDATES_STEP) Step processRSSplitCandidatesStep,
+            JobBuilderFactory jobBuilderFactory) {
+        return jobBuilderFactory.get("MERGE_SPLIT_RESOLUTION_JOB")
+                .incrementer(new RunIdIncrementer())
+                .start(processRSMergeCandidatesStep)
+                .next(processRSSplitCandidatesStep)
+                .build();
     }
 }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeAndSplitCandidatesReaderTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeAndSplitCandidatesReaderTest.java
@@ -38,7 +38,6 @@ import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplit
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.MongoTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
-import uk.ac.ebi.eva.accession.core.EVAObjectModelUtils;
 import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantInactiveEntity;
@@ -104,7 +103,7 @@ public class RSMergeAndSplitCandidatesReaderTest {
         splitOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss1.getAccession(), null, "Hash mismatch with rs1",
                              Arrays.asList(ss1, ss2, ss3));
-        splitOperation1.setId("RSSC_" + ASSEMBLY + "_1");
+        splitOperation1.setId(ClusteringWriter.getSplitCandidateId(splitOperation1));
 
         SubmittedVariantInactiveEntity ss4 = new SubmittedVariantInactiveEntity(
                 createSSWithLocus(4L, 2L, 103L, "C", "T"));
@@ -119,7 +118,7 @@ public class RSMergeAndSplitCandidatesReaderTest {
                              ss4.getAccession(),
                              null, "Hash mismatch with rs2",
                              Arrays.asList(ss4, ss5, ss6));
-        splitOperation2.setId("RSSC_" + ASSEMBLY + "_2");
+        splitOperation2.setId(ClusteringWriter.getSplitCandidateId(splitOperation2));
 
         mongoTemplate.insert(splitOperation1, SUBMITTED_VARIANT_OPERATION_COLLECTION);
         mongoTemplate.insert(splitOperation2, SUBMITTED_VARIANT_OPERATION_COLLECTION);
@@ -139,7 +138,7 @@ public class RSMergeAndSplitCandidatesReaderTest {
         mergeOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                              ss1.getAccession(), null, "Different RS with matching loci",
                              Arrays.asList(ss1, ss2, ss3));
-        mergeOperation1.setId("RSMC_" + ASSEMBLY + "_" + EVAObjectModelUtils.getClusteredVariantHash(ss1));
+        mergeOperation1.setId(ClusteringWriter.getMergeCandidateId(mergeOperation1));
 
         SubmittedVariantInactiveEntity ss4 = new SubmittedVariantInactiveEntity(
                 createSSWithLocus(4L, 4L, 103L, "A", "C"));
@@ -154,7 +153,7 @@ public class RSMergeAndSplitCandidatesReaderTest {
                              ss4.getAccession(),
                              null, "Different RS with matching loci",
                              Arrays.asList(ss4, ss5, ss6));
-        mergeOperation2.setId("RSMC_" + ASSEMBLY + "_" + EVAObjectModelUtils.getClusteredVariantHash(ss4));
+        mergeOperation2.setId(ClusteringWriter.getMergeCandidateId(mergeOperation2));
 
         mongoTemplate.insert(mergeOperation1, SUBMITTED_VARIANT_OPERATION_COLLECTION);
         mongoTemplate.insert(mergeOperation2, SUBMITTED_VARIANT_OPERATION_COLLECTION);

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeAndSplitCandidatesReaderTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeAndSplitCandidatesReaderTest.java
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
@@ -38,6 +38,8 @@ import uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplit
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.MongoTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
+import uk.ac.ebi.eva.accession.core.EVAObjectModelUtils;
+import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantInactiveEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
@@ -68,11 +70,11 @@ public class RSMergeAndSplitCandidatesReaderTest {
 
     @Autowired
     @Qualifier(RS_SPLIT_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
 
     @Autowired
     @Qualifier(RS_MERGE_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
 
     //Required by nosql-unit
     @Autowired
@@ -81,8 +83,7 @@ public class RSMergeAndSplitCandidatesReaderTest {
     @Rule
     public MongoDbRule mongoDbRule = new FixSpringMongoDbRule(
             MongoDbConfigurationBuilder.mongoDb().databaseName(TEST_DB).build());
-
-    private SubmittedVariantEntity createSSWithLocus(Long ssAccession, Long rsAccession, Long start, String reference,
+        private SubmittedVariantEntity createSSWithLocus(Long ssAccession, Long rsAccession, Long start, String reference,
                                                      String alternate) {
         return new SubmittedVariantEntity(ssAccession, "hash" + ssAccession, ASSEMBLY, 60711,
                                           "PRJ1", "chr1", start, reference, alternate, rsAccession, false, false, false,
@@ -103,6 +104,7 @@ public class RSMergeAndSplitCandidatesReaderTest {
         splitOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss1.getAccession(), null, "Hash mismatch with rs1",
                              Arrays.asList(ss1, ss2, ss3));
+        splitOperation1.setId("RSSC_" + ASSEMBLY + "_1");
 
         SubmittedVariantInactiveEntity ss4 = new SubmittedVariantInactiveEntity(
                 createSSWithLocus(4L, 2L, 103L, "C", "T"));
@@ -115,8 +117,9 @@ public class RSMergeAndSplitCandidatesReaderTest {
         // anything. We are updating the submitted variant, changing its rs field
         splitOperation2.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss4.getAccession(),
-                             null, "Hash mismatch with rs1",
+                             null, "Hash mismatch with rs2",
                              Arrays.asList(ss4, ss5, ss6));
+        splitOperation2.setId("RSSC_" + ASSEMBLY + "_2");
 
         mongoTemplate.insert(splitOperation1, SUBMITTED_VARIANT_OPERATION_COLLECTION);
         mongoTemplate.insert(splitOperation2, SUBMITTED_VARIANT_OPERATION_COLLECTION);
@@ -136,6 +139,7 @@ public class RSMergeAndSplitCandidatesReaderTest {
         mergeOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                              ss1.getAccession(), null, "Different RS with matching loci",
                              Arrays.asList(ss1, ss2, ss3));
+        mergeOperation1.setId("RSMC_" + ASSEMBLY + "_" + EVAObjectModelUtils.getClusteredVariantHash(ss1));
 
         SubmittedVariantInactiveEntity ss4 = new SubmittedVariantInactiveEntity(
                 createSSWithLocus(4L, 4L, 103L, "A", "C"));
@@ -150,6 +154,7 @@ public class RSMergeAndSplitCandidatesReaderTest {
                              ss4.getAccession(),
                              null, "Different RS with matching loci",
                              Arrays.asList(ss4, ss5, ss6));
+        mergeOperation2.setId("RSMC_" + ASSEMBLY + "_" + EVAObjectModelUtils.getClusteredVariantHash(ss4));
 
         mongoTemplate.insert(mergeOperation1, SUBMITTED_VARIANT_OPERATION_COLLECTION);
         mongoTemplate.insert(mergeOperation2, SUBMITTED_VARIANT_OPERATION_COLLECTION);
@@ -174,6 +179,8 @@ public class RSMergeAndSplitCandidatesReaderTest {
         createSplitCandidateEntries();
         List<SubmittedVariantOperationEntity> submittedVariantOperationEntities = new ArrayList<>();
         SubmittedVariantOperationEntity submittedVariantOperationEntity;
+        ExecutionContext executionContext = new ExecutionContext();
+        this.rsSplitCandidatesReader.open(executionContext);
         while ((submittedVariantOperationEntity = rsSplitCandidatesReader.read()) != null) {
             submittedVariantOperationEntities.add(submittedVariantOperationEntity);
         }
@@ -186,6 +193,8 @@ public class RSMergeAndSplitCandidatesReaderTest {
         createMergeCandidateEntries();
         List<SubmittedVariantOperationEntity> submittedVariantOperationEntities = new ArrayList<>();
         SubmittedVariantOperationEntity submittedVariantOperationEntity;
+        ExecutionContext executionContext = new ExecutionContext();
+        this.rsMergeCandidatesReader.open(executionContext);
         while ((submittedVariantOperationEntity = rsMergeCandidatesReader.read()) != null) {
             submittedVariantOperationEntities.add(submittedVariantOperationEntity);
         }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriterTest.java
@@ -49,15 +49,12 @@ import uk.ac.ebi.eva.accession.clustering.test.DatabaseState;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.MongoTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
-import uk.ac.ebi.eva.accession.core.EVAObjectModelUtils;
 import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.model.ClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantEntity;
 import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantInactiveEntity;
 import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantOperationEntity;
-import uk.ac.ebi.eva.accession.core.model.eva.ClusteredVariantEntity;
-import uk.ac.ebi.eva.accession.core.model.eva.ClusteredVariantInactiveEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantInactiveEntity;
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity;
@@ -192,7 +189,7 @@ public class RSMergeWriterTest {
         mergeOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                              ss1.getAccession(), null, "Different RS with matching loci",
                              Arrays.asList(ssInactive1, ssInactive4));
-        mergeOperation1.setId("RSMC_" + ASSEMBLY + "_" + EVAObjectModelUtils.getClusteredVariantHash(ss1));
+        mergeOperation1.setId(ClusteringWriter.getMergeCandidateId(mergeOperation1));
 
         //ss2 will be inserted to dbsnpSubmittedVariantEntity and ss5 to submittedVariantEntity collections respectively
         ss2 = createSS(2L, 2L, 103L, "A", "C");
@@ -205,7 +202,7 @@ public class RSMergeWriterTest {
                              ss2.getAccession(),
                              null, "Different RS with matching loci",
                              Arrays.asList(ssInactive2, ssInactive5));
-        mergeOperation2.setId("RSMC_" + ASSEMBLY + "_" + EVAObjectModelUtils.getClusteredVariantHash(ss2));
+        mergeOperation2.setId(ClusteringWriter.getMergeCandidateId(mergeOperation2));
 
         //Candidates for split are entries with same RS but different locus
         ss6 = createSS(6L, 4L, 104L, "G", "A");
@@ -223,15 +220,15 @@ public class RSMergeWriterTest {
         splitOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss2.getAccession(), "Hash mismatch with " + ss2.getClusteredVariantAccession(),
                              Arrays.asList(ssInactive2, ssInactive8));
-        splitOperation1.setId("RSSC_" + ASSEMBLY + "_" + ss2.getClusteredVariantAccession());
+        splitOperation1.setId(ClusteringWriter.getSplitCandidateId(splitOperation1));
         splitOperation2.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss4.getAccession(), "Hash mismatch with " + ss4.getClusteredVariantAccession(),
                              Arrays.asList(ssInactive4, ssInactive6, ssInactive7));
-        splitOperation2.setId("RSSC_" + ASSEMBLY + "_" + ss4.getClusteredVariantAccession());
+        splitOperation2.setId(ClusteringWriter.getSplitCandidateId(splitOperation2));
         splitOperation3.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss5.getAccession(), "Hash mismatch with " + ss5.getClusteredVariantAccession(),
                              Arrays.asList(ssInactive5, ssInactive9));
-        splitOperation3.setId("RSSC_" + ASSEMBLY + "_" + ss5.getClusteredVariantAccession());
+        splitOperation3.setId(ClusteringWriter.getSplitCandidateId(splitOperation3));
 
         List<SubmittedVariantEntity> ssToInsertToDbsnpSVE = Arrays.asList(ss1, ss2);
         List<SubmittedVariantEntity> ssToInsertToSVE = Arrays.asList(ss4, ss5, ss6, ss7, ss8, ss9);
@@ -457,19 +454,18 @@ public class RSMergeWriterTest {
         mergeOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                              ss1.getAccession(), null, "Different RS with matching loci",
                              Stream.of(ss1, ss2).map(SubmittedVariantInactiveEntity::new).collect(Collectors.toList()));
-        mergeOperation1.setId("RSMC_" + ss1.getReferenceSequenceAccession() + "_" +
-                                      EVAObjectModelUtils.getClusteredVariantHash(ss1));
+        mergeOperation1.setId(ClusteringWriter.getMergeCandidateId(mergeOperation1));
         SubmittedVariantOperationEntity mergeOperation2 = new SubmittedVariantOperationEntity();
         mergeOperation2.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                              ss3.getAccession(), null, "Different RS with matching loci",
                              Stream.of(ss3, ss4).map(SubmittedVariantInactiveEntity::new).collect(Collectors.toList()));
-        mergeOperation2.setId("RSMC_" + ss3.getReferenceSequenceAccession() + "_" +
-                                      EVAObjectModelUtils.getClusteredVariantHash(ss3));
+        mergeOperation2.setId(ClusteringWriter.getMergeCandidateId(mergeOperation2));
+
         SubmittedVariantOperationEntity splitOperation1 = new SubmittedVariantOperationEntity();
         splitOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss2.getAccession(), null, "Hash mismatch with " + ss2.getClusteredVariantAccession(),
                              Stream.of(ss2, ss3).map(SubmittedVariantInactiveEntity::new).collect(Collectors.toList()));
-        splitOperation1.setId("RSSC_" + ss2.getReferenceSequenceAccession() + "_" + ss2.getClusteredVariantAccession());
+        splitOperation1.setId(ClusteringWriter.getSplitCandidateId(splitOperation1));
 
         this.mongoTemplate.insert(Arrays.asList(mergeOperation1, mergeOperation2, splitOperation1),
                                   SUBMITTED_VARIANT_OPERATION_COLLECTION);

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriterTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -49,6 +49,8 @@ import uk.ac.ebi.eva.accession.clustering.test.DatabaseState;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.MongoTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
+import uk.ac.ebi.eva.accession.core.EVAObjectModelUtils;
+import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.model.ClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantEntity;
@@ -108,11 +110,11 @@ public class RSMergeWriterTest {
 
     @Autowired
     @Qualifier(RS_MERGE_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
 
     @Autowired
     @Qualifier(RS_SPLIT_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
 
     @Autowired
     @Qualifier(RS_MERGE_WRITER)
@@ -190,6 +192,7 @@ public class RSMergeWriterTest {
         mergeOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                              ss1.getAccession(), null, "Different RS with matching loci",
                              Arrays.asList(ssInactive1, ssInactive4));
+        mergeOperation1.setId("RSMC_" + ASSEMBLY + "_" + EVAObjectModelUtils.getClusteredVariantHash(ss1));
 
         //ss2 will be inserted to dbsnpSubmittedVariantEntity and ss5 to submittedVariantEntity collections respectively
         ss2 = createSS(2L, 2L, 103L, "A", "C");
@@ -202,6 +205,7 @@ public class RSMergeWriterTest {
                              ss2.getAccession(),
                              null, "Different RS with matching loci",
                              Arrays.asList(ssInactive2, ssInactive5));
+        mergeOperation2.setId("RSMC_" + ASSEMBLY + "_" + EVAObjectModelUtils.getClusteredVariantHash(ss2));
 
         //Candidates for split are entries with same RS but different locus
         ss6 = createSS(6L, 4L, 104L, "G", "A");
@@ -219,12 +223,15 @@ public class RSMergeWriterTest {
         splitOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss2.getAccession(), "Hash mismatch with " + ss2.getClusteredVariantAccession(),
                              Arrays.asList(ssInactive2, ssInactive8));
+        splitOperation1.setId("RSSC_" + ASSEMBLY + "_" + ss2.getClusteredVariantAccession());
         splitOperation2.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss4.getAccession(), "Hash mismatch with " + ss4.getClusteredVariantAccession(),
                              Arrays.asList(ssInactive4, ssInactive6, ssInactive7));
+        splitOperation2.setId("RSSC_" + ASSEMBLY + "_" + ss4.getClusteredVariantAccession());
         splitOperation3.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss5.getAccession(), "Hash mismatch with " + ss5.getClusteredVariantAccession(),
                              Arrays.asList(ssInactive5, ssInactive9));
+        splitOperation3.setId("RSSC_" + ASSEMBLY + "_" + ss5.getClusteredVariantAccession());
 
         List<SubmittedVariantEntity> ssToInsertToDbsnpSVE = Arrays.asList(ss1, ss2);
         List<SubmittedVariantEntity> ssToInsertToSVE = Arrays.asList(ss4, ss5, ss6, ss7, ss8, ss9);
@@ -284,6 +291,7 @@ public class RSMergeWriterTest {
         createMergeAndSplitCandidateEntries();
         List<SubmittedVariantOperationEntity> submittedVariantOperationEntities = new ArrayList<>();
         SubmittedVariantOperationEntity submittedVariantOperationEntity;
+        rsMergeCandidatesReader.open(new ExecutionContext());
         while ((submittedVariantOperationEntity = rsMergeCandidatesReader.read()) != null) {
             submittedVariantOperationEntities.add(submittedVariantOperationEntity);
         }
@@ -345,6 +353,7 @@ public class RSMergeWriterTest {
         // and hence generate a split candidate event
         List<SubmittedVariantOperationEntity> splitEvents = new ArrayList<>();
         SubmittedVariantOperationEntity tempObj;
+        rsSplitCandidatesReader.open(new ExecutionContext());
         while ((tempObj = rsSplitCandidatesReader.read()) != null) {
                 splitEvents.add(tempObj);
         }
@@ -399,6 +408,7 @@ public class RSMergeWriterTest {
         createSimilarEntriesInAnotherAssembly();
         List<SubmittedVariantOperationEntity> submittedVariantOperationEntities = new ArrayList<>();
         SubmittedVariantOperationEntity temp;
+        rsMergeCandidatesReader.open(new ExecutionContext());
         while ((temp = rsMergeCandidatesReader.read()) != null) {
             submittedVariantOperationEntities.add(temp);
         }
@@ -447,14 +457,19 @@ public class RSMergeWriterTest {
         mergeOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                              ss1.getAccession(), null, "Different RS with matching loci",
                              Stream.of(ss1, ss2).map(SubmittedVariantInactiveEntity::new).collect(Collectors.toList()));
+        mergeOperation1.setId("RSMC_" + ss1.getReferenceSequenceAccession() + "_" +
+                                      EVAObjectModelUtils.getClusteredVariantHash(ss1));
         SubmittedVariantOperationEntity mergeOperation2 = new SubmittedVariantOperationEntity();
         mergeOperation2.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                              ss3.getAccession(), null, "Different RS with matching loci",
                              Stream.of(ss3, ss4).map(SubmittedVariantInactiveEntity::new).collect(Collectors.toList()));
+        mergeOperation2.setId("RSMC_" + ss3.getReferenceSequenceAccession() + "_" +
+                                      EVAObjectModelUtils.getClusteredVariantHash(ss3));
         SubmittedVariantOperationEntity splitOperation1 = new SubmittedVariantOperationEntity();
         splitOperation1.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                              ss2.getAccession(), null, "Hash mismatch with " + ss2.getClusteredVariantAccession(),
                              Stream.of(ss2, ss3).map(SubmittedVariantInactiveEntity::new).collect(Collectors.toList()));
+        splitOperation1.setId("RSSC_" + ss2.getReferenceSequenceAccession() + "_" + ss2.getClusteredVariantAccession());
 
         this.mongoTemplate.insert(Arrays.asList(mergeOperation1, mergeOperation2, splitOperation1),
                                   SUBMITTED_VARIANT_OPERATION_COLLECTION);
@@ -496,6 +511,7 @@ public class RSMergeWriterTest {
         createMultiLevelMergeScenario();
         List<SubmittedVariantOperationEntity> submittedVariantOperationEntities = new ArrayList<>();
         SubmittedVariantOperationEntity temp;
+        rsMergeCandidatesReader.open(new ExecutionContext());
         while ((temp = rsMergeCandidatesReader.read()) != null) {
             submittedVariantOperationEntities.add(temp);
         }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/IssueAccessionClusteringWriterTest.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -46,6 +46,7 @@ import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
+import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.ClusteredVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.model.ClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
@@ -133,11 +134,11 @@ public class IssueAccessionClusteringWriterTest {
 
     @Autowired
     @Qualifier(RS_MERGE_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
 
     @Autowired
     @Qualifier(RS_SPLIT_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
 
     @Autowired
     @Qualifier(RS_MERGE_WRITER)
@@ -396,9 +397,11 @@ public class IssueAccessionClusteringWriterTest {
         List<SubmittedVariantOperationEntity> mergeCandidates = new ArrayList<>();
         List<SubmittedVariantOperationEntity> splitCandidates = new ArrayList<>();
         SubmittedVariantOperationEntity tempSVO;
+        rsMergeCandidatesReader.open(new ExecutionContext());
         while((tempSVO = rsMergeCandidatesReader.read()) != null) {
             mergeCandidates.add(tempSVO);
         }
+        rsSplitCandidatesReader.open(new ExecutionContext());
         while((tempSVO = rsSplitCandidatesReader.read()) != null) {
             splitCandidates.add(tempSVO);
         }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/MergeAccessionClusteringWriterTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -44,6 +44,7 @@ import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringMongoReader;
 import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
+import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.ClusteredVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.SubmittedVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.model.ClusteredVariant;
@@ -144,11 +145,11 @@ public class MergeAccessionClusteringWriterTest {
 
     @Autowired
     @Qualifier(RS_MERGE_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
 
     @Autowired
     @Qualifier(RS_SPLIT_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
 
     @Autowired
     @Qualifier(RS_MERGE_WRITER)
@@ -718,9 +719,11 @@ public class MergeAccessionClusteringWriterTest {
         List<SubmittedVariantOperationEntity> mergeCandidates = new ArrayList<>();
         List<SubmittedVariantOperationEntity> splitCandidates = new ArrayList<>();
         SubmittedVariantOperationEntity tempSVO;
+        rsMergeCandidatesReader.open(new ExecutionContext());
         while((tempSVO = rsMergeCandidatesReader.read()) != null) {
             mergeCandidates.add(tempSVO);
         }
+        rsSplitCandidatesReader.open(new ExecutionContext());
         while((tempSVO = rsSplitCandidatesReader.read()) != null) {
             splitCandidates.add(tempSVO);
         }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/RemappedVariantsClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/RemappedVariantsClusteringWriterTest.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -41,6 +41,7 @@ import uk.ac.ebi.eva.accession.clustering.batch.io.ClusteringWriter;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
+import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.ClusteredVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.model.ClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
@@ -126,11 +127,11 @@ public class RemappedVariantsClusteringWriterTest {
 
     @Autowired
     @Qualifier(RS_MERGE_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
 
     @Autowired
     @Qualifier(RS_SPLIT_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
 
     @Autowired
     @Qualifier(RS_MERGE_WRITER)
@@ -593,9 +594,11 @@ public class RemappedVariantsClusteringWriterTest {
         List<SubmittedVariantOperationEntity> mergeCandidates = new ArrayList<>();
         List<SubmittedVariantOperationEntity> splitCandidates = new ArrayList<>();
         SubmittedVariantOperationEntity tempSVO;
+        rsMergeCandidatesReader.open(new ExecutionContext());
         while((tempSVO = rsMergeCandidatesReader.read()) != null) {
             mergeCandidates.add(tempSVO);
         }
+        rsSplitCandidatesReader.open(new ExecutionContext());
         while((tempSVO = rsSplitCandidatesReader.read()) != null) {
             splitCandidates.add(tempSVO);
         }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/batch/io/clustering_writer/ReuseAccessionClusteringWriterTest.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -43,6 +43,7 @@ import uk.ac.ebi.eva.accession.clustering.metric.ClusteringMetric;
 import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters;
 import uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.accession.clustering.test.rule.FixSpringMongoDbRule;
+import uk.ac.ebi.eva.accession.core.batch.io.MongoDbCursorItemReader;
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.ClusteredVariantAccessioningConfiguration;
 import uk.ac.ebi.eva.accession.core.model.ClusteredVariant;
 import uk.ac.ebi.eva.accession.core.model.IClusteredVariant;
@@ -126,11 +127,11 @@ public class ReuseAccessionClusteringWriterTest {
 
     @Autowired
     @Qualifier(RS_MERGE_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsMergeCandidatesReader;
 
     @Autowired
     @Qualifier(RS_SPLIT_CANDIDATES_READER)
-    private ItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
+    private MongoDbCursorItemReader<SubmittedVariantOperationEntity> rsSplitCandidatesReader;
 
     @Autowired
     @Qualifier(RS_MERGE_WRITER)
@@ -299,9 +300,11 @@ public class ReuseAccessionClusteringWriterTest {
         List<SubmittedVariantOperationEntity> mergeCandidates = new ArrayList<>();
         List<SubmittedVariantOperationEntity> splitCandidates = new ArrayList<>();
         SubmittedVariantOperationEntity tempSVO;
+        rsMergeCandidatesReader.open(new ExecutionContext());
         while((tempSVO = rsMergeCandidatesReader.read()) != null) {
             mergeCandidates.add(tempSVO);
         }
+        rsSplitCandidatesReader.open(new ExecutionContext());
         while((tempSVO = rsSplitCandidatesReader.read()) != null) {
             splitCandidates.add(tempSVO);
         }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringVariantJobConfigurationTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringVariantJobConfigurationTest.java
@@ -72,7 +72,6 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTER
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTERING_NON_CLUSTERED_VARIANTS_FROM_MONGO_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROCESS_RS_MERGE_CANDIDATES_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROCESS_RS_SPLIT_CANDIDATES_STEP;
-import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.STUDY_CLUSTERING_JOB;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.STUDY_CLUSTERING_STEP;
 import static uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration.JOB_LAUNCHER_FROM_MONGO;
 import static uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration.JOB_LAUNCHER_FROM_VCF;
@@ -221,11 +220,12 @@ public class ClusteringVariantJobConfigurationTest {
         SubmittedVariantInactiveEntity ss2 = new SubmittedVariantInactiveEntity(
                 createSSWithLocus(2L, 2L, 100L, "C", "A"));
         for (int i = 0; i < numSplitCandidateOperations; i++) {
-            SubmittedVariantOperationEntity splitOperation = new SubmittedVariantOperationEntity();
-            splitOperation.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
+            SubmittedVariantOperationEntity mergeOperation = new SubmittedVariantOperationEntity();
+            mergeOperation.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                                 ss1.getAccession(), null, "Mock merge candidate",
                                 Arrays.asList(ss1, ss2));
-            mongoTemplate.insert(splitOperation,
+            mergeOperation.setId("RSMC_" + ss1.getReferenceSequenceAccession() + "_" + i);
+            mongoTemplate.insert(mergeOperation,
                                  mongoTemplate.getCollectionName(SubmittedVariantOperationEntity.class));
         }
     }
@@ -241,6 +241,7 @@ public class ClusteringVariantJobConfigurationTest {
             splitOperation.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                                 ss3.getAccession(), null, "Mock split candidate",
                                 Arrays.asList(ss3, ss4));
+            splitOperation.setId("RSSC_" + ss3.getReferenceSequenceAccession() + "_" + i);
             mongoTemplate.insert(splitOperation,
                                  mongoTemplate.getCollectionName(SubmittedVariantOperationEntity.class));
         }

--- a/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringVariantJobConfigurationTest.java
+++ b/eva-accession-clustering/src/test/java/uk/ac/ebi/eva/accession/clustering/configuration/batch/jobs/ClusteringVariantJobConfigurationTest.java
@@ -73,6 +73,8 @@ import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.CLUSTER
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROCESS_RS_MERGE_CANDIDATES_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.PROCESS_RS_SPLIT_CANDIDATES_STEP;
 import static uk.ac.ebi.eva.accession.clustering.configuration.BeanNames.STUDY_CLUSTERING_STEP;
+import static uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATE_ID_PREFIX;
+import static uk.ac.ebi.eva.accession.clustering.configuration.batch.io.RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATE_ID_PREFIX;
 import static uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration.JOB_LAUNCHER_FROM_MONGO;
 import static uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration.JOB_LAUNCHER_FROM_VCF;
 import static uk.ac.ebi.eva.accession.clustering.test.configuration.BatchTestConfiguration.JOB_LAUNCHER_STUDY_FROM_MONGO;
@@ -224,7 +226,7 @@ public class ClusteringVariantJobConfigurationTest {
             mergeOperation.fill(RSMergeAndSplitCandidatesReaderConfiguration.MERGE_CANDIDATES_EVENT_TYPE,
                                 ss1.getAccession(), null, "Mock merge candidate",
                                 Arrays.asList(ss1, ss2));
-            mergeOperation.setId("RSMC_" + ss1.getReferenceSequenceAccession() + "_" + i);
+            mergeOperation.setId(MERGE_CANDIDATE_ID_PREFIX + "_" + ss1.getReferenceSequenceAccession() + "_" + i);
             mongoTemplate.insert(mergeOperation,
                                  mongoTemplate.getCollectionName(SubmittedVariantOperationEntity.class));
         }
@@ -241,7 +243,7 @@ public class ClusteringVariantJobConfigurationTest {
             splitOperation.fill(RSMergeAndSplitCandidatesReaderConfiguration.SPLIT_CANDIDATES_EVENT_TYPE,
                                 ss3.getAccession(), null, "Mock split candidate",
                                 Arrays.asList(ss3, ss4));
-            splitOperation.setId("RSSC_" + ss3.getReferenceSequenceAccession() + "_" + i);
+            splitOperation.setId(SPLIT_CANDIDATE_ID_PREFIX + "_" + ss3.getReferenceSequenceAccession() + "_" + i);
             mongoTemplate.insert(splitOperation,
                                  mongoTemplate.getCollectionName(SubmittedVariantOperationEntity.class));
         }


### PR DESCRIPTION
Two major optimizations based on profiling:

* Use a [regex based ID search](https://github.com/EBIvariation/eva-accession/pull/393/files#diff-b6244e9907d2b0296d3a02a3fc6481f3fb8656821add15fea30f85a243ce3c59R608) to search for merge/split candidates
* Update [SVEs with the appropriate RS using ID lookups](https://github.com/EBIvariation/eva-accession/pull/393/files#diff-5dc442278e212785856f1b68bafbfa4a1e27c1c105b81adeda1ec9a84fa6c8deR459) instead of a query