### PR TITLE
Security fixes for accession-ws

### DIFF
--- a/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contigalias/ContigAliasService.java
+++ b/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/contigalias/ContigAliasService.java
@@ -18,6 +18,7 @@
 package uk.ac.ebi.eva.accession.core.contigalias;
 
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 import uk.ac.ebi.ampt2d.commons.accession.core.models.AccessionWrapper;
 import uk.ac.ebi.ampt2d.commons.accession.core.models.IEvent;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.models.IAccessionedObject;
@@ -33,6 +34,7 @@ import uk.ac.ebi.eva.commons.core.models.contigalias.ContigAliasResponse;
 import uk.ac.ebi.eva.commons.core.models.contigalias.ContigAliasTranslator;
 import uk.ac.ebi.eva.commons.core.models.contigalias.ContigNamingConvention;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -84,10 +86,10 @@ public class ContigAliasService {
      * Query contig alias service to translate the contig to the desired naming convention
      */
     public String translateContigFromInsdc(String genbankContig, ContigNamingConvention contigNamingConvention) {
-        String url = contigAliasUrl + CONTIG_ALIAS_CHROMOSOMES_GENBANK_ENDPOINT + genbankContig;
-        ContigAliasResponse contigAliasResponse = restTemplate.getForObject(url, ContigAliasResponse.class);
+        URI uri = buildUri(CONTIG_ALIAS_CHROMOSOMES_GENBANK_ENDPOINT, genbankContig);
+        ContigAliasResponse contigAliasResponse = restTemplate.getForObject(uri, ContigAliasResponse.class);
         if (contigAliasResponse == null || contigAliasResponse.getEmbedded() == null) {
-            throw new NoSuchElementException("No data returned for " + url + " from the contig alias service");
+            throw new NoSuchElementException("No contig alias data found for Genbank contig: " + genbankContig);
         }
         return ContigAliasTranslator.getTranslatedContig(contigAliasResponse, contigNamingConvention);
     }
@@ -107,22 +109,50 @@ public class ContigAliasService {
     }
 
     private String translateContigRefseqToInsdc(String refseq) {
-        String url = contigAliasUrl + CONTIG_ALIAS_CHROMOSOMES_REFSEQ_ENDPOINT + refseq;
-        ContigAliasResponse contigAliasResponse = restTemplate.getForObject(url, ContigAliasResponse.class);
+        URI uri = buildUri(CONTIG_ALIAS_CHROMOSOMES_REFSEQ_ENDPOINT, refseq);
+        ContigAliasResponse contigAliasResponse = restTemplate.getForObject(uri, ContigAliasResponse.class);
         if (contigAliasResponse == null || contigAliasResponse.getEmbedded() == null) {
-            throw new NoSuchElementException("No data returned for " + url + " from the contig alias service");
+            throw new NoSuchElementException("No contig alias data found for RefSeq: " + refseq);
         }
         return ContigAliasTranslator.getTranslatedContig(contigAliasResponse, ContigNamingConvention.INSDC);
     }
 
     private String translateContigNameToInsdc(String contigName, String assembly, ContigNamingConvention contigNamingConvention) {
-        String url = contigAliasUrl + CONTIG_ALIAS_CHROMOSOMES_NAME_ENDPOINT + contigName
-                + "?accession=" + assembly + "&name=" + getNameParam(contigNamingConvention);
-        ContigAliasResponse contigAliasResponse = restTemplate.getForObject(url, ContigAliasResponse.class);
+        String path = CONTIG_ALIAS_CHROMOSOMES_NAME_ENDPOINT;
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        URI uri = UriComponentsBuilder.fromHttpUrl(contigAliasUrl)
+                .path(path)
+                .pathSegment(contigName)
+                .queryParam("accession", assembly)
+                .queryParam("name", getNameParam(contigNamingConvention))
+                .build()
+                .encode()
+                .toUri();
+        ContigAliasResponse contigAliasResponse = restTemplate.getForObject(uri, ContigAliasResponse.class);
         if (contigAliasResponse == null || contigAliasResponse.getEmbedded() == null) {
-            throw new NoSuchElementException("No data returned for " + url + " from the contig alias service");
+            throw new NoSuchElementException("No contig alias data found for contig name: " + contigName);
         }
         return ContigAliasTranslator.getTranslatedContig(contigAliasResponse, ContigNamingConvention.INSDC);
+    }
+
+    /**
+     * Builds a safe URI for the contig alias service by encoding the path variable as a single path segment.
+     * Using pathSegment() causes UriComponentsBuilder to encode path-reserved characters (/, ?, #) within
+     * the variable value, preventing path traversal attacks.
+     */
+    private URI buildUri(String endpoint, String pathVariable) {
+        if (".".equals(pathVariable) || "..".equals(pathVariable)) {
+            throw new IllegalArgumentException("Invalid contig identifier: " + pathVariable);
+        }
+        String path = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+        return UriComponentsBuilder.fromHttpUrl(contigAliasUrl)
+                .path(path)
+                .pathSegment(pathVariable)
+                .build()
+                .encode()
+                .toUri();
     }
 
     /**

--- a/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/ClusteredVariantsRestController.java
+++ b/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/ClusteredVariantsRestController.java
@@ -20,6 +20,8 @@ package uk.ac.ebi.eva.accession.ws.rest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -63,6 +65,8 @@ import java.util.stream.Collectors;
 @RequestMapping(value = "/v1/clustered-variants")
 @Api(tags = {"Clustered variants"})
 public class ClusteredVariantsRestController {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClusteredVariantsRestController.class);
 
     private SubmittedVariantAccessioningService submittedVariantsService;
 
@@ -273,11 +277,13 @@ public class ClusteredVariantsRestController {
             return beaconService.queryBeaconClusteredVariant(assembly, chromosome, start, variantType,
                                                              contigNamingConvention, includeDatasetReponses);
         } catch (Exception ex) {
+            logger.error("Unexpected error in beacon query for chromosome={}, start={}, assembly={}, variantType={}",
+                         chromosome, start, assembly, variantType, ex);
             int responseStatus = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
             response.setStatus(responseStatus);
             return beaconService.getBeaconResponseObjectWithError(chromosome, start, assembly, variantType,
                     responseStatus,
-                    "Unexpected Error: " + ex.getMessage());
+                    "An unexpected error occurred processing the beacon query.");
         }
     }
 }

--- a/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/EvaControllerAdvice.java
+++ b/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/EvaControllerAdvice.java
@@ -23,6 +23,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionMergedException;
 import uk.ac.ebi.ampt2d.commons.accession.rest.BasicRestControllerAdvice;
 import uk.ac.ebi.ampt2d.commons.accession.rest.dto.ErrorMessage;
@@ -45,10 +47,11 @@ public class EvaControllerAdvice extends BasicRestControllerAdvice {
     @Value("${eva.api.base-url}")
     private String apiBaseUrl;
 
+    @Override
     @ExceptionHandler(value = AccessionMergedException.class)
-    public ResponseEntity<ErrorMessage> handleMergeExceptions(AccessionMergedException ex,
-                                                              HttpServletRequest request) {
+    public ResponseEntity<ErrorMessage> handleMergeExceptions(AccessionMergedException ex) {
         logger.error(ex.getMessage(), ex);
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
         if (HttpMethod.GET.name().equals(request.getMethod())) {
             // Use getRequestURI() (path only, no host) and prepend the configured base URL
             // so that the redirect target cannot be influenced by the incoming Host header.

--- a/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/EvaControllerAdvice.java
+++ b/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/EvaControllerAdvice.java
@@ -15,14 +15,56 @@
  */
 package uk.ac.ebi.eva.accession.ws.rest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionMergedException;
 import uk.ac.ebi.ampt2d.commons.accession.rest.BasicRestControllerAdvice;
+import uk.ac.ebi.ampt2d.commons.accession.rest.dto.ErrorMessage;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
 
 /**
  * This class activates the exception handling in {@link BasicRestControllerAdvice} for our controllers:
  * {@link ClusteredVariantsRestController} and {@link SubmittedVariantsRestController}.
+ *
+ * It overrides handleMergeExceptions to build the redirect URL from a configured base URL
+ * rather than from the incoming Host header, preventing open-redirect via Host-header injection.
  */
 @RestControllerAdvice(assignableTypes = {ClusteredVariantsRestController.class, SubmittedVariantsRestController.class})
 public class EvaControllerAdvice extends BasicRestControllerAdvice {
 
+    private static final Logger logger = LoggerFactory.getLogger(EvaControllerAdvice.class);
+
+    @Value("${eva.api.base-url}")
+    private String apiBaseUrl;
+
+    @ExceptionHandler(value = AccessionMergedException.class)
+    public ResponseEntity<ErrorMessage> handleMergeExceptions(AccessionMergedException ex,
+                                                              HttpServletRequest request) {
+        logger.error(ex.getMessage(), ex);
+        if (HttpMethod.GET.name().equals(request.getMethod())) {
+            // Use getRequestURI() (path only, no host) and prepend the configured base URL
+            // so that the redirect target cannot be influenced by the incoming Host header.
+            String path = request.getRequestURI();
+            int lastOccurrenceStart = path.lastIndexOf(ex.getOriginAccessionId());
+            if (lastOccurrenceStart >= 0) {
+                int lastOccurrenceEnd = lastOccurrenceStart + ex.getOriginAccessionId().length();
+                String newPath = path.substring(0, lastOccurrenceStart)
+                        + ex.getDestinationAccessionId()
+                        + path.substring(lastOccurrenceEnd);
+                return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                                     .location(URI.create(apiBaseUrl + newPath))
+                                     .body(new ErrorMessage(HttpStatus.MOVED_PERMANENTLY, ex, ex.getMessage()));
+            }
+        }
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                             .body(new ErrorMessage(HttpStatus.NOT_FOUND, ex, ex.getMessage()));
+    }
 }

--- a/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/SubmittedVariantsRestController.java
+++ b/eva-accession-ws/src/main/java/uk/ac/ebi/eva/accession/ws/rest/SubmittedVariantsRestController.java
@@ -20,6 +20,8 @@ package uk.ac.ebi.eva.accession.ws.rest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -54,6 +56,8 @@ import java.util.stream.Collectors;
 @RequestMapping(value = "/v1/submitted-variants")
 @Api(tags = {"Submitted variants"})
 public class SubmittedVariantsRestController {
+
+    private static final Logger logger = LoggerFactory.getLogger(SubmittedVariantsRestController.class);
 
     private SubmittedVariantsBeaconService submittedVariantsBeaconService;
 
@@ -134,10 +138,12 @@ public class SubmittedVariantsRestController {
                                                               assembly, contigNamingConvention, false);
         }
         catch (Exception ex) {
+            logger.error("Unexpected error in beacon query for chromosome={}, start={}, assembly={}, studies={}",
+                         chromosome, start, assembly, studies, ex);
             int responseStatus = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
             response.setStatus(responseStatus);
             return getBeaconResponseObjectWithError(alternate, reference, chromosome, start, assembly, studies,
-                                                    responseStatus, "Unexpected Error: " + ex.getMessage());
+                                                    responseStatus, "An unexpected error occurred processing the beacon query.");
         }
     }
 

--- a/eva-accession-ws/src/main/resources/application.properties
+++ b/eva-accession-ws/src/main/resources/application.properties
@@ -22,7 +22,11 @@ human.mongodb.database=|eva.accession.mongo.human.database|
 contig-alias.url=|contig-alias.url|
 
 management.endpoints.web.exposure.include=info,health
-management.info.git.mode=full
+management.info.git.mode=simple
+
+# Base URL used to build safe redirect responses (must not end with a slash).
+# Set this to the canonical public URL of the API in each deployment environment.
+eva.api.base-url=|eva.api.base-url|
 
 # See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding
 spring.main.allow-bean-definition-overriding=true

--- a/eva-accession-ws/src/test/resources/accession-ws-test.properties
+++ b/eva-accession-ws/src/test/resources/accession-ws-test.properties
@@ -22,3 +22,5 @@ mongodb.read-preference=primary
 
 human.mongodb.uri=mongodb://|eva.mongo.host.test|:27017
 human.mongodb.database=eva-accession-ws-test-db-human
+
+eva.api.base-url=http://localhost

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.2.5</version>
+                <version>42.7.5</version>
             </dependency>
             <dependency>
                 <groupId>com.lordofthejars</groupId>


### PR DESCRIPTION
1. Path traversal in contig alias URL construction (ContigAliasService.java)
Replaced string concatenation with UriComponentsBuilder.pathSegment() + .queryParam() for referenceName and assemblyId request parameters. Added a guard rejecting the bare  dot-segments . and .. as contig identifiers.
2. Internal service URL disclosed in error responses (ContigAliasService.java, both controllers)
Changed the exception messages to include only the user-supplied identifier (not the URL), and replaced the catch-all message in both beacon endpoints with a fixed generic string, logging the full detail  server-side instead.
3. Open redirect via Host header injection (EvaControllerAdvice.java)
When a merged accession was requested, the 301 redirect was built from httpServletRequest.getRequestURL(), which Tomcat populates using the Host request header. Overrode handleMergeExceptions in EvaControllerAdvice to use getRequestURI() (path only, no host) and prepend the trusted eva.api.base-url configuration property instead.
4. Full git commit messages exposed via actuator (application.properties)
management.info.git.mode=full caused /actuator/info to include the complete last commit message in its public JSON response. Changed to management.info.git.mode=simple, which retains only the commit ID and timestamp.
5. Permissions: Added permissions: contents: read block in github actions