### PR TITLE
EVA-3308 - Set the output file to contain the input taxonomy accession

### DIFF
--- a/eva-remapping-get-source/src/main/java/uk/ac/ebi/eva/remapping/source/configuration/batch/io/VariantContextWriterConfiguration.java
+++ b/eva-remapping-get-source/src/main/java/uk/ac/ebi/eva/remapping/source/configuration/batch/io/VariantContextWriterConfiguration.java
@@ -32,14 +32,16 @@ public class VariantContextWriterConfiguration {
     @Bean(BeanNames.EVA_SUBMITTED_VARIANT_WRITER)
     public VariantContextWriter evaVariantContextWriter(InputParameters parameters) {
         Path reportPath = ReportPathResolver.getEvaReportPath(parameters.getOutputFolder(),
-                                                              parameters.getAssemblyAccession());
+                                                              parameters.getAssemblyAccession(),
+                                                              parameters.getTaxonomy());
         return new VariantContextWriter(reportPath, parameters.getAssemblyAccession());
     }
 
     @Bean(BeanNames.DBSNP_SUBMITTED_VARIANT_WRITER)
     public VariantContextWriter dbsnpVariantContextWriter(InputParameters parameters) {
         Path reportPath = ReportPathResolver.getDbsnpReportPath(parameters.getOutputFolder(),
-                                                                parameters.getAssemblyAccession());
+                                                                parameters.getAssemblyAccession(),
+                                                                parameters.getTaxonomy());
         return new VariantContextWriter(reportPath, parameters.getAssemblyAccession());
     }
 }

--- a/eva-remapping-get-source/src/main/java/uk/ac/ebi/eva/remapping/source/parameters/ReportPathResolver.java
+++ b/eva-remapping-get-source/src/main/java/uk/ac/ebi/eva/remapping/source/parameters/ReportPathResolver.java
@@ -24,13 +24,13 @@ import java.nio.file.Paths;
  */
 public class ReportPathResolver {
 
-    public static Path getEvaReportPath(String outputFolder, String referenceAssembly) {
+    public static Path getEvaReportPath(String outputFolder, String referenceAssembly, int taxonomy) {
         final String FILE_SUFFIX = "_eva.vcf";
-        return Paths.get(outputFolder).resolve(referenceAssembly + FILE_SUFFIX);
+        return Paths.get(outputFolder).resolve(referenceAssembly + '_' + taxonomy + FILE_SUFFIX);
     }
 
-    public static Path getDbsnpReportPath(String outputFolder, String referenceAssembly) {
+    public static Path getDbsnpReportPath(String outputFolder, String referenceAssembly, int taxonomy) {
         final String FILE_SUFFIX = "_dbsnp.vcf";
-        return Paths.get(outputFolder).resolve(referenceAssembly + FILE_SUFFIX);
+        return Paths.get(outputFolder).resolve(referenceAssembly + '_' + taxonomy + FILE_SUFFIX);
     }
 }

--- a/eva-remapping-get-source/src/test/java/uk/ac/ebi/eva/remapping/source/batch/io/VariantContextWriterTest.java
+++ b/eva-remapping-get-source/src/test/java/uk/ac/ebi/eva/remapping/source/batch/io/VariantContextWriterTest.java
@@ -74,7 +74,8 @@ public class VariantContextWriterTest {
     }
 
     private File assertWriteVcf(File outputFolder, SubmittedVariantEntity... variants) throws Exception {
-        Path reportPath = ReportPathResolver.getEvaReportPath(outputFolder.getAbsolutePath(), REFERENCE_ASSEMBLY);
+        Path reportPath = ReportPathResolver.getEvaReportPath(outputFolder.getAbsolutePath(), REFERENCE_ASSEMBLY,
+                TAXONOMY_ACCESSION);
         VariantContextWriter writer = new VariantContextWriter(reportPath, REFERENCE_ASSEMBLY);
         writer.open(null);
 

--- a/eva-remapping-get-source/src/test/java/uk/ac/ebi/eva/remapping/source/configuration/batch/jobs/ExportSubmittedVariantsJobConfigurationTest.java
+++ b/eva-remapping-get-source/src/test/java/uk/ac/ebi/eva/remapping/source/configuration/batch/jobs/ExportSubmittedVariantsJobConfigurationTest.java
@@ -90,10 +90,12 @@ public class ExportSubmittedVariantsJobConfigurationTest {
 
     private void deleteOutputFiles() {
         ReportPathResolver.getDbsnpReportPath(inputParameters.getOutputFolder(),
-                                              inputParameters.getAssemblyAccession())
+                                              inputParameters.getAssemblyAccession(),
+                                              inputParameters.getTaxonomy())
                           .toFile().delete();
         ReportPathResolver.getEvaReportPath(inputParameters.getOutputFolder(),
-                                              inputParameters.getAssemblyAccession())
+                                            inputParameters.getAssemblyAccession(),
+                                            inputParameters.getTaxonomy())
                           .toFile().delete();
     }
 
@@ -125,13 +127,15 @@ public class ExportSubmittedVariantsJobConfigurationTest {
 
     private FileInputStream getExportedEva() throws FileNotFoundException {
         return new FileInputStream(ReportPathResolver.getEvaReportPath(inputParameters.getOutputFolder(),
-                                                                       inputParameters.getAssemblyAccession())
+                                                                       inputParameters.getAssemblyAccession(),
+                                                                       inputParameters.getTaxonomy())
                                                      .toFile());
     }
 
     private FileInputStream getExportedDbsnp() throws FileNotFoundException {
         return new FileInputStream(ReportPathResolver.getDbsnpReportPath(inputParameters.getOutputFolder(),
-                                                                         inputParameters.getAssemblyAccession())
+                                                                         inputParameters.getAssemblyAccession(),
+                                                                         inputParameters.getTaxonomy())
                                                      .toFile());
     }
 

--- a/eva-remapping-get-source/src/test/java/uk/ac/ebi/eva/remapping/source/runner/AccessionRemappingJobLauncherCommandLineRunnerTest.java
+++ b/eva-remapping-get-source/src/test/java/uk/ac/ebi/eva/remapping/source/runner/AccessionRemappingJobLauncherCommandLineRunnerTest.java
@@ -74,10 +74,12 @@ public class AccessionRemappingJobLauncherCommandLineRunnerTest {
 
     private void deleteOutputFiles() {
         ReportPathResolver.getDbsnpReportPath(inputParameters.getOutputFolder(),
-                                              inputParameters.getAssemblyAccession())
+                                              inputParameters.getAssemblyAccession(),
+                                              inputParameters.getTaxonomy())
                           .toFile().delete();
         ReportPathResolver.getEvaReportPath(inputParameters.getOutputFolder(),
-                                            inputParameters.getAssemblyAccession())
+                                            inputParameters.getAssemblyAccession(),
+                                            inputParameters.getTaxonomy())
                           .toFile().delete();
     }
 

--- a/eva-remapping-get-source/src/test/java/uk/ac/ebi/eva/remapping/source/runner/AccessionRemappingJobLauncherCommandLineRunnerWithProjectsTest.java
+++ b/eva-remapping-get-source/src/test/java/uk/ac/ebi/eva/remapping/source/runner/AccessionRemappingJobLauncherCommandLineRunnerWithProjectsTest.java
@@ -74,10 +74,12 @@ public class AccessionRemappingJobLauncherCommandLineRunnerWithProjectsTest {
 
     private void deleteOutputFiles() {
         ReportPathResolver.getDbsnpReportPath(inputParameters.getOutputFolder(),
-                                              inputParameters.getAssemblyAccession())
+                                              inputParameters.getAssemblyAccession(),
+                                              inputParameters.getTaxonomy())
                           .toFile().delete();
         ReportPathResolver.getEvaReportPath(inputParameters.getOutputFolder(),
-                                            inputParameters.getAssemblyAccession())
+                                            inputParameters.getAssemblyAccession(),
+                                            inputParameters.getTaxonomy())
                           .toFile().delete();
     }
 


### PR DESCRIPTION
Add taxonomy in the file name of the VCF export to prevent file name collision when multiple taxonomies are exported