### PR TITLE
EVA-3664 Update test to throw exception in transaction when saving new block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.13</junit.version>
         <variation-commons-version>0.8.5</variation-commons-version>
-        <accession-commons-version>0.7.17-SNAPSHOT</accession-commons-version>
+        <accession-commons-version>0.7.17</accession-commons-version>
     </properties>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.13</junit.version>
         <variation-commons-version>0.8.5</variation-commons-version>
-        <accession-commons-version>0.7.16</accession-commons-version>
+        <accession-commons-version>0.7.17-SNAPSHOT</accession-commons-version>
     </properties>
 
     <parent>


### PR DESCRIPTION
I have updated the test to throw an exception while trying to reserve a new block, forcing the code to retry. This is currently failing as it tries to use the same transaction once it succeeds after a few retries.

This test case should start passing once we pull in the changes done in accession commons to create a new transaction for every retry.