### PR TITLE
EVA-3544 - Fix SPLIT candidate accession

### DIFF
--- a/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriter.java
+++ b/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/batch/io/RSMergeWriter.java
@@ -423,13 +423,11 @@ public class RSMergeWriter implements ItemWriter<SubmittedVariantOperationEntity
                                             .collect(Collectors.toSet());
             // Condition for generating split operation: ensure that there is more than one locus sharing the target RS
             if (targetRSDistinctLoci.size() > 1) {
-                // Use a convention of lowest SS for testability
-                Long lowestSS = ssClusteredUnderTargetRS.stream().map(InactiveSubDocument::getAccession)
-                                                        .min(Comparator.naturalOrder()).get();
+                // The new SPLIT candidate is for rs prioritised.accessionToKeep
                 SubmittedVariantOperationEntity newSplitCandidateRecord = new SubmittedVariantOperationEntity();
                 // TODO: Refactor to use common fill method for split candidates generation
                 // to avoid duplicating reason text and call semantics
-                newSplitCandidateRecord.fill(EventType.RS_SPLIT_CANDIDATES, lowestSS,
+                newSplitCandidateRecord.fill(EventType.RS_SPLIT_CANDIDATES, prioritised.accessionToKeep,
                         "Hash mismatch with " + prioritised.accessionToKeep,
                         ssClusteredUnderTargetRS);
                 newSplitCandidateRecord.setId(ClusteringWriter.getSplitCandidateId(newSplitCandidateRecord));


### PR DESCRIPTION
Create new SPLIT candidates during merge that have the same accession as the one during the candidate detection.